### PR TITLE
feat(api): add OpenAI-compatible /v1/chat/completions with streaming …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,18 +4,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AI Secretary "Лидия" - a virtual secretary system with voice cloning using XTTS v2. Handles phone calls via Twilio with STT → LLM → TTS pipeline.
+AI Secretary "Лидия" - a virtual secretary system with voice cloning using XTTS v2. Handles phone calls via Twilio with STT → LLM → TTS pipeline. Integrated with OpenWebUI for text chat with voice responses.
 
-## Current Status (2026-01-14)
+## Current Status (2026-01-15)
 
 | Component | Status | Performance |
 |-----------|--------|-------------|
 | Voice Clone Service | **Working** | RTF 0.95x on GPU |
+| LLM Service | **Working** | Gemini 2.5 Flash |
+| OpenWebUI Integration | **Working** | Chat + TTS |
 | GPU (RTX 3060) | **Active** | 10 GB / 12 GB used |
 | GPU (P104-100) | Not supported | CC 6.1 < 7.0 required |
 | Speaker Latents Cache | **Enabled** | `./cache/` |
 | Intonation Presets | **5 presets** | warm, calm, energetic, natural, neutral |
 | Text Preprocessing | **Enabled** | Е→Ё, pauses, punctuation |
+| STT Service | **Disabled** | faster-whisper model loading issues |
 
 ## Architecture
 
@@ -41,14 +44,25 @@ COQUI_TOS_AGREED=1 python3 voice_clone_service.py
 # Output: test_warm.wav, test_calm.wav, test_energetic.wav
 ```
 
-### Run Full System
+### Run Orchestrator (for OpenWebUI)
+```bash
+# Start orchestrator (TTS + LLM, no STT)
+COQUI_TOS_AGREED=1 ./venv/bin/python orchestrator.py
+
+# Or in background:
+COQUI_TOS_AGREED=1 ./venv/bin/python orchestrator.py &
+
+# Check status:
+curl http://localhost:8002/health
+```
+
+### Run Full System (with phone service)
 ```bash
 ./run.sh                      # Start orchestrator + phone service
 
 # Or individually:
-source venv/bin/activate
-COQUI_TOS_AGREED=1 python3 orchestrator.py     # Port 8002
-python3 phone_service.py                        # Port 8001
+COQUI_TOS_AGREED=1 ./venv/bin/python orchestrator.py     # Port 8002
+./venv/bin/python phone_service.py                        # Port 8001
 ```
 
 ### Setup (first time)
@@ -127,13 +141,14 @@ wav, sr = service.synthesize(
 - VAD enabled
 
 ### LLM Service (`llm_service.py`)
-- Gemini API (`gemini-2.5-pro-latest`)
+- Gemini API (`gemini-2.5-flash`) - changed from pro due to quota limits
 - Requires `GEMINI_API_KEY` in `.env`
 - System prompt defines Лидия's persona
+- Supports streaming responses
 
 ### Orchestrator (`orchestrator.py`)
 - FastAPI on port 8002
-- OpenAI-compatible `/v1/audio/speech` for OpenWebUI
+- OpenAI-compatible API for OpenWebUI integration
 - Logs to `calls_log/`
 
 ## API Endpoints (Port 8002)
@@ -142,10 +157,34 @@ wav, sr = service.synthesize(
 |----------|--------|-------------|
 | `/health` | GET | Health check |
 | `/tts` | POST | TTS (JSON: text, language, preset) |
-| `/stt` | POST | STT (multipart: audio) |
+| `/stt` | POST | STT (multipart: audio) - currently disabled |
 | `/chat` | POST | LLM (JSON: text) |
 | `/process_call` | POST | Full pipeline: STT→LLM→TTS |
+| `/v1/models` | GET | OpenAI-compatible models list |
+| `/v1/chat/completions` | POST | OpenAI-compatible chat (streaming supported) |
 | `/v1/audio/speech` | POST | OpenAI-compatible TTS |
+| `/v1/voices` | GET | Available voices list |
+
+## OpenWebUI Integration
+
+### Setup (OpenWebUI in Docker on Linux)
+
+1. **Admin Panel → Settings → Connections → OpenAI API**
+   - URL: `http://172.17.0.1:8002/v1`
+   - API Key: `sk-dummy` (any value, not validated)
+   - Click "Verify" to test connection
+
+2. **Settings → Audio → Text-to-Speech**
+   - TTS Engine: `OpenAI`
+   - OpenAI API Base URL: `http://172.17.0.1:8002/v1`
+   - TTS Voice: `lidia`
+   - Auto-play response: Enable for automatic voice playback
+
+3. **Select model `lidia-gemini` in chat**
+
+### Available Models
+- `lidia-gemini` - Chat model (Gemini 2.5 Flash backend)
+- `lidia-voice` - TTS model (XTTS v2 with cloned voice)
 
 ## Environment Variables (.env)
 
