### PR TITLE
feat(vllm): integrate Qwen2.5-7B with Lydia LoRA adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ calls_log/
 
 # Voice samples directory (НЕ КОММИТИМ образцы голоса!)
 Лидия/
+Гуля/
 voice_samples/
 
 # Models (НЕ КОММИТИМ большие модели AI!)
@@ -100,3 +101,4 @@ __pycache__/
 result.json
 lydia_dataset_v2.jsonl
 lydia_dataset.jsonl
+Гуля

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -679,7 +679,17 @@ async def reset_conversation():
 async def list_models():
     """OpenAI-compatible models list for OpenWebUI"""
     # Определяем имя backend-а для описания
-    backend_name = "vLLM Llama-3.1-8B" if (llm_service and hasattr(llm_service, 'api_url')) else "Gemini"
+    if llm_service and hasattr(llm_service, 'api_url'):
+        # vLLM backend - проверяем модель
+        model_name = getattr(llm_service, 'model_name', 'unknown')
+        if model_name == "lydia" or "qwen" in model_name.lower():
+            backend_name = "vLLM Qwen2.5-7B + Lydia LoRA"
+        elif "llama" in model_name.lower():
+            backend_name = "vLLM Llama-3.1-8B"
+        else:
+            backend_name = f"vLLM {model_name}"
+    else:
+        backend_name = "Gemini"
 
     return {
         "object": "list",

--- a/start_gpu.sh
+++ b/start_gpu.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Запуск AI Secretary System на RTX 3060 (GPU 1)
-# XTTS (Лидия) + vLLM (Llama-3.1-8B) работают вместе на одном GPU
+# XTTS (Лидия) + vLLM работают вместе на одном GPU
+#
+# По умолчанию используется Qwen2.5-7B + Lydia LoRA
+# Для запуска с Llama: ./start_gpu.sh --llama
 #
 # Распределение памяти RTX 3060 (12GB):
 #   vLLM:  70% = ~8.4GB
@@ -12,14 +15,31 @@
 
 cd "$(dirname "$0")"
 
+# Определяем модель (по умолчанию Qwen)
+MODEL="qwen"
+LORA_PATH="/home/shaerware/qwen-finetune/qwen2.5-7b-lydia-lora/final"
+
+if [[ "$1" == "--llama" ]]; then
+    MODEL="llama"
+fi
+
 echo "=========================================="
 echo "  AI Secretary System - GPU Mode"
 echo "  RTX 3060 (12GB)"
 echo "=========================================="
 echo ""
+
+if [[ "$MODEL" == "qwen" ]]; then
+    echo "  LLM: Qwen2.5-7B + Lydia LoRA (default)"
+    echo "  LoRA: $LORA_PATH"
+else
+    echo "  LLM: Llama-3.1-8B GPTQ"
+fi
+
+echo ""
 echo "  Сервисы:"
 echo "    - Orchestrator + XTTS: http://localhost:8002"
-echo "    - vLLM (Llama-3.1-8B): http://localhost:11434"
+echo "    - vLLM: http://localhost:11434"
 echo ""
 echo "  GPU memory:"
 echo "    - vLLM:  70% (~8.4GB)"
@@ -46,37 +66,70 @@ export CUDA_VISIBLE_DEVICES=1
 
 # 1. Запуск vLLM (фоновый процесс)
 echo "[1/2] Запуск vLLM..."
-echo "      Модель: Llama-3.1-8B-Instruct GPTQ INT4"
-echo "      Память GPU: 70%"
 
-# Активируем vllm окружение и запускаем
-# Передаём переменные окружения явно в subshell
-(
-    export CUDA_DEVICE_ORDER=PCI_BUS_ID
-    export CUDA_VISIBLE_DEVICES=1
-    source ~/vllm_env/venv/bin/activate
-    vllm serve "fbaldassarri/meta-llama_Llama-3.1-8B-Instruct-auto_gptq-int4-gs128-sym" \
-        --gpu-memory-utilization 0.70 \
-        --max-model-len 4096 \
-        --quantization gptq \
-        --dtype float16 \
-        --max-num-seqs 32 \
-        --port 11434 \
-        --enforce-eager \
-        --trust-remote-code
-) > logs/vllm.log 2>&1 &
+if [[ "$MODEL" == "qwen" ]]; then
+    echo "      Модель: Qwen2.5-7B-Instruct + Lydia LoRA"
+    echo "      Память GPU: 70%"
+
+    # Проверка LoRA
+    if [ ! -f "$LORA_PATH/adapter_config.json" ]; then
+        echo "      ✗ LoRA adapter not found at $LORA_PATH"
+        echo "      Fallback to Llama..."
+        MODEL="llama"
+    fi
+fi
+
+if [[ "$MODEL" == "qwen" ]]; then
+    # Qwen с LoRA
+    (
+        export CUDA_DEVICE_ORDER=PCI_BUS_ID
+        export CUDA_VISIBLE_DEVICES=1
+        source ~/vllm_env/venv/bin/activate
+        vllm serve "Qwen/Qwen2.5-7B-Instruct" \
+            --gpu-memory-utilization 0.70 \
+            --max-model-len 4096 \
+            --dtype bfloat16 \
+            --max-num-seqs 32 \
+            --port 11434 \
+            --enforce-eager \
+            --trust-remote-code \
+            --enable-lora \
+            --lora-modules lydia="$LORA_PATH"
+    ) > logs/vllm.log 2>&1 &
+else
+    # Llama GPTQ
+    echo "      Модель: Llama-3.1-8B-Instruct GPTQ INT4"
+    echo "      Память GPU: 70%"
+
+    (
+        export CUDA_DEVICE_ORDER=PCI_BUS_ID
+        export CUDA_VISIBLE_DEVICES=1
+        source ~/vllm_env/venv/bin/activate
+        vllm serve "fbaldassarri/meta-llama_Llama-3.1-8B-Instruct-auto_gptq-int4-gs128-sym" \
+            --gpu-memory-utilization 0.70 \
+            --max-model-len 4096 \
+            --quantization gptq \
+            --dtype float16 \
+            --max-num-seqs 32 \
+            --port 11434 \
+            --enforce-eager \
+            --trust-remote-code
+    ) > logs/vllm.log 2>&1 &
+fi
+
 VLLM_PID=$!
 echo "      PID: $VLLM_PID, лог: logs/vllm.log"
 
 # Ждём пока vLLM запустится
-echo "      Ожидание запуска vLLM (может занять 30-60 сек)..."
-for i in {1..90}; do
+echo "      Ожидание запуска vLLM (может занять 30-90 сек)..."
+for i in {1..120}; do
     if curl -s http://localhost:11434/health > /dev/null 2>&1; then
         echo "      ✓ vLLM готов!"
         break
     fi
     if ! kill -0 $VLLM_PID 2>/dev/null; then
         echo "      ✗ vLLM упал! Проверьте logs/vllm.log"
+        tail -30 logs/vllm.log
         exit 1
     fi
     sleep 2
@@ -84,7 +137,7 @@ done
 
 # Проверяем финальный статус vLLM
 if ! curl -s http://localhost:11434/health > /dev/null 2>&1; then
-    echo "      ⚠ vLLM не ответил за 180 сек, продолжаем..."
+    echo "      ⚠ vLLM не ответил за 240 сек, продолжаем..."
 fi
 
 # 2. Запуск Orchestrator с XTTS (основной процесс)
@@ -95,6 +148,13 @@ echo "      XTTS загрузится на оставшуюся память GPU
 export COQUI_TOS_AGREED=1
 export LLM_BACKEND=vllm  # Указываем использовать vLLM вместо Gemini
 export VLLM_API_URL=http://localhost:11434
+
+# Передаём информацию о модели для правильного выбора имени
+if [[ "$MODEL" == "qwen" ]]; then
+    export VLLM_MODEL_NAME="lydia"  # LoRA adapter name
+else
+    export VLLM_MODEL_NAME=""  # Auto-detect
+fi
 
 ./venv/bin/python orchestrator.py > logs/orchestrator.log 2>&1 &
 ORCHESTRATOR_PID=$!
@@ -118,6 +178,12 @@ done
 echo ""
 echo "=========================================="
 echo "  ✓ Все сервисы запущены!"
+echo ""
+if [[ "$MODEL" == "qwen" ]]; then
+    echo "  Модель: Qwen2.5-7B + Lydia LoRA"
+else
+    echo "  Модель: Llama-3.1-8B GPTQ"
+fi
 echo ""
 echo "  Логи: tail -f logs/*.log"
 echo "  Admin: http://localhost:8002/admin"

--- a/start_qwen.sh
+++ b/start_qwen.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Запуск vLLM с Qwen2.5-7B + Lydia LoRA на GPU 1 (RTX 3060, 12GB)
+# Основная модель для AI Secretary System
+#
+# Базовая модель: Qwen/Qwen2.5-7B-Instruct
+# LoRA адаптер: /home/shaerware/qwen-finetune/qwen2.5-7b-lydia-lora/final
+
+# ВАЖНО: CUDA_DEVICE_ORDER=PCI_BUS_ID чтобы GPU нумеровались по PCI bus
+export CUDA_DEVICE_ORDER=PCI_BUS_ID
+export CUDA_VISIBLE_DEVICES=1
+
+LORA_PATH="/home/shaerware/qwen-finetune/qwen2.5-7b-lydia-lora/final"
+
+echo "=========================================="
+echo "  vLLM Server - Qwen2.5-7B + Lydia LoRA"
+echo "  GPU: RTX 3060 (12GB)"
+echo "  Port: 11434"
+echo "=========================================="
+echo ""
+echo "  Base model: Qwen/Qwen2.5-7B-Instruct"
+echo "  LoRA: $LORA_PATH"
+echo ""
+
+source ~/vllm_env/venv/bin/activate
+
+# Проверка GPU
+python -c "import torch; print(f'GPU: {torch.cuda.get_device_name(0)}')" 2>/dev/null || echo "GPU check failed"
+
+# Проверка LoRA
+if [ ! -f "$LORA_PATH/adapter_config.json" ]; then
+    echo "ERROR: LoRA adapter not found at $LORA_PATH"
+    exit 1
+fi
+
+echo "LoRA adapter found, starting vLLM..."
+
+# Запуск vLLM с LoRA
+# --enable-lora включает поддержку LoRA
+# --lora-modules задает имя и путь к адаптеру
+vllm serve "Qwen/Qwen2.5-7B-Instruct" \
+    --gpu-memory-utilization 0.70 \
+    --max-model-len 4096 \
+    --dtype bfloat16 \
+    --max-num-seqs 32 \
+    --port 11434 \
+    --enforce-eager \
+    --trust-remote-code \
+    --enable-lora \
+    --lora-modules lydia="$LORA_PATH"


### PR DESCRIPTION
## Описание

Интеграция Qwen2.5-7B с Lydia LoRA адаптером в качестве основной модели для vLLM.

## Что сделано?

### Новые файлы
- `start_qwen.sh` — скрипт для запуска только vLLM с Qwen + LoRA (для отладки)

### Изменённые файлы
- `start_gpu.sh` — Qwen+LoRA по умолчанию, `--llama` для fallback на Llama GPTQ
- `vllm_llm_service.py` — поддержка выбора модели (аргумент → env → auto-detect)
- `orchestrator.py` — корректное отображение backend'а в `/v1/models`
- `CLAUDE.md` — обновлена документация

## Как проверить?

1. Запустить основной режим:
```bash
   ./start_gpu.sh
```
   Ожидаемый результат: vLLM запускается с Qwen2.5-7B + Lydia LoRA

2. Проверить fallback:
```bash
   ./start_gpu.sh --llama
```
   Ожидаемый результат: vLLM запускается с Llama GPTQ

3. Проверить endpoint моделей:
```bash
   curl http://localhost:8000/v1/models
```
   Ожидаемый результат: отображается "vLLM Qwen2.5-7B + Lydia LoRA"

## Зависимости

- LoRA адаптер: `/home/shaerware/qwen-finetune/qwen2.5-7b-lydia-lora/final`
- Base model: `Qwen/Qwen2.5-7B-Instruct`

## Чеклист

- [ ] Протестирован запуск с Qwen + LoRA
- [ ] Протестирован fallback на Llama
- [ ] Проверен endpoint `/v1/models`
- [ ] Документация обновлена