@@ -182,3 +221,13 @@ AI_Secretary_System/
 2. **First synthesis slow**: Normal, model loading + latent computation cached after first run
 3. **GPU OOM**: Reduce `gpt_cond_len` or use fewer voice samples (`max_samples=20`)
 4. **Unnatural pronunciation**: Check Ё replacement, add pauses with `...` or double spaces
+5. **STT (faster-whisper) hangs on startup**: Model download/loading issue. Currently disabled in orchestrator. For text chat via OpenWebUI, STT is not needed.
+6. **Gemini quota exceeded (429)**: Switch from `gemini-2.5-pro` to `gemini-2.5-flash` in `llm_service.py`
+7. **OpenWebUI can't connect**: Use `http://172.17.0.1:8002/v1` instead of `localhost` when OpenWebUI runs in Docker
+
+## TODO / Next Steps
+
+1. **Fix STT Service**: Debug faster-whisper model loading, or switch to openai-whisper
+2. **Streaming TTS**: Implement sentence-by-sentence TTS for real-time voice during LLM streaming
+3. **Twilio Integration**: Connect phone_service.py for actual phone calls
+4. **Voice Input in OpenWebUI**: Enable STT for voice-to-voice conversations


### PR DESCRIPTION
# feat: OpenAI-совместимый Chat API + переход на Gemini Flash + временное отключение STT

## Что сделано?

- Реализован endpoint `/v1/chat/completions` в стиле OpenAI API (совместим с OpenWebUI)
- Добавлена поддержка streaming-ответов через Server-Sent Events (SSE)
- Модель `lidia-gemini` теперь доступна в OpenWebUI
- LLM-сервис переключён с gemini-1.5-pro → gemini-1.5-flash (исчерпана квота pro)
- Исправлена проблема с пустыми ответами генератора → разделены sync и stream методы
- Установлены новые зависимости: fastapi, uvicorn, python-multipart, openai-whisper, faster-whisper, google-generativeai, python-dotenv
- Временно отключён STT (faster-whisper зависает при загрузке модели) — для текстового чата не критично
- Обновлена документация `CLAUDE.md`:
  - инструкция по подключению OpenWebUI
  - новые API-endpoints
  - список known issues и TODO

## Как проверить?

1. Запустить orchestrator: `uvicorn main:app --host 0.0.0.0 --port 8002 --reload`
2. Подключить OpenWebUI:
   - URL: `http://172.17.0.1:8002/v1` (или ваш IP:8002/v1)
   - API Key: `sk-dummy`
   - Model: `lidia-gemini`
3. Отправить тестовый запрос через OpenWebUI или curl:
   ```bash
   curl http://localhost:8002/v1/chat/completions \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer sk-dummy" \
     -d '{
       "model": "lidia-gemini",
       "messages": [{"role": "user", "content": "Привет, как дела?"}],
       "stream": true
     }'