### PR TITLE
feat(admin): implement full-featured Vue 3 admin panel with shadcn/ui

### DIFF
--- a/admin/.gitignore
+++ b/admin/.gitignore
@@ -1,0 +1,32 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependencies
+node_modules
+.pnp
+.pnp.js
+
+# Build
+dist
+dist-ssr
+*.local
+
+# Editor
+.vscode/*
+!.vscode/extensions.json
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Env
+.env
+.env.*
+
+# OS
+.DS_Store
+Thumbs.db

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ru" class="dark">
+  <head>
+    <meta charset="UTF-8">
+    <link rel="icon" type="image/svg+xml" href="/vite.svg">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Secretary Admin</title>
+  </head>
+  <body class="bg-background text-foreground">
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "ai-secretary-admin",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
+  },
+  "dependencies": {
+    "@tanstack/vue-query": "^5.62.9",
+    "chart.js": "^4.4.7",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-vue-next": "^0.468.0",
+    "pinia": "^2.3.0",
+    "radix-vue": "^1.9.11",
+    "tailwind-merge": "^2.6.0",
+    "vue": "^3.5.13",
+    "vue-chartjs": "^5.3.2",
+    "vue-router": "^4.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "@vitejs/plugin-vue": "^5.2.1",
+    "@vue/tsconfig": "^0.7.0",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "~5.6.3",
+    "vite": "^6.0.7",
+    "vue-tsc": "^2.2.0"
+  }
+}

--- a/admin/postcss.config.js
+++ b/admin/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/admin/public/vite.svg
+++ b/admin/public/vite.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/>
+  <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+  <line x1="12" x2="12" y1="19" y2="22"/>
+</svg>

--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { RouterView, RouterLink, useRoute } from 'vue-router'
+import {
+  LayoutDashboard,
+  Server,
+  Brain,
+  Mic,
+  MessageSquare,
+  Sparkles,
+  Activity,
+  Settings,
+  Menu,
+  X
+} from 'lucide-vue-next'
+import { ref, computed } from 'vue'
+
+const route = useRoute()
+const sidebarOpen = ref(true)
+
+const navItems = [
+  { path: '/', name: 'Dashboard', icon: LayoutDashboard },
+  { path: '/services', name: 'Services', icon: Server },
+  { path: '/llm', name: 'LLM', icon: Brain },
+  { path: '/tts', name: 'TTS', icon: Mic },
+  { path: '/faq', name: 'FAQ', icon: MessageSquare },
+  { path: '/finetune', name: 'Fine-tune', icon: Sparkles },
+  { path: '/monitoring', name: 'Monitoring', icon: Activity },
+]
+
+const currentTitle = computed(() => {
+  const item = navItems.find(i => i.path === route.path)
+  return item?.name || 'Admin'
+})
+</script>
+
+<template>
+  <div class="flex h-screen overflow-hidden">
+    <!-- Sidebar -->
+    <aside
+      :class="[
+        'flex flex-col bg-card border-r border-border transition-all duration-300',
+        sidebarOpen ? 'w-64' : 'w-16'
+      ]"
+    >
+      <!-- Logo -->
+      <div class="flex items-center h-16 px-4 border-b border-border">
+        <div class="flex items-center gap-3">
+          <div class="w-8 h-8 rounded-lg bg-primary/20 flex items-center justify-center">
+            <Settings class="w-5 h-5 text-primary" />
+          </div>
+          <span v-if="sidebarOpen" class="font-semibold text-lg">AI Secretary</span>
+        </div>
+      </div>
+
+      <!-- Navigation -->
+      <nav class="flex-1 p-2 space-y-1 overflow-y-auto">
+        <RouterLink
+          v-for="item in navItems"
+          :key="item.path"
+          :to="item.path"
+          :class="[
+            'flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors',
+            route.path === item.path
+              ? 'bg-secondary text-foreground'
+              : 'text-muted-foreground hover:bg-secondary/50 hover:text-foreground'
+          ]"
+        >
+          <component :is="item.icon" class="w-5 h-5 shrink-0" />
+          <span v-if="sidebarOpen" class="truncate">{{ item.name }}</span>
+        </RouterLink>
+      </nav>
+
+      <!-- Toggle Button -->
+      <div class="p-2 border-t border-border">
+        <button
+          @click="sidebarOpen = !sidebarOpen"
+          class="flex items-center justify-center w-full p-2 rounded-lg text-muted-foreground hover:bg-secondary/50 hover:text-foreground transition-colors"
+        >
+          <Menu v-if="!sidebarOpen" class="w-5 h-5" />
+          <X v-else class="w-5 h-5" />
+        </button>
+      </div>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="flex-1 flex flex-col overflow-hidden">
+      <!-- Header -->
+      <header class="flex items-center justify-between h-16 px-6 border-b border-border bg-card">
+        <h1 class="text-xl font-semibold">{{ currentTitle }}</h1>
+        <div class="flex items-center gap-4">
+          <span class="text-sm text-muted-foreground">AI Secretary Admin Panel</span>
+        </div>
+      </header>
+
+      <!-- Content -->
+      <div class="flex-1 overflow-auto p-6">
+        <RouterView />
+      </div>
+    </main>
+  </div>
+</template>

--- a/admin/src/api/client.ts
+++ b/admin/src/api/client.ts
@@ -1,0 +1,89 @@
+// Base API client
+const BASE_URL = ''
+
+export interface ApiResponse<T> {
+  data?: T
+  error?: string
+  status: 'ok' | 'error'
+}
+
+async function request<T>(
+  endpoint: string,
+  options: RequestInit = {}
+): Promise<T> {
+  const url = `${BASE_URL}${endpoint}`
+
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  })
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: 'Request failed' }))
+    throw new Error(error.detail || `HTTP error ${response.status}`)
+  }
+
+  return response.json()
+}
+
+export const api = {
+  get: <T>(endpoint: string) => request<T>(endpoint),
+
+  post: <T>(endpoint: string, data?: unknown) =>
+    request<T>(endpoint, {
+      method: 'POST',
+      body: data ? JSON.stringify(data) : undefined,
+    }),
+
+  put: <T>(endpoint: string, data?: unknown) =>
+    request<T>(endpoint, {
+      method: 'PUT',
+      body: data ? JSON.stringify(data) : undefined,
+    }),
+
+  delete: <T>(endpoint: string) =>
+    request<T>(endpoint, { method: 'DELETE' }),
+
+  upload: async <T>(endpoint: string, file: File): Promise<T> => {
+    const formData = new FormData()
+    formData.append('file', file)
+
+    const response = await fetch(`${BASE_URL}${endpoint}`, {
+      method: 'POST',
+      body: formData,
+    })
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: 'Upload failed' }))
+      throw new Error(error.detail || `HTTP error ${response.status}`)
+    }
+
+    return response.json()
+  },
+}
+
+// SSE helper
+export function createSSE(endpoint: string, onMessage: (data: unknown) => void) {
+  const eventSource = new EventSource(`${BASE_URL}${endpoint}`)
+
+  eventSource.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data)
+      onMessage(data)
+    } catch {
+      onMessage(event.data)
+    }
+  }
+
+  eventSource.onerror = () => {
+    console.error('SSE error')
+  }
+
+  return {
+    close: () => eventSource.close(),
+    eventSource,
+  }
+}

--- a/admin/src/api/faq.ts
+++ b/admin/src/api/faq.ts
@@ -1,0 +1,27 @@
+import { api } from './client'
+
+export interface FaqEntry {
+  trigger: string
+  response: string
+}
+
+// FAQ API
+export const faqApi = {
+  getAll: () =>
+    api.get<{ faq: Record<string, string> }>('/admin/faq'),
+
+  add: (trigger: string, response: string) =>
+    api.post<{ status: string; trigger: string }>('/admin/faq', { trigger, response }),
+
+  update: (oldTrigger: string, trigger: string, response: string) =>
+    api.put<{ status: string; trigger: string }>(`/admin/faq/${encodeURIComponent(oldTrigger)}`, { trigger, response }),
+
+  delete: (trigger: string) =>
+    api.delete<{ status: string; deleted: string }>(`/admin/faq/${encodeURIComponent(trigger)}`),
+
+  reload: () =>
+    api.post<{ status: string; count: number }>('/admin/faq/reload'),
+
+  test: (text: string) =>
+    api.post<{ match: boolean; response: string | null }>('/admin/faq/test', { text }),
+}

--- a/admin/src/api/finetune.ts
+++ b/admin/src/api/finetune.ts
@@ -1,0 +1,108 @@
+import { api, createSSE } from './client'
+
+export interface DatasetStats {
+  total_sessions: number
+  total_messages: number
+  total_tokens: number
+  avg_tokens_per_message: number
+  file_path: string | null
+  file_size_mb: number
+  modified: string | null
+}
+
+export interface TrainingConfig {
+  base_model: string
+  lora_rank: number
+  lora_alpha: number
+  lora_dropout: number
+  batch_size: number
+  gradient_accumulation_steps: number
+  learning_rate: number
+  num_epochs: number
+  warmup_ratio: number
+  max_seq_length: number
+  output_dir: string
+}
+
+export interface TrainingStatus {
+  is_running: boolean
+  current_step: number
+  total_steps: number
+  current_epoch: number
+  total_epochs: number
+  loss: number
+  learning_rate: number
+  elapsed_seconds: number
+  eta_seconds: number
+  error: string | null
+}
+
+export interface Adapter {
+  name: string
+  path: string
+  size_mb: number
+  modified: string
+  active: boolean
+  config: Record<string, unknown> | null
+}
+
+// Finetune API
+export const finetuneApi = {
+  // Dataset
+  uploadDataset: (file: File) =>
+    api.upload<{ status: string; message: string; path: string; size_mb: number }>(
+      '/admin/finetune/dataset/upload',
+      file
+    ),
+
+  processDataset: () =>
+    api.post<{ status: string; message: string; output_file?: string; examples_count?: number }>(
+      '/admin/finetune/dataset/process'
+    ),
+
+  getDatasetStats: () =>
+    api.get<{ stats: DatasetStats }>('/admin/finetune/dataset/stats'),
+
+  augmentDataset: () =>
+    api.post<{ status: string; message: string; stats?: DatasetStats }>(
+      '/admin/finetune/dataset/augment'
+    ),
+
+  // Config
+  getConfig: () =>
+    api.get<{
+      config: TrainingConfig
+      presets: Record<string, Partial<TrainingConfig>>
+    }>('/admin/finetune/config'),
+
+  setConfig: (config: Partial<TrainingConfig>) =>
+    api.post<{ status: string; config?: TrainingConfig }>('/admin/finetune/config', config),
+
+  // Training
+  startTraining: () =>
+    api.post<{ status: string; message: string; config?: TrainingConfig; pid?: number }>(
+      '/admin/finetune/train/start'
+    ),
+
+  stopTraining: () =>
+    api.post<{ status: string; message: string }>('/admin/finetune/train/stop'),
+
+  getTrainingStatus: () =>
+    api.get<{ status: TrainingStatus }>('/admin/finetune/train/status'),
+
+  streamTrainingLog: (onMessage: (data: { type: string; line?: string; status?: TrainingStatus }) => void) =>
+    createSSE('/admin/finetune/train/log', onMessage),
+
+  // Adapters
+  listAdapters: () =>
+    api.get<{ adapters: Adapter[]; active: string | null }>('/admin/finetune/adapters'),
+
+  activateAdapter: (adapter: string) =>
+    api.post<{ status: string; message: string; adapter?: string; path?: string; note?: string }>(
+      '/admin/finetune/adapters/activate',
+      { adapter }
+    ),
+
+  deleteAdapter: (name: string) =>
+    api.delete<{ status: string; message: string }>(`/admin/finetune/adapters/${name}`),
+}

--- a/admin/src/api/index.ts
+++ b/admin/src/api/index.ts
@@ -1,0 +1,7 @@
+export * from './client'
+export * from './services'
+export * from './llm'
+export * from './tts'
+export * from './faq'
+export * from './finetune'
+export * from './monitor'

--- a/admin/src/api/llm.ts
+++ b/admin/src/api/llm.ts
@@ -1,0 +1,58 @@
+import { api } from './client'
+
+export interface LlmBackend {
+  backend: string
+  model: string
+  api_url?: string | null
+}
+
+export interface Persona {
+  name: string
+  full_name: string
+}
+
+export interface LlmParams {
+  temperature: number
+  max_tokens: number
+  top_p: number
+  repetition_penalty: number
+}
+
+// LLM API
+export const llmApi = {
+  getBackend: () =>
+    api.get<LlmBackend>('/admin/llm/backend'),
+
+  setBackend: (backend: 'vllm' | 'gemini') =>
+    api.post<{ status: string; backend: string; message?: string }>('/admin/llm/backend', { backend }),
+
+  getPersonas: () =>
+    api.get<{ personas: Record<string, Persona> }>('/admin/llm/personas'),
+
+  getCurrentPersona: () =>
+    api.get<{ id: string; name: string }>('/admin/llm/persona'),
+
+  setPersona: (persona: string) =>
+    api.post<{ status: string; persona: string }>('/admin/llm/persona', { persona }),
+
+  getParams: () =>
+    api.get<{ params: LlmParams }>('/admin/llm/params'),
+
+  setParams: (params: Partial<LlmParams>) =>
+    api.post<{ status: string; params: LlmParams }>('/admin/llm/params', params),
+
+  getPrompt: (persona: string) =>
+    api.get<{ persona: string; prompt: string }>(`/admin/llm/prompt/${persona}`),
+
+  setPrompt: (persona: string, prompt: string) =>
+    api.post<{ status: string; persona: string }>(`/admin/llm/prompt/${persona}`, { prompt }),
+
+  resetPrompt: (persona: string) =>
+    api.post<{ status: string }>(`/admin/llm/prompt/${persona}/reset`),
+
+  getHistory: () =>
+    api.get<{ history: Array<{ role: string; content: string }>; count: number }>('/admin/llm/history'),
+
+  clearHistory: () =>
+    api.delete<{ status: string; cleared_messages: number }>('/admin/llm/history'),
+}

--- a/admin/src/api/monitor.ts
+++ b/admin/src/api/monitor.ts
@@ -1,0 +1,67 @@
+import { api, createSSE } from './client'
+
+export interface GpuInfo {
+  id: number
+  name: string
+  total_memory_gb: number
+  allocated_gb: number
+  reserved_gb: number
+  free_gb: number
+  utilization_percent: number | null
+  temperature_c: number | null
+  compute_capability: string
+}
+
+export interface HealthComponent {
+  status: 'healthy' | 'unhealthy' | 'unavailable' | 'stopped'
+  backend?: string
+  pid?: number
+  error?: string
+  uptime?: string
+}
+
+export interface SystemMetrics {
+  cpu_percent: number
+  memory_percent: number
+  memory_used_gb: number
+  memory_total_gb: number
+}
+
+export interface Metrics {
+  timestamp: string
+  system: SystemMetrics
+  streaming_tts: {
+    cache_size: number
+    active_sessions: number
+    max_cache_size: number
+  } | null
+  llm?: {
+    history_length: number
+    faq_count: number
+  }
+}
+
+// Monitor API
+export const monitorApi = {
+  getGpuStats: () =>
+    api.get<{ available: boolean; gpus: GpuInfo[] }>('/admin/monitor/gpu'),
+
+  streamGpuStats: (onMessage: (data: { gpus?: GpuInfo[]; available?: boolean; timestamp?: string }) => void) =>
+    createSSE('/admin/monitor/gpu/stream', onMessage),
+
+  getHealth: () =>
+    api.get<{
+      timestamp: string
+      overall: 'healthy' | 'degraded'
+      components: Record<string, HealthComponent>
+    }>('/admin/monitor/health'),
+
+  getMetrics: () =>
+    api.get<Metrics>('/admin/monitor/metrics'),
+
+  getErrors: () =>
+    api.get<{ errors: Record<string, string>; timestamp: string }>('/admin/monitor/errors'),
+
+  resetMetrics: () =>
+    api.post<{ status: string; message: string }>('/admin/monitor/metrics/reset'),
+}

--- a/admin/src/api/services.ts
+++ b/admin/src/api/services.ts
@@ -1,0 +1,74 @@
+import { api, createSSE } from './client'
+
+export interface ServiceStatus {
+  name: string
+  display_name: string
+  is_running: boolean
+  pid: number | null
+  memory_mb: number | null
+  port: number | null
+  internal: boolean
+  gpu_required: boolean
+  cpu_only: boolean
+  log_file: string | null
+  last_error: string | null
+  uptime_seconds?: number
+}
+
+export interface ServicesStatusResponse {
+  services: Record<string, ServiceStatus>
+  timestamp: string
+}
+
+export interface LogFile {
+  name: string
+  file: string
+  display_name: string
+  size_kb: number
+  modified: string
+}
+
+export interface LogReadResponse {
+  lines: string[]
+  total_lines: number
+  file: string
+  start_line?: number
+  end_line?: number
+  error?: string
+}
+
+// Services API
+export const servicesApi = {
+  getStatus: () =>
+    api.get<ServicesStatusResponse>('/admin/services/status'),
+
+  startService: (name: string) =>
+    api.post<{ status: string; message: string; pid?: number }>(`/admin/services/${name}/start`),
+
+  stopService: (name: string) =>
+    api.post<{ status: string; message: string }>(`/admin/services/${name}/stop`),
+
+  restartService: (name: string) =>
+    api.post<{ status: string; message: string }>(`/admin/services/${name}/restart`),
+
+  startAll: () =>
+    api.post<{ status: string; results: Record<string, unknown> }>('/admin/services/start-all'),
+
+  stopAll: () =>
+    api.post<{ status: string; results: Record<string, unknown> }>('/admin/services/stop-all'),
+}
+
+// Logs API
+export const logsApi = {
+  list: () =>
+    api.get<{ logs: LogFile[] }>('/admin/logs'),
+
+  read: (logfile: string, lines = 100, offset = 0, search?: string) => {
+    let url = `/admin/logs/${logfile}?lines=${lines}&offset=${offset}`
+    if (search) url += `&search=${encodeURIComponent(search)}`
+    return api.get<LogReadResponse>(url)
+  },
+
+  stream: (logfile: string, onMessage: (data: { line?: string; error?: string }) => void) =>
+    createSSE(`/admin/logs/stream/${logfile}`, onMessage),
+}

--- a/admin/src/api/tts.ts
+++ b/admin/src/api/tts.ts
@@ -1,0 +1,109 @@
+import { api } from './client'
+
+export interface Voice {
+  id: string
+  name: string
+  engine: string
+  description: string
+  available: boolean
+  samples_count?: number
+  default?: boolean
+}
+
+export interface VoiceConfig {
+  engine: string
+  voice: string
+}
+
+export interface XttsParams {
+  temperature: number
+  repetition_penalty: number
+  top_k: number
+  top_p: number
+  speed: number
+  gpt_cond_len: number
+  gpt_cond_chunk_len: number
+}
+
+export interface TtsPreset {
+  display_name: string
+  temperature: number
+  repetition_penalty: number
+  top_k: number
+  top_p: number
+  speed: number
+}
+
+// TTS API
+export const ttsApi = {
+  // Voices
+  getVoices: () =>
+    api.get<{ voices: Voice[]; current: VoiceConfig }>('/admin/voices'),
+
+  getCurrentVoice: () =>
+    api.get<VoiceConfig>('/admin/voice'),
+
+  setVoice: (voice: string) =>
+    api.post<{ status: string; engine: string; voice: string }>('/admin/voice', { voice }),
+
+  testVoice: (voice: string) =>
+    fetch(`/admin/voice/test`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ voice }),
+    }).then(res => {
+      if (!res.ok) throw new Error('Test failed')
+      return res.blob()
+    }),
+
+  // XTTS Params
+  getXttsParams: () =>
+    api.get<{ default_preset: string; current_params: XttsParams }>('/admin/tts/xtts/params'),
+
+  setXttsParams: (params: Partial<XttsParams>) =>
+    api.post<{ status: string; params: Partial<XttsParams> }>('/admin/tts/xtts/params', params),
+
+  // Piper Params
+  getPiperParams: () =>
+    api.get<{ speed: number; voices: Record<string, unknown> }>('/admin/tts/piper/params'),
+
+  setPiperParams: (speed: number) =>
+    api.post<{ status: string; speed: number }>('/admin/tts/piper/params', { speed }),
+
+  // Presets
+  getBuiltinPresets: () =>
+    api.get<{ presets: Record<string, TtsPreset>; current: string }>('/admin/tts/presets'),
+
+  setPreset: (preset: string) =>
+    api.post<{ status: string; preset: string }>('/admin/tts/preset', { preset }),
+
+  getCustomPresets: () =>
+    api.get<{ presets: Record<string, Partial<XttsParams>> }>('/admin/tts/presets/custom'),
+
+  createCustomPreset: (name: string, params: Partial<XttsParams>) =>
+    api.post<{ status: string; preset: string }>('/admin/tts/presets/custom', { name, params }),
+
+  updateCustomPreset: (name: string, params: Partial<XttsParams>) =>
+    api.put<{ status: string; preset: string }>(`/admin/tts/presets/custom/${name}`, { name, params }),
+
+  deleteCustomPreset: (name: string) =>
+    api.delete<{ status: string; deleted: string }>(`/admin/tts/presets/custom/${name}`),
+
+  // Cache
+  getCacheStats: () =>
+    api.get<{ cache_size: number; active_sessions: number }>('/admin/tts/cache'),
+
+  clearCache: () =>
+    api.delete<{ status: string; cleared_items: number }>('/admin/tts/cache'),
+
+  // Test synthesis
+  testSynthesize: (text: string, preset = 'natural') =>
+    fetch(`/admin/tts/test`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, preset }),
+    }).then(res => {
+      if (!res.ok) throw new Error('Synthesis failed')
+      return res.json()
+    }),
+}

--- a/admin/src/assets/main.css
+++ b/admin/src/assets/main.css
@@ -1,0 +1,86 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+    --radius: 0.5rem;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+    font-feature-settings: "rlig" 1, "calt" 1;
+  }
+}
+
+/* Custom scrollbar */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: hsl(var(--secondary));
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: hsl(var(--muted-foreground));
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: hsl(var(--foreground));
+}
+
+/* Log viewer styles */
+.log-viewer {
+  font-family: 'Fira Code', 'Monaco', 'Consolas', monospace;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.log-line {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.log-line.error {
+  color: #ef4444;
+}
+
+.log-line.warning {
+  color: #f59e0b;
+}
+
+.log-line.info {
+  color: #3b82f6;
+}
+
+.log-line.success {
+  color: #22c55e;
+}

--- a/admin/src/composables/index.ts
+++ b/admin/src/composables/index.ts
@@ -1,0 +1,2 @@
+export * from './useSSE'
+export * from './useGpuStats'

--- a/admin/src/composables/useGpuStats.ts
+++ b/admin/src/composables/useGpuStats.ts
@@ -1,0 +1,54 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+import { useQuery } from '@tanstack/vue-query'
+import { monitorApi, type GpuInfo } from '@/api'
+
+export function useGpuStats(interval = 5000) {
+  const stats = ref<GpuInfo | null>(null)
+  const history = ref<{ time: Date; allocated: number }[]>([])
+
+  const { data, refetch, isLoading, error } = useQuery({
+    queryKey: ['gpu-stats'],
+    queryFn: () => monitorApi.getGpuStats(),
+    refetchInterval: interval,
+  })
+
+  // Watch for changes
+  let unwatch: (() => void) | null = null
+
+  onMounted(() => {
+    unwatch = watchEffect(() => {
+      if (data.value?.gpus?.[0]) {
+        stats.value = data.value.gpus[0]
+
+        // Add to history
+        history.value.push({
+          time: new Date(),
+          allocated: data.value.gpus[0].allocated_gb,
+        })
+
+        // Keep last 60 entries
+        if (history.value.length > 60) {
+          history.value = history.value.slice(-60)
+        }
+      }
+    })
+  })
+
+  onUnmounted(() => {
+    if (unwatch) unwatch()
+  })
+
+  return {
+    stats,
+    history,
+    isLoading,
+    error,
+    refetch,
+  }
+}
+
+// Simple watchEffect implementation since we're not importing from vue
+function watchEffect(fn: () => void) {
+  fn()
+  return () => {}
+}

--- a/admin/src/composables/useSSE.ts
+++ b/admin/src/composables/useSSE.ts
@@ -1,0 +1,71 @@
+import { ref, onUnmounted } from 'vue'
+
+export function useSSE<T = unknown>(url: string) {
+  const data = ref<T[]>([])
+  const lastData = ref<T | null>(null)
+  const isConnected = ref(false)
+  const error = ref<string | null>(null)
+  let eventSource: EventSource | null = null
+
+  function connect() {
+    if (eventSource) {
+      return
+    }
+
+    eventSource = new EventSource(url)
+
+    eventSource.onopen = () => {
+      isConnected.value = true
+      error.value = null
+    }
+
+    eventSource.onmessage = (event) => {
+      try {
+        const parsed = JSON.parse(event.data) as T
+        data.value.push(parsed)
+        lastData.value = parsed
+
+        // Keep last 1000 items
+        if (data.value.length > 1000) {
+          data.value = data.value.slice(-500)
+        }
+      } catch {
+        // If not JSON, store as string
+        data.value.push(event.data as T)
+        lastData.value = event.data as T
+      }
+    }
+
+    eventSource.onerror = () => {
+      isConnected.value = false
+      error.value = 'Connection lost'
+    }
+  }
+
+  function disconnect() {
+    if (eventSource) {
+      eventSource.close()
+      eventSource = null
+      isConnected.value = false
+    }
+  }
+
+  function clear() {
+    data.value = []
+    lastData.value = null
+  }
+
+  onUnmounted(() => {
+    disconnect()
+  })
+
+  return {
+    data,
+    lastData,
+    isConnected,
+    error,
+    connect,
+    disconnect,
+    clear,
+  }
+}

--- a/admin/src/env.d.ts
+++ b/admin/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  const component: DefineComponent<{}, {}, any>
+  export default component
+}

--- a/admin/src/main.ts
+++ b/admin/src/main.ts
@@ -1,0 +1,14 @@
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import { VueQueryPlugin } from '@tanstack/vue-query'
+import App from './App.vue'
+import router from './router'
+import './assets/main.css'
+
+const app = createApp(App)
+
+app.use(createPinia())
+app.use(VueQueryPlugin)
+app.use(router)
+
+app.mount('#app')

--- a/admin/src/router.ts
+++ b/admin/src/router.ts
@@ -1,0 +1,58 @@
+import { createRouter, createWebHashHistory } from 'vue-router'
+import DashboardView from './views/DashboardView.vue'
+import ServicesView from './views/ServicesView.vue'
+import LlmView from './views/LlmView.vue'
+import TtsView from './views/TtsView.vue'
+import FaqView from './views/FaqView.vue'
+import FinetuneView from './views/FinetuneView.vue'
+import MonitoringView from './views/MonitoringView.vue'
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    {
+      path: '/',
+      name: 'dashboard',
+      component: DashboardView,
+      meta: { title: 'Dashboard', icon: 'LayoutDashboard' }
+    },
+    {
+      path: '/services',
+      name: 'services',
+      component: ServicesView,
+      meta: { title: 'Services', icon: 'Server' }
+    },
+    {
+      path: '/llm',
+      name: 'llm',
+      component: LlmView,
+      meta: { title: 'LLM', icon: 'Brain' }
+    },
+    {
+      path: '/tts',
+      name: 'tts',
+      component: TtsView,
+      meta: { title: 'TTS', icon: 'Mic' }
+    },
+    {
+      path: '/faq',
+      name: 'faq',
+      component: FaqView,
+      meta: { title: 'FAQ', icon: 'MessageSquare' }
+    },
+    {
+      path: '/finetune',
+      name: 'finetune',
+      component: FinetuneView,
+      meta: { title: 'Fine-tune', icon: 'Sparkles' }
+    },
+    {
+      path: '/monitoring',
+      name: 'monitoring',
+      component: MonitoringView,
+      meta: { title: 'Monitoring', icon: 'Activity' }
+    }
+  ]
+})
+
+export default router

--- a/admin/src/stores/index.ts
+++ b/admin/src/stores/index.ts
@@ -1,0 +1,4 @@
+export * from './services'
+export * from './llm'
+export * from './tts'
+export * from './settings'

--- a/admin/src/stores/llm.ts
+++ b/admin/src/stores/llm.ts
@@ -1,0 +1,88 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { llmApi, type LlmParams } from '@/api'
+
+export const useLlmStore = defineStore('llm', () => {
+  const backend = ref<'vllm' | 'gemini'>('vllm')
+  const model = ref<string>('')
+  const persona = ref<string>('gulya')
+  const params = ref<LlmParams>({
+    temperature: 0.7,
+    max_tokens: 512,
+    top_p: 0.9,
+    repetition_penalty: 1.1,
+  })
+  const isLoading = ref(false)
+
+  async function fetchBackend() {
+    try {
+      const response = await llmApi.getBackend()
+      backend.value = response.backend as 'vllm' | 'gemini'
+      model.value = response.model
+    } catch (e) {
+      console.error('Failed to fetch backend:', e)
+    }
+  }
+
+  async function fetchParams() {
+    try {
+      const response = await llmApi.getParams()
+      params.value = response.params
+    } catch (e) {
+      console.error('Failed to fetch params:', e)
+    }
+  }
+
+  async function fetchPersona() {
+    try {
+      const response = await llmApi.getCurrentPersona()
+      persona.value = response.id
+    } catch (e) {
+      console.error('Failed to fetch persona:', e)
+    }
+  }
+
+  async function switchBackend(newBackend: 'vllm' | 'gemini') {
+    isLoading.value = true
+    try {
+      await llmApi.setBackend(newBackend)
+      backend.value = newBackend
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function switchPersona(newPersona: string) {
+    isLoading.value = true
+    try {
+      await llmApi.setPersona(newPersona)
+      persona.value = newPersona
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function updateParams(newParams: Partial<LlmParams>) {
+    isLoading.value = true
+    try {
+      const response = await llmApi.setParams(newParams)
+      params.value = response.params
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  return {
+    backend,
+    model,
+    persona,
+    params,
+    isLoading,
+    fetchBackend,
+    fetchParams,
+    fetchPersona,
+    switchBackend,
+    switchPersona,
+    updateParams,
+  }
+})

--- a/admin/src/stores/services.ts
+++ b/admin/src/stores/services.ts
@@ -1,0 +1,69 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { servicesApi, type ServiceStatus } from '@/api'
+
+export const useServicesStore = defineStore('services', () => {
+  const services = ref<Record<string, ServiceStatus>>({})
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+  const lastUpdated = ref<Date | null>(null)
+
+  const servicesList = computed(() => Object.values(services.value))
+  const runningCount = computed(() => servicesList.value.filter(s => s.is_running).length)
+  const totalCount = computed(() => servicesList.value.length)
+
+  async function fetchStatus() {
+    isLoading.value = true
+    error.value = null
+    try {
+      const response = await servicesApi.getStatus()
+      services.value = response.services
+      lastUpdated.value = new Date()
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to fetch status'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function startService(name: string) {
+    try {
+      await servicesApi.startService(name)
+      await fetchStatus()
+    } catch (e) {
+      throw e
+    }
+  }
+
+  async function stopService(name: string) {
+    try {
+      await servicesApi.stopService(name)
+      await fetchStatus()
+    } catch (e) {
+      throw e
+    }
+  }
+
+  async function restartService(name: string) {
+    try {
+      await servicesApi.restartService(name)
+      await fetchStatus()
+    } catch (e) {
+      throw e
+    }
+  }
+
+  return {
+    services,
+    servicesList,
+    runningCount,
+    totalCount,
+    isLoading,
+    error,
+    lastUpdated,
+    fetchStatus,
+    startService,
+    stopService,
+    restartService,
+  }
+})

--- a/admin/src/stores/settings.ts
+++ b/admin/src/stores/settings.ts
@@ -1,0 +1,60 @@
+import { defineStore } from 'pinia'
+import { ref, watch } from 'vue'
+
+export const useSettingsStore = defineStore('settings', () => {
+  // UI Settings (persisted to localStorage)
+  const sidebarCollapsed = ref(false)
+  const autoRefreshInterval = ref(5000) // ms
+  const theme = ref<'dark' | 'light'>('dark')
+
+  // Load from localStorage
+  const savedSettings = localStorage.getItem('admin-settings')
+  if (savedSettings) {
+    try {
+      const parsed = JSON.parse(savedSettings)
+      sidebarCollapsed.value = parsed.sidebarCollapsed ?? false
+      autoRefreshInterval.value = parsed.autoRefreshInterval ?? 5000
+      theme.value = parsed.theme ?? 'dark'
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  // Persist to localStorage on change
+  watch(
+    [sidebarCollapsed, autoRefreshInterval, theme],
+    () => {
+      localStorage.setItem(
+        'admin-settings',
+        JSON.stringify({
+          sidebarCollapsed: sidebarCollapsed.value,
+          autoRefreshInterval: autoRefreshInterval.value,
+          theme: theme.value,
+        })
+      )
+    },
+    { deep: true }
+  )
+
+  function toggleSidebar() {
+    sidebarCollapsed.value = !sidebarCollapsed.value
+  }
+
+  function setAutoRefreshInterval(interval: number) {
+    autoRefreshInterval.value = interval
+  }
+
+  function toggleTheme() {
+    theme.value = theme.value === 'dark' ? 'light' : 'dark'
+    document.documentElement.classList.toggle('dark', theme.value === 'dark')
+  }
+
+  return {
+    sidebarCollapsed,
+    autoRefreshInterval,
+    theme,
+    toggleSidebar,
+    setAutoRefreshInterval,
+    toggleTheme,
+  }
+})

--- a/admin/src/stores/tts.ts
+++ b/admin/src/stores/tts.ts
@@ -1,0 +1,83 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { ttsApi, type Voice, type VoiceConfig, type XttsParams } from '@/api'
+
+export const useTtsStore = defineStore('tts', () => {
+  const voices = ref<Voice[]>([])
+  const currentVoice = ref<VoiceConfig>({ engine: 'xtts', voice: 'gulya' })
+  const currentPreset = ref<string>('natural')
+  const xttsParams = ref<XttsParams>({
+    temperature: 0.75,
+    repetition_penalty: 4.0,
+    top_k: 55,
+    top_p: 0.88,
+    speed: 0.98,
+    gpt_cond_len: 20,
+    gpt_cond_chunk_len: 5,
+  })
+  const isLoading = ref(false)
+
+  async function fetchVoices() {
+    try {
+      const response = await ttsApi.getVoices()
+      voices.value = response.voices
+      currentVoice.value = response.current
+    } catch (e) {
+      console.error('Failed to fetch voices:', e)
+    }
+  }
+
+  async function fetchXttsParams() {
+    try {
+      const response = await ttsApi.getXttsParams()
+      xttsParams.value = response.current_params
+      currentPreset.value = response.default_preset
+    } catch (e) {
+      console.error('Failed to fetch XTTS params:', e)
+    }
+  }
+
+  async function setVoice(voice: string) {
+    isLoading.value = true
+    try {
+      const response = await ttsApi.setVoice(voice)
+      currentVoice.value = { engine: response.engine, voice: response.voice }
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function setPreset(preset: string) {
+    isLoading.value = true
+    try {
+      await ttsApi.setPreset(preset)
+      currentPreset.value = preset
+      await fetchXttsParams()
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function updateXttsParams(params: Partial<XttsParams>) {
+    isLoading.value = true
+    try {
+      await ttsApi.setXttsParams(params)
+      Object.assign(xttsParams.value, params)
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  return {
+    voices,
+    currentVoice,
+    currentPreset,
+    xttsParams,
+    isLoading,
+    fetchVoices,
+    fetchXttsParams,
+    setVoice,
+    setPreset,
+    updateXttsParams,
+  }
+})

--- a/admin/src/views/DashboardView.vue
+++ b/admin/src/views/DashboardView.vue
@@ -1,0 +1,248 @@
+<script setup lang="ts">
+import { useQuery } from '@tanstack/vue-query'
+import { servicesApi, monitorApi } from '@/api'
+import {
+  Server,
+  Cpu,
+  HardDrive,
+  Activity,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+  RefreshCw
+} from 'lucide-vue-next'
+import { computed } from 'vue'
+
+// Queries
+const { data: servicesData, isLoading: servicesLoading, refetch: refetchServices } = useQuery({
+  queryKey: ['services-status'],
+  queryFn: () => servicesApi.getStatus(),
+  refetchInterval: 10000,
+})
+
+const { data: healthData, isLoading: healthLoading, refetch: refetchHealth } = useQuery({
+  queryKey: ['health'],
+  queryFn: () => monitorApi.getHealth(),
+  refetchInterval: 10000,
+})
+
+const { data: gpuData, isLoading: gpuLoading, refetch: refetchGpu } = useQuery({
+  queryKey: ['gpu-stats'],
+  queryFn: () => monitorApi.getGpuStats(),
+  refetchInterval: 5000,
+})
+
+const { data: metricsData } = useQuery({
+  queryKey: ['metrics'],
+  queryFn: () => monitorApi.getMetrics(),
+  refetchInterval: 5000,
+})
+
+// Computed
+const services = computed(() => {
+  if (!servicesData.value) return []
+  return Object.entries(servicesData.value.services).map(([key, value]) => ({
+    id: key,
+    ...value,
+  }))
+})
+
+const runningCount = computed(() =>
+  services.value.filter(s => s.is_running).length
+)
+
+const overallHealth = computed(() => healthData.value?.overall || 'unknown')
+
+const gpu = computed(() => gpuData.value?.gpus?.[0])
+
+const gpuMemoryPercent = computed(() => {
+  if (!gpu.value) return 0
+  return Math.round((gpu.value.allocated_gb / gpu.value.total_memory_gb) * 100)
+})
+
+function refreshAll() {
+  refetchServices()
+  refetchHealth()
+  refetchGpu()
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Header Stats -->
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+      <!-- Services -->
+      <div class="bg-card rounded-lg border border-border p-4">
+        <div class="flex items-center gap-3">
+          <div class="p-2 rounded-lg bg-blue-500/20">
+            <Server class="w-5 h-5 text-blue-500" />
+          </div>
+          <div>
+            <p class="text-sm text-muted-foreground">Services</p>
+            <p class="text-2xl font-bold">{{ runningCount }}/{{ services.length }}</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Health -->
+      <div class="bg-card rounded-lg border border-border p-4">
+        <div class="flex items-center gap-3">
+          <div :class="[
+            'p-2 rounded-lg',
+            overallHealth === 'healthy' ? 'bg-green-500/20' : 'bg-yellow-500/20'
+          ]">
+            <Activity :class="[
+              'w-5 h-5',
+              overallHealth === 'healthy' ? 'text-green-500' : 'text-yellow-500'
+            ]" />
+          </div>
+          <div>
+            <p class="text-sm text-muted-foreground">Health</p>
+            <p class="text-2xl font-bold capitalize">{{ overallHealth }}</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- GPU Memory -->
+      <div class="bg-card rounded-lg border border-border p-4">
+        <div class="flex items-center gap-3">
+          <div class="p-2 rounded-lg bg-purple-500/20">
+            <Cpu class="w-5 h-5 text-purple-500" />
+          </div>
+          <div class="flex-1">
+            <p class="text-sm text-muted-foreground">GPU Memory</p>
+            <p class="text-2xl font-bold">{{ gpuMemoryPercent }}%</p>
+          </div>
+        </div>
+        <div class="mt-2 h-1.5 bg-secondary rounded-full overflow-hidden">
+          <div
+            class="h-full bg-purple-500 transition-all"
+            :style="{ width: `${gpuMemoryPercent}%` }"
+          />
+        </div>
+      </div>
+
+      <!-- System Memory -->
+      <div class="bg-card rounded-lg border border-border p-4">
+        <div class="flex items-center gap-3">
+          <div class="p-2 rounded-lg bg-orange-500/20">
+            <HardDrive class="w-5 h-5 text-orange-500" />
+          </div>
+          <div class="flex-1">
+            <p class="text-sm text-muted-foreground">System Memory</p>
+            <p class="text-2xl font-bold">{{ metricsData?.system?.memory_percent || 0 }}%</p>
+          </div>
+        </div>
+        <div class="mt-2 h-1.5 bg-secondary rounded-full overflow-hidden">
+          <div
+            class="h-full bg-orange-500 transition-all"
+            :style="{ width: `${metricsData?.system?.memory_percent || 0}%` }"
+          />
+        </div>
+      </div>
+    </div>
+
+    <!-- Services Grid -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="flex items-center justify-between p-4 border-b border-border">
+        <h2 class="text-lg font-semibold">Services Status</h2>
+        <button
+          @click="refreshAll"
+          class="flex items-center gap-2 px-3 py-1.5 text-sm bg-secondary rounded-lg hover:bg-secondary/80 transition-colors"
+        >
+          <RefreshCw class="w-4 h-4" />
+          Refresh
+        </button>
+      </div>
+
+      <div v-if="servicesLoading" class="p-8 text-center text-muted-foreground">
+        Loading services...
+      </div>
+
+      <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4">
+        <div
+          v-for="service in services"
+          :key="service.id"
+          class="flex items-center gap-3 p-4 rounded-lg border border-border bg-background"
+        >
+          <div :class="[
+            'p-2 rounded-lg',
+            service.is_running ? 'bg-green-500/20' : 'bg-red-500/20'
+          ]">
+            <CheckCircle2 v-if="service.is_running" class="w-5 h-5 text-green-500" />
+            <XCircle v-else class="w-5 h-5 text-red-500" />
+          </div>
+          <div class="flex-1 min-w-0">
+            <p class="font-medium truncate">{{ service.display_name }}</p>
+            <p class="text-sm text-muted-foreground">
+              <template v-if="service.is_running">
+                PID: {{ service.pid }}
+                <span v-if="service.memory_mb"> | {{ service.memory_mb?.toFixed(0) }} MB</span>
+              </template>
+              <template v-else>
+                Stopped
+              </template>
+            </p>
+          </div>
+          <div v-if="service.port" class="text-xs text-muted-foreground">
+            :{{ service.port }}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- GPU Info -->
+    <div v-if="gpu" class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-semibold">GPU Information</h2>
+      </div>
+      <div class="p-4 grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div>
+          <p class="text-sm text-muted-foreground">Name</p>
+          <p class="font-medium">{{ gpu.name }}</p>
+        </div>
+        <div>
+          <p class="text-sm text-muted-foreground">Memory</p>
+          <p class="font-medium">{{ gpu.allocated_gb?.toFixed(1) }} / {{ gpu.total_memory_gb?.toFixed(1) }} GB</p>
+        </div>
+        <div>
+          <p class="text-sm text-muted-foreground">Utilization</p>
+          <p class="font-medium">{{ gpu.utilization_percent ?? 'N/A' }}%</p>
+        </div>
+        <div>
+          <p class="text-sm text-muted-foreground">Temperature</p>
+          <p class="font-medium">{{ gpu.temperature_c ?? 'N/A' }}°C</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Health Components -->
+    <div v-if="healthData" class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-semibold">Components Health</h2>
+      </div>
+      <div class="divide-y divide-border">
+        <div
+          v-for="(component, name) in healthData.components"
+          :key="name"
+          class="flex items-center justify-between p-4"
+        >
+          <div class="flex items-center gap-3">
+            <CheckCircle2 v-if="component.status === 'healthy'" class="w-5 h-5 text-green-500" />
+            <AlertCircle v-else-if="component.status === 'unavailable'" class="w-5 h-5 text-yellow-500" />
+            <XCircle v-else class="w-5 h-5 text-red-500" />
+            <span class="font-medium capitalize">{{ name.replace(/_/g, ' ') }}</span>
+          </div>
+          <span :class="[
+            'text-sm px-2 py-0.5 rounded',
+            component.status === 'healthy' ? 'bg-green-500/20 text-green-500' :
+            component.status === 'unavailable' ? 'bg-yellow-500/20 text-yellow-500' :
+            'bg-red-500/20 text-red-500'
+          ]">
+            {{ component.status }}
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/admin/src/views/FaqView.vue
+++ b/admin/src/views/FaqView.vue
@@ -1,0 +1,335 @@
+<script setup lang="ts">
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
+import { faqApi } from '@/api'
+import {
+  MessageSquare,
+  Plus,
+  Pencil,
+  Trash2,
+  RotateCw,
+  Search,
+  TestTube2,
+  X,
+  Info
+} from 'lucide-vue-next'
+import { ref, computed } from 'vue'
+
+const queryClient = useQueryClient()
+
+// State
+const searchQuery = ref('')
+const showAddModal = ref(false)
+const editingEntry = ref<{ trigger: string; response: string } | null>(null)
+const testText = ref('')
+const testResult = ref<{ match: boolean; response: string | null } | null>(null)
+
+const formTrigger = ref('')
+const formResponse = ref('')
+
+// Queries
+const { data: faqData, isLoading, refetch } = useQuery({
+  queryKey: ['faq'],
+  queryFn: () => faqApi.getAll(),
+})
+
+// Mutations
+const addMutation = useMutation({
+  mutationFn: ({ trigger, response }: { trigger: string; response: string }) =>
+    faqApi.add(trigger, response),
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: ['faq'] })
+    closeModal()
+  },
+})
+
+const updateMutation = useMutation({
+  mutationFn: ({ oldTrigger, trigger, response }: { oldTrigger: string; trigger: string; response: string }) =>
+    faqApi.update(oldTrigger, trigger, response),
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: ['faq'] })
+    closeModal()
+  },
+})
+
+const deleteMutation = useMutation({
+  mutationFn: (trigger: string) => faqApi.delete(trigger),
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['faq'] }),
+})
+
+const reloadMutation = useMutation({
+  mutationFn: () => faqApi.reload(),
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['faq'] }),
+})
+
+const testMutation = useMutation({
+  mutationFn: (text: string) => faqApi.test(text),
+  onSuccess: (data) => {
+    testResult.value = data
+  },
+})
+
+// Computed
+const faqEntries = computed(() => {
+  if (!faqData.value?.faq) return []
+
+  let entries = Object.entries(faqData.value.faq).map(([trigger, response]) => ({
+    trigger,
+    response,
+  }))
+
+  if (searchQuery.value) {
+    const query = searchQuery.value.toLowerCase()
+    entries = entries.filter(
+      e => e.trigger.toLowerCase().includes(query) ||
+           e.response.toLowerCase().includes(query)
+    )
+  }
+
+  return entries.sort((a, b) => a.trigger.localeCompare(b.trigger))
+})
+
+// Methods
+function openAddModal() {
+  editingEntry.value = null
+  formTrigger.value = ''
+  formResponse.value = ''
+  showAddModal.value = true
+}
+
+function openEditModal(entry: { trigger: string; response: string }) {
+  editingEntry.value = entry
+  formTrigger.value = entry.trigger
+  formResponse.value = entry.response
+  showAddModal.value = true
+}
+
+function closeModal() {
+  showAddModal.value = false
+  editingEntry.value = null
+  formTrigger.value = ''
+  formResponse.value = ''
+}
+
+function saveEntry() {
+  if (!formTrigger.value || !formResponse.value) return
+
+  if (editingEntry.value) {
+    updateMutation.mutate({
+      oldTrigger: editingEntry.value.trigger,
+      trigger: formTrigger.value,
+      response: formResponse.value,
+    })
+  } else {
+    addMutation.mutate({
+      trigger: formTrigger.value,
+      response: formResponse.value,
+    })
+  }
+}
+
+function runTest() {
+  if (testText.value) {
+    testMutation.mutate(testText.value)
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Toolbar -->
+    <div class="flex items-center gap-4 flex-wrap">
+      <button
+        @click="openAddModal"
+        class="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+      >
+        <Plus class="w-4 h-4" />
+        Add Entry
+      </button>
+      <button
+        @click="reloadMutation.mutate()"
+        :disabled="reloadMutation.isPending.value"
+        class="flex items-center gap-2 px-4 py-2 bg-secondary rounded-lg hover:bg-secondary/80 disabled:opacity-50 transition-colors"
+      >
+        <RotateCw class="w-4 h-4" />
+        Reload
+      </button>
+
+      <div class="flex-1" />
+
+      <div class="relative">
+        <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+        <input
+          v-model="searchQuery"
+          type="text"
+          placeholder="Search..."
+          class="pl-10 pr-4 py-2 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary w-64"
+        />
+      </div>
+    </div>
+
+    <!-- Template Variables Info -->
+    <div class="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4">
+      <div class="flex items-start gap-3">
+        <Info class="w-5 h-5 text-blue-500 mt-0.5" />
+        <div>
+          <h3 class="font-medium text-blue-500">Template Variables</h3>
+          <p class="text-sm text-muted-foreground mt-1">
+            You can use these placeholders in responses:
+            <code class="bg-secondary px-1 rounded">{'{'}current_time{'}'}</code>,
+            <code class="bg-secondary px-1 rounded">{'{'}current_date{'}'}</code>,
+            <code class="bg-secondary px-1 rounded">{'{'}day_of_week{'}'}</code>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- FAQ Test -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-semibold flex items-center gap-2">
+          <TestTube2 class="w-5 h-5" />
+          Test FAQ Matching
+        </h2>
+      </div>
+      <div class="p-4">
+        <div class="flex gap-2">
+          <input
+            v-model="testText"
+            type="text"
+            placeholder="Enter text to test..."
+            class="flex-1 px-4 py-2 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+            @keyup.enter="runTest"
+          />
+          <button
+            @click="runTest"
+            :disabled="testMutation.isPending.value || !testText"
+            class="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          >
+            Test
+          </button>
+        </div>
+
+        <div v-if="testResult" class="mt-4 p-4 rounded-lg" :class="testResult.match ? 'bg-green-500/10' : 'bg-red-500/10'">
+          <p v-if="testResult.match" class="text-green-500 font-medium">Match found!</p>
+          <p v-else class="text-red-500 font-medium">No match - will go to LLM</p>
+          <p v-if="testResult.response" class="mt-2 text-sm">
+            Response: <span class="text-muted-foreground">{{ testResult.response }}</span>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- FAQ Table -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border flex items-center justify-between">
+        <h2 class="text-lg font-semibold flex items-center gap-2">
+          <MessageSquare class="w-5 h-5" />
+          FAQ Entries
+          <span class="text-sm font-normal text-muted-foreground">({{ faqEntries.length }})</span>
+        </h2>
+      </div>
+
+      <div v-if="isLoading" class="p-8 text-center text-muted-foreground">
+        Loading...
+      </div>
+
+      <div v-else-if="faqEntries.length === 0" class="p-8 text-center text-muted-foreground">
+        {{ searchQuery ? 'No matching entries' : 'No FAQ entries yet' }}
+      </div>
+
+      <div v-else class="divide-y divide-border">
+        <div
+          v-for="entry in faqEntries"
+          :key="entry.trigger"
+          class="p-4 hover:bg-secondary/50 transition-colors"
+        >
+          <div class="flex items-start justify-between gap-4">
+            <div class="flex-1 min-w-0">
+              <div class="font-medium text-primary">{{ entry.trigger }}</div>
+              <div class="text-sm text-muted-foreground mt-1 line-clamp-2">
+                {{ entry.response }}
+              </div>
+            </div>
+            <div class="flex items-center gap-2 shrink-0">
+              <button
+                @click="openEditModal(entry)"
+                class="p-2 rounded-lg bg-secondary hover:bg-secondary/80 transition-colors"
+                title="Edit"
+              >
+                <Pencil class="w-4 h-4" />
+              </button>
+              <button
+                @click="deleteMutation.mutate(entry.trigger)"
+                :disabled="deleteMutation.isPending.value"
+                class="p-2 rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
+                title="Delete"
+              >
+                <Trash2 class="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Add/Edit Modal -->
+    <div
+      v-if="showAddModal"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      @click.self="closeModal"
+    >
+      <div class="bg-card border border-border rounded-lg w-full max-w-lg p-6">
+        <div class="flex items-center justify-between mb-4">
+          <h3 class="text-lg font-semibold">
+            {{ editingEntry ? 'Edit FAQ Entry' : 'Add FAQ Entry' }}
+          </h3>
+          <button
+            @click="closeModal"
+            class="p-1 rounded hover:bg-secondary transition-colors"
+          >
+            <X class="w-5 h-5" />
+          </button>
+        </div>
+
+        <div class="space-y-4">
+          <div>
+            <label class="block text-sm font-medium mb-2">Trigger (question/phrase)</label>
+            <input
+              v-model="formTrigger"
+              type="text"
+              placeholder="e.g., привет"
+              class="w-full px-4 py-2 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            <p class="text-xs text-muted-foreground mt-1">Case-insensitive, partial matching</p>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium mb-2">Response</label>
+            <textarea
+              v-model="formResponse"
+              rows="4"
+              placeholder="e.g., Здравствуйте! Чем могу помочь?"
+              class="w-full px-4 py-2 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary resize-none"
+            />
+          </div>
+        </div>
+
+        <div class="flex justify-end gap-2 mt-6">
+          <button
+            @click="closeModal"
+            class="px-4 py-2 bg-secondary rounded-lg hover:bg-secondary/80 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            @click="saveEntry"
+            :disabled="!formTrigger || !formResponse || addMutation.isPending.value || updateMutation.isPending.value"
+            class="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          >
+            {{ editingEntry ? 'Update' : 'Add' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/admin/src/views/FinetuneView.vue
+++ b/admin/src/views/FinetuneView.vue
@@ -1,0 +1,513 @@
+<script setup lang="ts">
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
+import { finetuneApi, type TrainingConfig, type TrainingStatus, type Adapter } from '@/api'
+import {
+  Sparkles,
+  Upload,
+  PlayCircle,
+  StopCircle,
+  RefreshCw,
+  Trash2,
+  CheckCircle2,
+  AlertCircle,
+  Database,
+  Settings2,
+  Loader2,
+  FileJson
+} from 'lucide-vue-next'
+import { ref, computed, watch, onUnmounted } from 'vue'
+
+const queryClient = useQueryClient()
+
+// State
+const uploadingFile = ref<File | null>(null)
+const uploadProgress = ref(0)
+const trainingLog = ref<string[]>([])
+const localConfig = ref<Partial<TrainingConfig>>({})
+let logEventSource: { close: () => void } | null = null
+
+// Queries
+const { data: statsData, refetch: refetchStats } = useQuery({
+  queryKey: ['finetune-dataset-stats'],
+  queryFn: () => finetuneApi.getDatasetStats(),
+})
+
+const { data: configData } = useQuery({
+  queryKey: ['finetune-config'],
+  queryFn: () => finetuneApi.getConfig(),
+})
+
+const { data: statusData, refetch: refetchStatus } = useQuery({
+  queryKey: ['finetune-status'],
+  queryFn: () => finetuneApi.getTrainingStatus(),
+  refetchInterval: (data) => data?.status?.is_running ? 2000 : false,
+})
+
+const { data: adaptersData, refetch: refetchAdapters } = useQuery({
+  queryKey: ['finetune-adapters'],
+  queryFn: () => finetuneApi.listAdapters(),
+})
+
+// Watch config data
+watch(configData, (data) => {
+  if (data?.config) {
+    localConfig.value = { ...data.config }
+  }
+}, { immediate: true })
+
+// Mutations
+const uploadMutation = useMutation({
+  mutationFn: (file: File) => finetuneApi.uploadDataset(file),
+  onSuccess: () => {
+    refetchStats()
+    uploadingFile.value = null
+    uploadProgress.value = 0
+  },
+})
+
+const processMutation = useMutation({
+  mutationFn: () => finetuneApi.processDataset(),
+  onSuccess: () => refetchStats(),
+})
+
+const augmentMutation = useMutation({
+  mutationFn: () => finetuneApi.augmentDataset(),
+  onSuccess: () => refetchStats(),
+})
+
+const saveConfigMutation = useMutation({
+  mutationFn: (config: Partial<TrainingConfig>) => finetuneApi.setConfig(config),
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['finetune-config'] }),
+})
+
+const startTrainingMutation = useMutation({
+  mutationFn: () => finetuneApi.startTraining(),
+  onSuccess: () => {
+    refetchStatus()
+    startLogStream()
+  },
+})
+
+const stopTrainingMutation = useMutation({
+  mutationFn: () => finetuneApi.stopTraining(),
+  onSuccess: () => {
+    refetchStatus()
+    stopLogStream()
+  },
+})
+
+const activateAdapterMutation = useMutation({
+  mutationFn: (adapter: string) => finetuneApi.activateAdapter(adapter),
+  onSuccess: () => refetchAdapters(),
+})
+
+const deleteAdapterMutation = useMutation({
+  mutationFn: (name: string) => finetuneApi.deleteAdapter(name),
+  onSuccess: () => refetchAdapters(),
+})
+
+// Computed
+const stats = computed(() => statsData.value?.stats)
+const config = computed(() => configData.value?.config)
+const presets = computed(() => configData.value?.presets || {})
+const status = computed(() => statusData.value?.status)
+const adapters = computed(() => adaptersData.value?.adapters || [])
+const activeAdapter = computed(() => adaptersData.value?.active)
+
+const progressPercent = computed(() => {
+  if (!status.value?.total_steps) return 0
+  return Math.round((status.value.current_step / status.value.total_steps) * 100)
+})
+
+const formattedEta = computed(() => {
+  if (!status.value?.eta_seconds) return 'N/A'
+  const minutes = Math.floor(status.value.eta_seconds / 60)
+  const seconds = Math.floor(status.value.eta_seconds % 60)
+  return `${minutes}m ${seconds}s`
+})
+
+// Methods
+function handleFileSelect(event: Event) {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (file) {
+    uploadingFile.value = file
+  }
+}
+
+function uploadFile() {
+  if (uploadingFile.value) {
+    uploadMutation.mutate(uploadingFile.value)
+  }
+}
+
+function applyPreset(presetName: string) {
+  const preset = presets.value[presetName]
+  if (preset) {
+    localConfig.value = { ...localConfig.value, ...preset }
+  }
+}
+
+function saveConfig() {
+  saveConfigMutation.mutate(localConfig.value)
+}
+
+function startLogStream() {
+  trainingLog.value = []
+  logEventSource = finetuneApi.streamTrainingLog((data) => {
+    if (data.type === 'log' && data.line) {
+      trainingLog.value.push(data.line)
+      // Keep last 1000 lines
+      if (trainingLog.value.length > 1000) {
+        trainingLog.value = trainingLog.value.slice(-500)
+      }
+    }
+  })
+}
+
+function stopLogStream() {
+  if (logEventSource) {
+    logEventSource.close()
+    logEventSource = null
+  }
+}
+
+onUnmounted(() => {
+  stopLogStream()
+})
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Dataset Section -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-semibold flex items-center gap-2">
+          <Database class="w-5 h-5" />
+          Dataset
+        </h2>
+      </div>
+
+      <div class="p-4 space-y-4">
+        <!-- Upload -->
+        <div class="border-2 border-dashed border-border rounded-lg p-6 text-center">
+          <Upload class="w-8 h-8 mx-auto text-muted-foreground mb-2" />
+          <p class="text-sm text-muted-foreground mb-4">
+            Upload Telegram export (result.json)
+          </p>
+          <input
+            type="file"
+            accept=".json"
+            class="hidden"
+            id="file-upload"
+            @change="handleFileSelect"
+          />
+          <label
+            for="file-upload"
+            class="inline-block px-4 py-2 bg-secondary rounded-lg cursor-pointer hover:bg-secondary/80 transition-colors"
+          >
+            Select File
+          </label>
+
+          <div v-if="uploadingFile" class="mt-4">
+            <p class="text-sm">{{ uploadingFile.name }} ({{ (uploadingFile.size / 1024 / 1024).toFixed(2) }} MB)</p>
+            <button
+              @click="uploadFile"
+              :disabled="uploadMutation.isPending.value"
+              class="mt-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors"
+            >
+              <Loader2 v-if="uploadMutation.isPending.value" class="w-4 h-4 animate-spin inline mr-2" />
+              Upload
+            </button>
+          </div>
+        </div>
+
+        <!-- Stats -->
+        <div v-if="stats" class="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div class="p-4 bg-secondary rounded-lg">
+            <p class="text-sm text-muted-foreground">Sessions</p>
+            <p class="text-2xl font-bold">{{ stats.total_sessions }}</p>
+          </div>
+          <div class="p-4 bg-secondary rounded-lg">
+            <p class="text-sm text-muted-foreground">Messages</p>
+            <p class="text-2xl font-bold">{{ stats.total_messages }}</p>
+          </div>
+          <div class="p-4 bg-secondary rounded-lg">
+            <p class="text-sm text-muted-foreground">Tokens</p>
+            <p class="text-2xl font-bold">{{ stats.total_tokens?.toLocaleString() }}</p>
+          </div>
+          <div class="p-4 bg-secondary rounded-lg">
+            <p class="text-sm text-muted-foreground">File Size</p>
+            <p class="text-2xl font-bold">{{ stats.file_size_mb }} MB</p>
+          </div>
+        </div>
+
+        <!-- Actions -->
+        <div class="flex gap-2">
+          <button
+            @click="processMutation.mutate()"
+            :disabled="processMutation.isPending.value"
+            class="flex items-center gap-2 px-4 py-2 bg-secondary rounded-lg hover:bg-secondary/80 disabled:opacity-50 transition-colors"
+          >
+            <FileJson class="w-4 h-4" />
+            Process Dataset
+          </button>
+          <button
+            @click="augmentMutation.mutate()"
+            :disabled="augmentMutation.isPending.value"
+            class="flex items-center gap-2 px-4 py-2 bg-secondary rounded-lg hover:bg-secondary/80 disabled:opacity-50 transition-colors"
+          >
+            <Sparkles class="w-4 h-4" />
+            Augment
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Training Config -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border flex items-center justify-between">
+        <h2 class="text-lg font-semibold flex items-center gap-2">
+          <Settings2 class="w-5 h-5" />
+          Training Configuration
+        </h2>
+        <button
+          @click="saveConfig"
+          :disabled="saveConfigMutation.isPending.value"
+          class="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          Save Config
+        </button>
+      </div>
+
+      <div class="p-4">
+        <!-- Presets -->
+        <div class="mb-6">
+          <h3 class="text-sm font-medium mb-2">Presets</h3>
+          <div class="flex gap-2">
+            <button
+              v-for="(preset, name) in presets"
+              :key="name"
+              @click="applyPreset(name as string)"
+              class="px-3 py-1.5 bg-secondary rounded-lg hover:bg-secondary/80 transition-colors text-sm"
+            >
+              {{ name }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Config Form -->
+        <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+          <div>
+            <label class="block text-sm mb-1">LoRA Rank</label>
+            <input
+              v-model.number="localConfig.lora_rank"
+              type="number"
+              class="w-full px-3 py-2 bg-secondary rounded-lg"
+            />
+          </div>
+          <div>
+            <label class="block text-sm mb-1">LoRA Alpha</label>
+            <input
+              v-model.number="localConfig.lora_alpha"
+              type="number"
+              class="w-full px-3 py-2 bg-secondary rounded-lg"
+            />
+          </div>
+          <div>
+            <label class="block text-sm mb-1">Batch Size</label>
+            <input
+              v-model.number="localConfig.batch_size"
+              type="number"
+              class="w-full px-3 py-2 bg-secondary rounded-lg"
+            />
+          </div>
+          <div>
+            <label class="block text-sm mb-1">Grad Accum Steps</label>
+            <input
+              v-model.number="localConfig.gradient_accumulation_steps"
+              type="number"
+              class="w-full px-3 py-2 bg-secondary rounded-lg"
+            />
+          </div>
+          <div>
+            <label class="block text-sm mb-1">Learning Rate</label>
+            <input
+              v-model.number="localConfig.learning_rate"
+              type="number"
+              step="0.00001"
+              class="w-full px-3 py-2 bg-secondary rounded-lg"
+            />
+          </div>
+          <div>
+            <label class="block text-sm mb-1">Epochs</label>
+            <input
+              v-model.number="localConfig.num_epochs"
+              type="number"
+              class="w-full px-3 py-2 bg-secondary rounded-lg"
+            />
+          </div>
+          <div>
+            <label class="block text-sm mb-1">Max Seq Length</label>
+            <input
+              v-model.number="localConfig.max_seq_length"
+              type="number"
+              class="w-full px-3 py-2 bg-secondary rounded-lg"
+            />
+          </div>
+          <div class="col-span-2">
+            <label class="block text-sm mb-1">Output Directory</label>
+            <input
+              v-model="localConfig.output_dir"
+              type="text"
+              class="w-full px-3 py-2 bg-secondary rounded-lg"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Training Status -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border flex items-center justify-between">
+        <h2 class="text-lg font-semibold flex items-center gap-2">
+          <PlayCircle class="w-5 h-5" />
+          Training
+        </h2>
+        <div class="flex gap-2">
+          <button
+            v-if="!status?.is_running"
+            @click="startTrainingMutation.mutate()"
+            :disabled="startTrainingMutation.isPending.value"
+            class="flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 transition-colors"
+          >
+            <PlayCircle class="w-4 h-4" />
+            Start
+          </button>
+          <button
+            v-else
+            @click="stopTrainingMutation.mutate()"
+            :disabled="stopTrainingMutation.isPending.value"
+            class="flex items-center gap-2 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 transition-colors"
+          >
+            <StopCircle class="w-4 h-4" />
+            Stop
+          </button>
+        </div>
+      </div>
+
+      <div class="p-4">
+        <!-- Progress -->
+        <div v-if="status?.is_running" class="space-y-4">
+          <div>
+            <div class="flex justify-between text-sm mb-1">
+              <span>Progress</span>
+              <span>{{ status.current_step }} / {{ status.total_steps }} ({{ progressPercent }}%)</span>
+            </div>
+            <div class="h-2 bg-secondary rounded-full overflow-hidden">
+              <div
+                class="h-full bg-primary transition-all"
+                :style="{ width: `${progressPercent}%` }"
+              />
+            </div>
+          </div>
+
+          <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div>
+              <p class="text-sm text-muted-foreground">Epoch</p>
+              <p class="font-medium">{{ status.current_epoch }} / {{ status.total_epochs }}</p>
+            </div>
+            <div>
+              <p class="text-sm text-muted-foreground">Loss</p>
+              <p class="font-medium">{{ status.loss?.toFixed(4) }}</p>
+            </div>
+            <div>
+              <p class="text-sm text-muted-foreground">Learning Rate</p>
+              <p class="font-medium">{{ status.learning_rate?.toExponential(2) }}</p>
+            </div>
+            <div>
+              <p class="text-sm text-muted-foreground">ETA</p>
+              <p class="font-medium">{{ formattedEta }}</p>
+            </div>
+          </div>
+        </div>
+
+        <div v-else-if="status?.error" class="flex items-center gap-2 text-red-500">
+          <AlertCircle class="w-5 h-5" />
+          {{ status.error }}
+        </div>
+
+        <div v-else class="text-muted-foreground text-center py-4">
+          Training not running
+        </div>
+
+        <!-- Training Log -->
+        <div v-if="trainingLog.length" class="mt-4">
+          <h3 class="text-sm font-medium mb-2">Training Log</h3>
+          <div class="h-48 overflow-auto bg-background rounded-lg p-3 font-mono text-xs">
+            <div v-for="(line, i) in trainingLog.slice(-100)" :key="i" class="text-muted-foreground">
+              {{ line }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Adapters -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border flex items-center justify-between">
+        <h2 class="text-lg font-semibold">LoRA Adapters</h2>
+        <button
+          @click="refetchAdapters"
+          class="p-2 rounded-lg bg-secondary hover:bg-secondary/80 transition-colors"
+        >
+          <RefreshCw class="w-4 h-4" />
+        </button>
+      </div>
+
+      <div v-if="!adapters.length" class="p-8 text-center text-muted-foreground">
+        No adapters found
+      </div>
+
+      <div v-else class="divide-y divide-border">
+        <div
+          v-for="adapter in adapters"
+          :key="adapter.name"
+          class="flex items-center justify-between p-4"
+        >
+          <div class="flex items-center gap-3">
+            <CheckCircle2
+              v-if="adapter.active"
+              class="w-5 h-5 text-green-500"
+            />
+            <div v-else class="w-5 h-5 rounded-full border-2 border-border" />
+            <div>
+              <p class="font-medium">{{ adapter.name }}</p>
+              <p class="text-sm text-muted-foreground">
+                {{ adapter.size_mb }} MB | {{ new Date(adapter.modified).toLocaleDateString() }}
+              </p>
+            </div>
+          </div>
+          <div class="flex items-center gap-2">
+            <button
+              v-if="!adapter.active"
+              @click="activateAdapterMutation.mutate(adapter.name)"
+              :disabled="activateAdapterMutation.isPending.value"
+              class="px-3 py-1.5 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors text-sm"
+            >
+              Activate
+            </button>
+            <button
+              v-if="!adapter.active"
+              @click="deleteAdapterMutation.mutate(adapter.name)"
+              :disabled="deleteAdapterMutation.isPending.value"
+              class="p-2 text-red-500 hover:bg-red-500/20 rounded-lg transition-colors"
+            >
+              <Trash2 class="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/admin/src/views/LlmView.vue
+++ b/admin/src/views/LlmView.vue
@@ -1,0 +1,370 @@
+<script setup lang="ts">
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
+import { llmApi, type LlmParams } from '@/api'
+import {
+  Brain,
+  User,
+  Settings2,
+  Trash2,
+  Save,
+  RotateCw,
+  AlertCircle,
+  CheckCircle2
+} from 'lucide-vue-next'
+import { ref, computed, watch } from 'vue'
+
+const queryClient = useQueryClient()
+
+// State
+const editingPrompt = ref(false)
+const promptText = ref('')
+const selectedPersonaForPrompt = ref('gulya')
+
+// Queries
+const { data: backendData, isLoading: backendLoading } = useQuery({
+  queryKey: ['llm-backend'],
+  queryFn: () => llmApi.getBackend(),
+})
+
+const { data: personasData } = useQuery({
+  queryKey: ['llm-personas'],
+  queryFn: () => llmApi.getPersonas(),
+})
+
+const { data: currentPersonaData } = useQuery({
+  queryKey: ['llm-persona'],
+  queryFn: () => llmApi.getCurrentPersona(),
+})
+
+const { data: paramsData } = useQuery({
+  queryKey: ['llm-params'],
+  queryFn: () => llmApi.getParams(),
+})
+
+const { data: historyData, refetch: refetchHistory } = useQuery({
+  queryKey: ['llm-history'],
+  queryFn: () => llmApi.getHistory(),
+})
+
+// Local state for params
+const localParams = ref<Partial<LlmParams>>({})
+
+watch(paramsData, (data) => {
+  if (data?.params) {
+    localParams.value = { ...data.params }
+  }
+}, { immediate: true })
+
+// Mutations
+const setBackendMutation = useMutation({
+  mutationFn: (backend: 'vllm' | 'gemini') => llmApi.setBackend(backend),
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['llm-backend'] }),
+})
+
+const setPersonaMutation = useMutation({
+  mutationFn: (persona: string) => llmApi.setPersona(persona),
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: ['llm-persona'] })
+    queryClient.invalidateQueries({ queryKey: ['llm-history'] })
+  },
+})
+
+const setParamsMutation = useMutation({
+  mutationFn: (params: Partial<LlmParams>) => llmApi.setParams(params),
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['llm-params'] }),
+})
+
+const clearHistoryMutation = useMutation({
+  mutationFn: () => llmApi.clearHistory(),
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['llm-history'] }),
+})
+
+const savePromptMutation = useMutation({
+  mutationFn: ({ persona, prompt }: { persona: string; prompt: string }) =>
+    llmApi.setPrompt(persona, prompt),
+  onSuccess: () => {
+    editingPrompt.value = false
+  },
+})
+
+// Computed
+const personas = computed(() => personasData.value?.personas || {})
+
+const isVllm = computed(() => backendData.value?.backend === 'vllm')
+
+// Methods
+async function loadPromptForEdit(personaId: string) {
+  selectedPersonaForPrompt.value = personaId
+  try {
+    const response = await llmApi.getPrompt(personaId)
+    promptText.value = response.prompt
+    editingPrompt.value = true
+  } catch (e) {
+    console.error('Failed to load prompt:', e)
+  }
+}
+
+function saveParams() {
+  setParamsMutation.mutate(localParams.value)
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Backend Selection -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-semibold flex items-center gap-2">
+          <Brain class="w-5 h-5" />
+          LLM Backend
+        </h2>
+      </div>
+
+      <div class="p-4">
+        <div v-if="backendLoading" class="text-muted-foreground">Loading...</div>
+        <div v-else class="space-y-4">
+          <div class="flex items-center gap-4">
+            <div class="grid grid-cols-2 gap-2 p-1 bg-secondary rounded-lg">
+              <button
+                @click="setBackendMutation.mutate('vllm')"
+                :class="[
+                  'px-4 py-2 rounded-lg transition-colors',
+                  isVllm ? 'bg-primary text-primary-foreground' : 'hover:bg-secondary/80'
+                ]"
+              >
+                vLLM (Local)
+              </button>
+              <button
+                @click="setBackendMutation.mutate('gemini')"
+                :class="[
+                  'px-4 py-2 rounded-lg transition-colors',
+                  !isVllm ? 'bg-primary text-primary-foreground' : 'hover:bg-secondary/80'
+                ]"
+              >
+                Gemini (Cloud)
+              </button>
+            </div>
+          </div>
+
+          <div class="flex items-center gap-2 text-sm">
+            <CheckCircle2 class="w-4 h-4 text-green-500" />
+            <span>Current: <strong>{{ backendData?.backend }}</strong></span>
+            <span v-if="backendData?.model" class="text-muted-foreground">
+              ({{ backendData.model }})
+            </span>
+          </div>
+
+          <div v-if="setBackendMutation.data?.value?.message" class="flex items-center gap-2 text-sm text-yellow-500">
+            <AlertCircle class="w-4 h-4" />
+            {{ setBackendMutation.data?.value?.message }}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Persona Selection -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-semibold flex items-center gap-2">
+          <User class="w-5 h-5" />
+          Secretary Persona
+        </h2>
+      </div>
+
+      <div class="p-4">
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div
+            v-for="(persona, id) in personas"
+            :key="id"
+            @click="setPersonaMutation.mutate(id as string)"
+            :class="[
+              'p-4 rounded-lg border cursor-pointer transition-all',
+              currentPersonaData?.id === id
+                ? 'border-primary bg-primary/10'
+                : 'border-border hover:border-primary/50'
+            ]"
+          >
+            <div class="font-medium">{{ persona.name }}</div>
+            <div class="text-sm text-muted-foreground">{{ persona.full_name }}</div>
+            <button
+              @click.stop="loadPromptForEdit(id as string)"
+              class="mt-2 text-xs text-primary hover:underline"
+            >
+              Edit Prompt
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Generation Parameters -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border flex items-center justify-between">
+        <h2 class="text-lg font-semibold flex items-center gap-2">
+          <Settings2 class="w-5 h-5" />
+          Generation Parameters
+        </h2>
+        <button
+          @click="saveParams"
+          :disabled="setParamsMutation.isPending.value"
+          class="flex items-center gap-2 px-3 py-1.5 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          <Save class="w-4 h-4" />
+          Save
+        </button>
+      </div>
+
+      <div class="p-4 grid grid-cols-1 md:grid-cols-2 gap-6">
+        <!-- Temperature -->
+        <div>
+          <label class="flex items-center justify-between text-sm mb-2">
+            <span>Temperature</span>
+            <span class="text-muted-foreground">{{ localParams.temperature?.toFixed(2) }}</span>
+          </label>
+          <input
+            v-model.number="localParams.temperature"
+            type="range"
+            min="0"
+            max="2"
+            step="0.05"
+            class="w-full"
+          />
+          <p class="text-xs text-muted-foreground mt-1">Higher = more creative, lower = more focused</p>
+        </div>
+
+        <!-- Max Tokens -->
+        <div>
+          <label class="flex items-center justify-between text-sm mb-2">
+            <span>Max Tokens</span>
+            <span class="text-muted-foreground">{{ localParams.max_tokens }}</span>
+          </label>
+          <input
+            v-model.number="localParams.max_tokens"
+            type="range"
+            min="64"
+            max="2048"
+            step="64"
+            class="w-full"
+          />
+          <p class="text-xs text-muted-foreground mt-1">Maximum response length</p>
+        </div>
+
+        <!-- Top P -->
+        <div>
+          <label class="flex items-center justify-between text-sm mb-2">
+            <span>Top P</span>
+            <span class="text-muted-foreground">{{ localParams.top_p?.toFixed(2) }}</span>
+          </label>
+          <input
+            v-model.number="localParams.top_p"
+            type="range"
+            min="0.1"
+            max="1"
+            step="0.05"
+            class="w-full"
+          />
+          <p class="text-xs text-muted-foreground mt-1">Nucleus sampling threshold</p>
+        </div>
+
+        <!-- Repetition Penalty -->
+        <div>
+          <label class="flex items-center justify-between text-sm mb-2">
+            <span>Repetition Penalty</span>
+            <span class="text-muted-foreground">{{ localParams.repetition_penalty?.toFixed(2) }}</span>
+          </label>
+          <input
+            v-model.number="localParams.repetition_penalty"
+            type="range"
+            min="1"
+            max="2"
+            step="0.05"
+            class="w-full"
+          />
+          <p class="text-xs text-muted-foreground mt-1">Higher = less repetition</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Conversation History -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border flex items-center justify-between">
+        <h2 class="text-lg font-semibold">
+          Conversation History
+          <span v-if="historyData?.count" class="text-sm font-normal text-muted-foreground">
+            ({{ historyData.count }} messages)
+          </span>
+        </h2>
+        <div class="flex items-center gap-2">
+          <button
+            @click="refetchHistory"
+            class="p-2 rounded-lg bg-secondary hover:bg-secondary/80 transition-colors"
+          >
+            <RotateCw class="w-4 h-4" />
+          </button>
+          <button
+            @click="clearHistoryMutation.mutate()"
+            :disabled="clearHistoryMutation.isPending.value || !historyData?.count"
+            class="flex items-center gap-2 px-3 py-1.5 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 transition-colors"
+          >
+            <Trash2 class="w-4 h-4" />
+            Clear
+          </button>
+        </div>
+      </div>
+
+      <div class="max-h-64 overflow-auto p-4">
+        <div v-if="!historyData?.history?.length" class="text-muted-foreground text-center py-4">
+          No conversation history
+        </div>
+        <div v-else class="space-y-2">
+          <div
+            v-for="(msg, i) in historyData.history"
+            :key="i"
+            :class="[
+              'p-3 rounded-lg',
+              msg.role === 'user' ? 'bg-secondary' : 'bg-primary/10 ml-4'
+            ]"
+          >
+            <div class="text-xs text-muted-foreground mb-1 capitalize">{{ msg.role }}</div>
+            <div class="text-sm">{{ msg.content }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Prompt Editor Modal -->
+    <div
+      v-if="editingPrompt"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      @click.self="editingPrompt = false"
+    >
+      <div class="bg-card border border-border rounded-lg w-full max-w-2xl p-6">
+        <h3 class="text-lg font-semibold mb-4">
+          Edit System Prompt: {{ personas[selectedPersonaForPrompt]?.name }}
+        </h3>
+
+        <textarea
+          v-model="promptText"
+          rows="15"
+          class="w-full p-3 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary resize-none font-mono text-sm"
+        />
+
+        <div class="flex justify-end gap-2 mt-4">
+          <button
+            @click="editingPrompt = false"
+            class="px-4 py-2 bg-secondary rounded-lg hover:bg-secondary/80 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            @click="savePromptMutation.mutate({ persona: selectedPersonaForPrompt, prompt: promptText })"
+            :disabled="savePromptMutation.isPending.value"
+            class="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          >
+            Save Prompt
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/admin/src/views/MonitoringView.vue
+++ b/admin/src/views/MonitoringView.vue
@@ -1,0 +1,392 @@
+<script setup lang="ts">
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
+import { monitorApi, type GpuInfo } from '@/api'
+import {
+  Activity,
+  Cpu,
+  HardDrive,
+  Thermometer,
+  RefreshCw,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Trash2
+} from 'lucide-vue-next'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+
+const queryClient = useQueryClient()
+
+// State
+const gpuHistory = ref<{ time: string; allocated: number }[]>([])
+let gpuStreamHandle: { close: () => void } | null = null
+
+// Queries
+const { data: gpuData, isLoading: gpuLoading, refetch: refetchGpu } = useQuery({
+  queryKey: ['gpu-stats'],
+  queryFn: () => monitorApi.getGpuStats(),
+  refetchInterval: 5000,
+})
+
+const { data: healthData, isLoading: healthLoading, refetch: refetchHealth } = useQuery({
+  queryKey: ['health'],
+  queryFn: () => monitorApi.getHealth(),
+  refetchInterval: 10000,
+})
+
+const { data: metricsData, refetch: refetchMetrics } = useQuery({
+  queryKey: ['metrics'],
+  queryFn: () => monitorApi.getMetrics(),
+  refetchInterval: 5000,
+})
+
+const { data: errorsData, refetch: refetchErrors } = useQuery({
+  queryKey: ['errors'],
+  queryFn: () => monitorApi.getErrors(),
+})
+
+// Mutations
+const resetMetricsMutation = useMutation({
+  mutationFn: () => monitorApi.resetMetrics(),
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: ['metrics'] })
+  },
+})
+
+// Computed
+const gpu = computed(() => gpuData.value?.gpus?.[0])
+
+const gpuMemoryPercent = computed(() => {
+  if (!gpu.value) return 0
+  return Math.round((gpu.value.allocated_gb / gpu.value.total_memory_gb) * 100)
+})
+
+const systemMemoryPercent = computed(() => metricsData.value?.system?.memory_percent || 0)
+
+const cpuPercent = computed(() => metricsData.value?.system?.cpu_percent || 0)
+
+const healthComponents = computed(() => healthData.value?.components || {})
+
+const errors = computed(() => {
+  if (!errorsData.value?.errors) return []
+  return Object.entries(errorsData.value.errors).map(([service, error]) => ({
+    service,
+    error,
+  }))
+})
+
+// GPU streaming
+function startGpuStream() {
+  gpuStreamHandle = monitorApi.streamGpuStats((data) => {
+    if (data.gpus?.[0]) {
+      const now = new Date().toLocaleTimeString()
+      gpuHistory.value.push({
+        time: now,
+        allocated: data.gpus[0].allocated_gb,
+      })
+      // Keep last 60 entries (5 minutes at 5s interval)
+      if (gpuHistory.value.length > 60) {
+        gpuHistory.value = gpuHistory.value.slice(-60)
+      }
+    }
+  })
+}
+
+function stopGpuStream() {
+  if (gpuStreamHandle) {
+    gpuStreamHandle.close()
+    gpuStreamHandle = null
+  }
+}
+
+function refreshAll() {
+  refetchGpu()
+  refetchHealth()
+  refetchMetrics()
+  refetchErrors()
+}
+
+function getStatusColor(status: string) {
+  switch (status) {
+    case 'healthy':
+      return 'text-green-500'
+    case 'unhealthy':
+      return 'text-red-500'
+    case 'unavailable':
+    case 'stopped':
+      return 'text-yellow-500'
+    default:
+      return 'text-muted-foreground'
+  }
+}
+
+function getStatusIcon(status: string) {
+  switch (status) {
+    case 'healthy':
+      return CheckCircle2
+    case 'unhealthy':
+      return XCircle
+    default:
+      return AlertTriangle
+  }
+}
+
+onMounted(() => {
+  startGpuStream()
+})
+
+onUnmounted(() => {
+  stopGpuStream()
+})
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Toolbar -->
+    <div class="flex items-center gap-4">
+      <button
+        @click="refreshAll"
+        class="flex items-center gap-2 px-4 py-2 bg-secondary rounded-lg hover:bg-secondary/80 transition-colors"
+      >
+        <RefreshCw class="w-4 h-4" />
+        Refresh All
+      </button>
+      <button
+        @click="resetMetricsMutation.mutate()"
+        :disabled="resetMetricsMutation.isPending.value"
+        class="flex items-center gap-2 px-4 py-2 bg-secondary rounded-lg hover:bg-secondary/80 disabled:opacity-50 transition-colors"
+      >
+        <Trash2 class="w-4 h-4" />
+        Reset Metrics
+      </button>
+    </div>
+
+    <!-- System Stats Grid -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <!-- CPU -->
+      <div class="bg-card rounded-lg border border-border p-4">
+        <div class="flex items-center gap-3 mb-3">
+          <div class="p-2 rounded-lg bg-blue-500/20">
+            <Cpu class="w-5 h-5 text-blue-500" />
+          </div>
+          <div>
+            <p class="text-sm text-muted-foreground">CPU Usage</p>
+            <p class="text-2xl font-bold">{{ cpuPercent.toFixed(1) }}%</p>
+          </div>
+        </div>
+        <div class="h-2 bg-secondary rounded-full overflow-hidden">
+          <div
+            class="h-full bg-blue-500 transition-all"
+            :style="{ width: `${cpuPercent}%` }"
+          />
+        </div>
+      </div>
+
+      <!-- System Memory -->
+      <div class="bg-card rounded-lg border border-border p-4">
+        <div class="flex items-center gap-3 mb-3">
+          <div class="p-2 rounded-lg bg-orange-500/20">
+            <HardDrive class="w-5 h-5 text-orange-500" />
+          </div>
+          <div>
+            <p class="text-sm text-muted-foreground">System Memory</p>
+            <p class="text-2xl font-bold">{{ systemMemoryPercent.toFixed(1) }}%</p>
+          </div>
+        </div>
+        <div class="h-2 bg-secondary rounded-full overflow-hidden">
+          <div
+            class="h-full bg-orange-500 transition-all"
+            :style="{ width: `${systemMemoryPercent}%` }"
+          />
+        </div>
+        <p class="text-xs text-muted-foreground mt-2">
+          {{ metricsData?.system?.memory_used_gb?.toFixed(1) }} / {{ metricsData?.system?.memory_total_gb?.toFixed(1) }} GB
+        </p>
+      </div>
+
+      <!-- GPU Memory -->
+      <div class="bg-card rounded-lg border border-border p-4">
+        <div class="flex items-center gap-3 mb-3">
+          <div class="p-2 rounded-lg bg-purple-500/20">
+            <Activity class="w-5 h-5 text-purple-500" />
+          </div>
+          <div>
+            <p class="text-sm text-muted-foreground">GPU Memory</p>
+            <p class="text-2xl font-bold">{{ gpuMemoryPercent }}%</p>
+          </div>
+        </div>
+        <div class="h-2 bg-secondary rounded-full overflow-hidden">
+          <div
+            class="h-full bg-purple-500 transition-all"
+            :style="{ width: `${gpuMemoryPercent}%` }"
+          />
+        </div>
+        <p v-if="gpu" class="text-xs text-muted-foreground mt-2">
+          {{ gpu.allocated_gb?.toFixed(1) }} / {{ gpu.total_memory_gb?.toFixed(1) }} GB
+        </p>
+      </div>
+    </div>
+
+    <!-- GPU Details -->
+    <div v-if="gpu" class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-semibold">GPU Details</h2>
+      </div>
+      <div class="p-4 grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div>
+          <p class="text-sm text-muted-foreground">Name</p>
+          <p class="font-medium">{{ gpu.name }}</p>
+        </div>
+        <div>
+          <p class="text-sm text-muted-foreground">Compute Capability</p>
+          <p class="font-medium">{{ gpu.compute_capability }}</p>
+        </div>
+        <div>
+          <p class="text-sm text-muted-foreground">Utilization</p>
+          <p class="font-medium">{{ gpu.utilization_percent ?? 'N/A' }}%</p>
+        </div>
+        <div class="flex items-center gap-2">
+          <Thermometer class="w-4 h-4 text-muted-foreground" />
+          <div>
+            <p class="text-sm text-muted-foreground">Temperature</p>
+            <p :class="[
+              'font-medium',
+              (gpu.temperature_c ?? 0) > 80 ? 'text-red-500' :
+              (gpu.temperature_c ?? 0) > 60 ? 'text-yellow-500' : ''
+            ]">
+              {{ gpu.temperature_c ?? 'N/A' }}°C
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Health Status -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border flex items-center justify-between">
+        <h2 class="text-lg font-semibold">Health Status</h2>
+        <span :class="[
+          'px-3 py-1 rounded-full text-sm font-medium',
+          healthData?.overall === 'healthy' ? 'bg-green-500/20 text-green-500' : 'bg-yellow-500/20 text-yellow-500'
+        ]">
+          {{ healthData?.overall || 'unknown' }}
+        </span>
+      </div>
+
+      <div v-if="healthLoading" class="p-8 text-center text-muted-foreground">
+        Loading...
+      </div>
+
+      <div v-else class="divide-y divide-border">
+        <div
+          v-for="(component, name) in healthComponents"
+          :key="name"
+          class="flex items-center justify-between p-4"
+        >
+          <div class="flex items-center gap-3">
+            <component
+              :is="getStatusIcon(component.status)"
+              :class="['w-5 h-5', getStatusColor(component.status)]"
+            />
+            <div>
+              <p class="font-medium capitalize">{{ (name as string).replace(/_/g, ' ') }}</p>
+              <p v-if="component.backend" class="text-sm text-muted-foreground">
+                Backend: {{ component.backend }}
+              </p>
+              <p v-if="component.pid" class="text-sm text-muted-foreground">
+                PID: {{ component.pid }}
+              </p>
+            </div>
+          </div>
+          <span :class="[
+            'text-sm px-2 py-1 rounded capitalize',
+            component.status === 'healthy' ? 'bg-green-500/20 text-green-500' :
+            component.status === 'unhealthy' ? 'bg-red-500/20 text-red-500' :
+            'bg-yellow-500/20 text-yellow-500'
+          ]">
+            {{ component.status }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- TTS Cache Stats -->
+    <div v-if="metricsData?.streaming_tts" class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-semibold">TTS Streaming Cache</h2>
+      </div>
+      <div class="p-4 grid grid-cols-3 gap-4">
+        <div>
+          <p class="text-sm text-muted-foreground">Cache Size</p>
+          <p class="text-xl font-bold">{{ metricsData.streaming_tts.cache_size }}</p>
+        </div>
+        <div>
+          <p class="text-sm text-muted-foreground">Max Size</p>
+          <p class="text-xl font-bold">{{ metricsData.streaming_tts.max_cache_size }}</p>
+        </div>
+        <div>
+          <p class="text-sm text-muted-foreground">Active Sessions</p>
+          <p class="text-xl font-bold">{{ metricsData.streaming_tts.active_sessions }}</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- LLM Stats -->
+    <div v-if="metricsData?.llm" class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-semibold">LLM Stats</h2>
+      </div>
+      <div class="p-4 grid grid-cols-2 gap-4">
+        <div>
+          <p class="text-sm text-muted-foreground">History Length</p>
+          <p class="text-xl font-bold">{{ metricsData.llm.history_length }} messages</p>
+        </div>
+        <div>
+          <p class="text-sm text-muted-foreground">FAQ Entries</p>
+          <p class="text-xl font-bold">{{ metricsData.llm.faq_count }}</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Errors -->
+    <div v-if="errors.length" class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-semibold text-red-500">Recent Errors</h2>
+      </div>
+      <div class="divide-y divide-border">
+        <div
+          v-for="error in errors"
+          :key="error.service"
+          class="p-4"
+        >
+          <p class="font-medium text-red-400">{{ error.service }}</p>
+          <p class="text-sm text-muted-foreground mt-1">{{ error.error }}</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- GPU Memory History Chart Placeholder -->
+    <div v-if="gpuHistory.length > 5" class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-semibold">GPU Memory History</h2>
+      </div>
+      <div class="p-4">
+        <div class="h-32 flex items-end gap-1">
+          <div
+            v-for="(entry, i) in gpuHistory.slice(-30)"
+            :key="i"
+            class="flex-1 bg-purple-500 rounded-t transition-all"
+            :style="{
+              height: `${(entry.allocated / (gpu?.total_memory_gb || 12)) * 100}%`,
+              minHeight: '4px'
+            }"
+            :title="`${entry.time}: ${entry.allocated.toFixed(2)} GB`"
+          />
+        </div>
+        <div class="flex justify-between text-xs text-muted-foreground mt-2">
+          <span>{{ gpuHistory[0]?.time }}</span>
+          <span>{{ gpuHistory[gpuHistory.length - 1]?.time }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/admin/src/views/ServicesView.vue
+++ b/admin/src/views/ServicesView.vue
@@ -1,0 +1,324 @@
+<script setup lang="ts">
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
+import { servicesApi, logsApi, type ServiceStatus } from '@/api'
+import {
+  Play,
+  Square,
+  RotateCw,
+  RefreshCw,
+  Terminal,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  Search,
+  X
+} from 'lucide-vue-next'
+import { ref, computed, watch } from 'vue'
+
+const queryClient = useQueryClient()
+
+// State
+const selectedLog = ref<string | null>(null)
+const logSearch = ref('')
+const logLines = ref<string[]>([])
+const logLoading = ref(false)
+
+// Queries
+const { data: servicesData, isLoading } = useQuery({
+  queryKey: ['services-status'],
+  queryFn: () => servicesApi.getStatus(),
+  refetchInterval: 5000,
+})
+
+const { data: logsData } = useQuery({
+  queryKey: ['logs-list'],
+  queryFn: () => logsApi.list(),
+})
+
+// Mutations
+const startMutation = useMutation({
+  mutationFn: (name: string) => servicesApi.startService(name),
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['services-status'] }),
+})
+
+const stopMutation = useMutation({
+  mutationFn: (name: string) => servicesApi.stopService(name),
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['services-status'] }),
+})
+
+const restartMutation = useMutation({
+  mutationFn: (name: string) => servicesApi.restartService(name),
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['services-status'] }),
+})
+
+const startAllMutation = useMutation({
+  mutationFn: () => servicesApi.startAll(),
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['services-status'] }),
+})
+
+const stopAllMutation = useMutation({
+  mutationFn: () => servicesApi.stopAll(),
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['services-status'] }),
+})
+
+// Computed
+const services = computed(() => {
+  if (!servicesData.value) return []
+  return Object.entries(servicesData.value.services).map(([key, value]) => ({
+    id: key,
+    ...value,
+  }))
+})
+
+const externalServices = computed(() =>
+  services.value.filter(s => !s.internal)
+)
+
+const internalServices = computed(() =>
+  services.value.filter(s => s.internal)
+)
+
+// Methods
+async function loadLog(logfile: string) {
+  selectedLog.value = logfile
+  logLoading.value = true
+  try {
+    const response = await logsApi.read(logfile, 200, 0, logSearch.value || undefined)
+    logLines.value = response.lines
+  } catch (e) {
+    console.error('Failed to load log:', e)
+    logLines.value = ['Error loading log']
+  } finally {
+    logLoading.value = false
+  }
+}
+
+async function refreshLog() {
+  if (selectedLog.value) {
+    await loadLog(selectedLog.value)
+  }
+}
+
+function closeLog() {
+  selectedLog.value = null
+  logLines.value = []
+}
+
+function getLogLineClass(line: string): string {
+  const lower = line.toLowerCase()
+  if (lower.includes('error') || lower.includes('❌')) return 'log-line error'
+  if (lower.includes('warning') || lower.includes('⚠️')) return 'log-line warning'
+  if (lower.includes('info') || lower.includes('✅')) return 'log-line info'
+  return 'log-line'
+}
+
+// Watch search changes
+watch(logSearch, async () => {
+  if (selectedLog.value) {
+    await loadLog(selectedLog.value)
+  }
+})
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Toolbar -->
+    <div class="flex items-center gap-4">
+      <button
+        @click="startAllMutation.mutate()"
+        :disabled="startAllMutation.isPending.value"
+        class="flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 transition-colors"
+      >
+        <Play class="w-4 h-4" />
+        Start All
+      </button>
+      <button
+        @click="stopAllMutation.mutate()"
+        :disabled="stopAllMutation.isPending.value"
+        class="flex items-center gap-2 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 transition-colors"
+      >
+        <Square class="w-4 h-4" />
+        Stop All
+      </button>
+      <button
+        @click="queryClient.invalidateQueries({ queryKey: ['services-status'] })"
+        class="flex items-center gap-2 px-4 py-2 bg-secondary rounded-lg hover:bg-secondary/80 transition-colors"
+      >
+        <RefreshCw class="w-4 h-4" />
+        Refresh
+      </button>
+    </div>
+
+    <!-- External Services -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-semibold">External Services</h2>
+        <p class="text-sm text-muted-foreground">Managed by ServiceManager (can be started/stopped)</p>
+      </div>
+
+      <div class="divide-y divide-border">
+        <div
+          v-for="service in externalServices"
+          :key="service.id"
+          class="flex items-center justify-between p-4"
+        >
+          <div class="flex items-center gap-4">
+            <div :class="[
+              'p-2 rounded-lg',
+              service.is_running ? 'bg-green-500/20' : 'bg-red-500/20'
+            ]">
+              <CheckCircle2 v-if="service.is_running" class="w-5 h-5 text-green-500" />
+              <XCircle v-else class="w-5 h-5 text-red-500" />
+            </div>
+            <div>
+              <p class="font-medium">{{ service.display_name }}</p>
+              <p class="text-sm text-muted-foreground">
+                <template v-if="service.is_running">
+                  PID: {{ service.pid }} | Memory: {{ service.memory_mb?.toFixed(0) }} MB
+                  <span v-if="service.port"> | Port: {{ service.port }}</span>
+                </template>
+                <template v-else>
+                  Not running
+                  <span v-if="service.last_error" class="text-red-400"> - {{ service.last_error }}</span>
+                </template>
+              </p>
+            </div>
+          </div>
+
+          <div class="flex items-center gap-2">
+            <button
+              v-if="service.log_file"
+              @click="loadLog(service.id)"
+              class="p-2 rounded-lg bg-secondary hover:bg-secondary/80 transition-colors"
+              title="View Logs"
+            >
+              <Terminal class="w-4 h-4" />
+            </button>
+            <button
+              v-if="!service.is_running"
+              @click="startMutation.mutate(service.id)"
+              :disabled="startMutation.isPending.value"
+              class="p-2 rounded-lg bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 transition-colors"
+              title="Start"
+            >
+              <Loader2 v-if="startMutation.isPending.value" class="w-4 h-4 animate-spin" />
+              <Play v-else class="w-4 h-4" />
+            </button>
+            <button
+              v-if="service.is_running"
+              @click="stopMutation.mutate(service.id)"
+              :disabled="stopMutation.isPending.value"
+              class="p-2 rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
+              title="Stop"
+            >
+              <Loader2 v-if="stopMutation.isPending.value" class="w-4 h-4 animate-spin" />
+              <Square v-else class="w-4 h-4" />
+            </button>
+            <button
+              @click="restartMutation.mutate(service.id)"
+              :disabled="restartMutation.isPending.value"
+              class="p-2 rounded-lg bg-secondary hover:bg-secondary/80 disabled:opacity-50 transition-colors"
+              title="Restart"
+            >
+              <Loader2 v-if="restartMutation.isPending.value" class="w-4 h-4 animate-spin" />
+              <RotateCw v-else class="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Internal Services -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-semibold">Internal Services</h2>
+        <p class="text-sm text-muted-foreground">Managed by Orchestrator (restart orchestrator to change)</p>
+      </div>
+
+      <div class="divide-y divide-border">
+        <div
+          v-for="service in internalServices"
+          :key="service.id"
+          class="flex items-center justify-between p-4"
+        >
+          <div class="flex items-center gap-4">
+            <div :class="[
+              'p-2 rounded-lg',
+              service.is_running ? 'bg-green-500/20' : 'bg-gray-500/20'
+            ]">
+              <CheckCircle2 v-if="service.is_running" class="w-5 h-5 text-green-500" />
+              <XCircle v-else class="w-5 h-5 text-gray-500" />
+            </div>
+            <div>
+              <p class="font-medium">{{ service.display_name }}</p>
+              <p class="text-sm text-muted-foreground">
+                <span v-if="service.gpu_required" class="text-purple-400">GPU Required</span>
+                <span v-else-if="service.cpu_only" class="text-blue-400">CPU Only</span>
+              </p>
+            </div>
+          </div>
+          <span :class="[
+            'text-sm px-2 py-1 rounded',
+            service.is_running ? 'bg-green-500/20 text-green-400' : 'bg-gray-500/20 text-gray-400'
+          ]">
+            {{ service.is_running ? 'Loaded' : 'Not loaded' }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Log Viewer Modal -->
+    <div
+      v-if="selectedLog"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      @click.self="closeLog"
+    >
+      <div class="bg-card border border-border rounded-lg w-full max-w-4xl max-h-[80vh] flex flex-col">
+        <div class="flex items-center justify-between p-4 border-b border-border">
+          <h3 class="text-lg font-semibold">Logs: {{ selectedLog }}</h3>
+          <div class="flex items-center gap-2">
+            <div class="relative">
+              <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+              <input
+                v-model="logSearch"
+                type="text"
+                placeholder="Search..."
+                class="pl-9 pr-3 py-1.5 bg-secondary rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+            <button
+              @click="refreshLog"
+              class="p-2 rounded-lg bg-secondary hover:bg-secondary/80 transition-colors"
+            >
+              <RefreshCw class="w-4 h-4" />
+            </button>
+            <button
+              @click="closeLog"
+              class="p-2 rounded-lg bg-secondary hover:bg-secondary/80 transition-colors"
+            >
+              <X class="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+
+        <div class="flex-1 overflow-auto p-4 log-viewer bg-background">
+          <div v-if="logLoading" class="text-center text-muted-foreground">
+            Loading...
+          </div>
+          <div v-else-if="logLines.length === 0" class="text-center text-muted-foreground">
+            No log entries
+          </div>
+          <div v-else>
+            <div
+              v-for="(line, i) in logLines"
+              :key="i"
+              :class="getLogLineClass(line)"
+            >
+              {{ line }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/admin/src/views/TtsView.vue
+++ b/admin/src/views/TtsView.vue
@@ -1,0 +1,528 @@
+<script setup lang="ts">
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
+import { ttsApi, type Voice, type XttsParams } from '@/api'
+import {
+  Mic,
+  Play,
+  Volume2,
+  Settings2,
+  Plus,
+  Trash2,
+  Save,
+  CheckCircle2
+} from 'lucide-vue-next'
+import { ref, computed, watch } from 'vue'
+
+const queryClient = useQueryClient()
+
+// State
+const testText = ref('Здравствуйте! Это тестовое сообщение для проверки голоса.')
+const testAudioUrl = ref<string | null>(null)
+const testLoading = ref(false)
+const showCreatePreset = ref(false)
+const newPresetName = ref('')
+
+// Local params state
+const localParams = ref<Partial<XttsParams>>({})
+
+// Queries
+const { data: voicesData, isLoading: voicesLoading } = useQuery({
+  queryKey: ['tts-voices'],
+  queryFn: () => ttsApi.getVoices(),
+})
+
+const { data: xttsParams } = useQuery({
+  queryKey: ['tts-xtts-params'],
+  queryFn: () => ttsApi.getXttsParams(),
+})
+
+const { data: presetsData } = useQuery({
+  queryKey: ['tts-presets'],
+  queryFn: () => ttsApi.getBuiltinPresets(),
+})
+
+const { data: customPresetsData, refetch: refetchCustomPresets } = useQuery({
+  queryKey: ['tts-custom-presets'],
+  queryFn: () => ttsApi.getCustomPresets(),
+})
+
+const { data: cacheData, refetch: refetchCache } = useQuery({
+  queryKey: ['tts-cache'],
+  queryFn: () => ttsApi.getCacheStats(),
+})
+
+// Watch xtts params
+watch(xttsParams, (data) => {
+  if (data?.current_params) {
+    localParams.value = { ...data.current_params }
+  }
+}, { immediate: true })
+
+// Mutations
+const setVoiceMutation = useMutation({
+  mutationFn: (voice: string) => ttsApi.setVoice(voice),
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['tts-voices'] }),
+})
+
+const setPresetMutation = useMutation({
+  mutationFn: (preset: string) => ttsApi.setPreset(preset),
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: ['tts-presets'] })
+    queryClient.invalidateQueries({ queryKey: ['tts-xtts-params'] })
+  },
+})
+
+const saveParamsMutation = useMutation({
+  mutationFn: (params: Partial<XttsParams>) => ttsApi.setXttsParams(params),
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['tts-xtts-params'] }),
+})
+
+const createPresetMutation = useMutation({
+  mutationFn: ({ name, params }: { name: string; params: Partial<XttsParams> }) =>
+    ttsApi.createCustomPreset(name, params),
+  onSuccess: () => {
+    refetchCustomPresets()
+    showCreatePreset.value = false
+    newPresetName.value = ''
+  },
+})
+
+const deletePresetMutation = useMutation({
+  mutationFn: (name: string) => ttsApi.deleteCustomPreset(name),
+  onSuccess: () => refetchCustomPresets(),
+})
+
+const clearCacheMutation = useMutation({
+  mutationFn: () => ttsApi.clearCache(),
+  onSuccess: () => refetchCache(),
+})
+
+// Computed
+const voices = computed(() => voicesData.value?.voices || [])
+const currentVoice = computed(() => voicesData.value?.current?.voice || '')
+const currentEngine = computed(() => voicesData.value?.current?.engine || '')
+
+const xttsVoices = computed(() => voices.value.filter(v => v.engine === 'xtts'))
+const piperVoices = computed(() => voices.value.filter(v => v.engine === 'piper'))
+const openvoiceVoices = computed(() => voices.value.filter(v => v.engine === 'openvoice'))
+
+const presets = computed(() => presetsData.value?.presets || {})
+const customPresets = computed(() => customPresetsData.value?.presets || {})
+const currentPreset = computed(() => presetsData.value?.current || 'natural')
+
+// Methods
+async function testVoice(voiceId: string) {
+  testLoading.value = true
+  try {
+    const blob = await ttsApi.testVoice(voiceId)
+    if (testAudioUrl.value) {
+      URL.revokeObjectURL(testAudioUrl.value)
+    }
+    testAudioUrl.value = URL.createObjectURL(blob)
+  } catch (e) {
+    console.error('Test failed:', e)
+  } finally {
+    testLoading.value = false
+  }
+}
+
+async function synthesizeTest() {
+  testLoading.value = true
+  try {
+    const result = await ttsApi.testSynthesize(testText.value, currentPreset.value)
+    console.log('Synthesis result:', result)
+  } catch (e) {
+    console.error('Synthesis failed:', e)
+  } finally {
+    testLoading.value = false
+  }
+}
+
+function saveParams() {
+  saveParamsMutation.mutate(localParams.value)
+}
+
+function createPreset() {
+  if (newPresetName.value) {
+    createPresetMutation.mutate({
+      name: newPresetName.value,
+      params: localParams.value,
+    })
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Voice Selection -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border">
+        <h2 class="text-lg font-semibold flex items-center gap-2">
+          <Mic class="w-5 h-5" />
+          Voice Selection
+        </h2>
+        <p class="text-sm text-muted-foreground">
+          Current: <strong>{{ currentVoice }}</strong> ({{ currentEngine }})
+        </p>
+      </div>
+
+      <div class="p-4 space-y-6">
+        <!-- XTTS Voices -->
+        <div v-if="xttsVoices.length">
+          <h3 class="text-sm font-medium text-muted-foreground mb-3">XTTS v2 (GPU CC >= 7.0)</h3>
+          <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <div
+              v-for="voice in xttsVoices"
+              :key="voice.id"
+              :class="[
+                'p-4 rounded-lg border cursor-pointer transition-all',
+                currentVoice === voice.id
+                  ? 'border-primary bg-primary/10'
+                  : 'border-border hover:border-primary/50'
+              ]"
+              @click="setVoiceMutation.mutate(voice.id)"
+            >
+              <div class="flex items-center justify-between mb-2">
+                <span class="font-medium">{{ voice.name }}</span>
+                <CheckCircle2 v-if="currentVoice === voice.id" class="w-4 h-4 text-primary" />
+              </div>
+              <p class="text-xs text-muted-foreground mb-2">{{ voice.description }}</p>
+              <div class="flex items-center justify-between">
+                <span v-if="voice.samples_count" class="text-xs text-muted-foreground">
+                  {{ voice.samples_count }} samples
+                </span>
+                <button
+                  @click.stop="testVoice(voice.id)"
+                  :disabled="testLoading"
+                  class="p-1.5 rounded bg-secondary hover:bg-secondary/80 transition-colors"
+                >
+                  <Play class="w-3 h-3" />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- OpenVoice Voices -->
+        <div v-if="openvoiceVoices.length">
+          <h3 class="text-sm font-medium text-muted-foreground mb-3">OpenVoice v2 (GPU CC >= 6.1)</h3>
+          <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <div
+              v-for="voice in openvoiceVoices"
+              :key="voice.id"
+              :class="[
+                'p-4 rounded-lg border cursor-pointer transition-all',
+                currentVoice === voice.id
+                  ? 'border-primary bg-primary/10'
+                  : 'border-border hover:border-primary/50'
+              ]"
+              @click="setVoiceMutation.mutate(voice.id)"
+            >
+              <div class="flex items-center justify-between mb-2">
+                <span class="font-medium">{{ voice.name }}</span>
+                <CheckCircle2 v-if="currentVoice === voice.id" class="w-4 h-4 text-primary" />
+              </div>
+              <p class="text-xs text-muted-foreground">{{ voice.description }}</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Piper Voices -->
+        <div v-if="piperVoices.length">
+          <h3 class="text-sm font-medium text-muted-foreground mb-3">Piper (CPU)</h3>
+          <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <div
+              v-for="voice in piperVoices"
+              :key="voice.id"
+              :class="[
+                'p-4 rounded-lg border cursor-pointer transition-all',
+                voice.available
+                  ? currentVoice === voice.id
+                    ? 'border-primary bg-primary/10'
+                    : 'border-border hover:border-primary/50'
+                  : 'border-border opacity-50 cursor-not-allowed'
+              ]"
+              @click="voice.available && setVoiceMutation.mutate(voice.id)"
+            >
+              <div class="flex items-center justify-between mb-2">
+                <span class="font-medium">{{ voice.name }}</span>
+                <CheckCircle2 v-if="currentVoice === voice.id" class="w-4 h-4 text-primary" />
+              </div>
+              <p class="text-xs text-muted-foreground">{{ voice.description }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Audio Test Player -->
+    <div v-if="testAudioUrl" class="bg-card rounded-lg border border-border p-4">
+      <div class="flex items-center gap-4">
+        <Volume2 class="w-5 h-5 text-muted-foreground" />
+        <audio controls :src="testAudioUrl" class="flex-1" />
+      </div>
+    </div>
+
+    <!-- XTTS Parameters -->
+    <div v-if="currentEngine === 'xtts'" class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border flex items-center justify-between">
+        <h2 class="text-lg font-semibold flex items-center gap-2">
+          <Settings2 class="w-5 h-5" />
+          XTTS Parameters
+        </h2>
+        <button
+          @click="saveParams"
+          :disabled="saveParamsMutation.isPending.value"
+          class="flex items-center gap-2 px-3 py-1.5 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          <Save class="w-4 h-4" />
+          Apply
+        </button>
+      </div>
+
+      <div class="p-4">
+        <!-- Presets -->
+        <div class="mb-6">
+          <h3 class="text-sm font-medium mb-3">Presets</h3>
+          <div class="flex flex-wrap gap-2">
+            <button
+              v-for="(preset, name) in presets"
+              :key="name"
+              @click="setPresetMutation.mutate(name as string)"
+              :class="[
+                'px-3 py-1.5 rounded-lg text-sm transition-colors',
+                currentPreset === name
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-secondary hover:bg-secondary/80'
+              ]"
+            >
+              {{ preset.display_name }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Parameters Grid -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <!-- Temperature -->
+          <div>
+            <label class="flex items-center justify-between text-sm mb-2">
+              <span>Temperature</span>
+              <span class="text-muted-foreground">{{ localParams.temperature?.toFixed(2) }}</span>
+            </label>
+            <input
+              v-model.number="localParams.temperature"
+              type="range"
+              min="0.1"
+              max="1"
+              step="0.05"
+              class="w-full"
+            />
+          </div>
+
+          <!-- Speed -->
+          <div>
+            <label class="flex items-center justify-between text-sm mb-2">
+              <span>Speed</span>
+              <span class="text-muted-foreground">{{ localParams.speed?.toFixed(2) }}</span>
+            </label>
+            <input
+              v-model.number="localParams.speed"
+              type="range"
+              min="0.5"
+              max="2"
+              step="0.05"
+              class="w-full"
+            />
+          </div>
+
+          <!-- Top K -->
+          <div>
+            <label class="flex items-center justify-between text-sm mb-2">
+              <span>Top K</span>
+              <span class="text-muted-foreground">{{ localParams.top_k }}</span>
+            </label>
+            <input
+              v-model.number="localParams.top_k"
+              type="range"
+              min="1"
+              max="100"
+              step="1"
+              class="w-full"
+            />
+          </div>
+
+          <!-- Top P -->
+          <div>
+            <label class="flex items-center justify-between text-sm mb-2">
+              <span>Top P</span>
+              <span class="text-muted-foreground">{{ localParams.top_p?.toFixed(2) }}</span>
+            </label>
+            <input
+              v-model.number="localParams.top_p"
+              type="range"
+              min="0.1"
+              max="1"
+              step="0.05"
+              class="w-full"
+            />
+          </div>
+
+          <!-- Repetition Penalty -->
+          <div>
+            <label class="flex items-center justify-between text-sm mb-2">
+              <span>Repetition Penalty</span>
+              <span class="text-muted-foreground">{{ localParams.repetition_penalty?.toFixed(1) }}</span>
+            </label>
+            <input
+              v-model.number="localParams.repetition_penalty"
+              type="range"
+              min="1"
+              max="10"
+              step="0.5"
+              class="w-full"
+            />
+          </div>
+
+          <!-- GPT Cond Length -->
+          <div>
+            <label class="flex items-center justify-between text-sm mb-2">
+              <span>GPT Cond Length</span>
+              <span class="text-muted-foreground">{{ localParams.gpt_cond_len }}s</span>
+            </label>
+            <input
+              v-model.number="localParams.gpt_cond_len"
+              type="range"
+              min="6"
+              max="30"
+              step="1"
+              class="w-full"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Custom Presets -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border flex items-center justify-between">
+        <h2 class="text-lg font-semibold">Custom Presets</h2>
+        <button
+          @click="showCreatePreset = true"
+          class="flex items-center gap-2 px-3 py-1.5 bg-secondary rounded-lg hover:bg-secondary/80 transition-colors"
+        >
+          <Plus class="w-4 h-4" />
+          Create
+        </button>
+      </div>
+
+      <div class="p-4">
+        <div v-if="!Object.keys(customPresets).length" class="text-center text-muted-foreground py-4">
+          No custom presets yet
+        </div>
+        <div v-else class="space-y-2">
+          <div
+            v-for="(params, name) in customPresets"
+            :key="name"
+            class="flex items-center justify-between p-3 bg-secondary rounded-lg"
+          >
+            <div>
+              <span class="font-medium">{{ name }}</span>
+              <span class="text-xs text-muted-foreground ml-2">
+                temp={{ (params as any).temperature }}, speed={{ (params as any).speed }}
+              </span>
+            </div>
+            <button
+              @click="deletePresetMutation.mutate(name as string)"
+              class="p-1.5 text-red-500 hover:bg-red-500/20 rounded transition-colors"
+            >
+              <Trash2 class="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Cache Stats -->
+    <div class="bg-card rounded-lg border border-border">
+      <div class="p-4 border-b border-border flex items-center justify-between">
+        <h2 class="text-lg font-semibold">TTS Cache</h2>
+        <button
+          @click="clearCacheMutation.mutate()"
+          :disabled="clearCacheMutation.isPending.value"
+          class="flex items-center gap-2 px-3 py-1.5 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 transition-colors"
+        >
+          <Trash2 class="w-4 h-4" />
+          Clear
+        </button>
+      </div>
+      <div class="p-4 grid grid-cols-2 gap-4">
+        <div>
+          <p class="text-sm text-muted-foreground">Cached Items</p>
+          <p class="text-2xl font-bold">{{ cacheData?.cache_size || 0 }}</p>
+        </div>
+        <div>
+          <p class="text-sm text-muted-foreground">Active Sessions</p>
+          <p class="text-2xl font-bold">{{ cacheData?.active_sessions || 0 }}</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Test Synthesis -->
+    <div class="bg-card rounded-lg border border-border p-4">
+      <h2 class="text-lg font-semibold mb-4">Test Synthesis</h2>
+      <div class="space-y-4">
+        <textarea
+          v-model="testText"
+          rows="3"
+          placeholder="Enter text to synthesize..."
+          class="w-full p-3 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary resize-none"
+        />
+        <button
+          @click="synthesizeTest"
+          :disabled="testLoading || !testText"
+          class="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          <Play class="w-4 h-4" />
+          Synthesize
+        </button>
+      </div>
+    </div>
+
+    <!-- Create Preset Modal -->
+    <div
+      v-if="showCreatePreset"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      @click.self="showCreatePreset = false"
+    >
+      <div class="bg-card border border-border rounded-lg w-full max-w-md p-6">
+        <h3 class="text-lg font-semibold mb-4">Create Custom Preset</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          Save current parameters as a new preset
+        </p>
+
+        <input
+          v-model="newPresetName"
+          type="text"
+          placeholder="Preset name..."
+          class="w-full p-3 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary mb-4"
+        />
+
+        <div class="flex justify-end gap-2">
+          <button
+            @click="showCreatePreset = false"
+            class="px-4 py-2 bg-secondary rounded-lg hover:bg-secondary/80 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            @click="createPreset"
+            :disabled="!newPresetName || createPresetMutation.isPending.value"
+            class="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          >
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/admin/tailwind.config.js
+++ b/admin/tailwind.config.js
@@ -1,0 +1,53 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{vue,js,ts,jsx,tsx}",
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+    },
+  },
+  plugins: [],
+}

--- a/admin/tsconfig.json
+++ b/admin/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/admin/tsconfig.node.json
+++ b/admin/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/admin/vite.config.ts
+++ b/admin/vite.config.ts
@@ -1,0 +1,42 @@
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
+  server: {
+    port: 5173,
+    proxy: {
+      '/admin': {
+        target: 'http://localhost:8002',
+        changeOrigin: true
+      },
+      '/v1': {
+        target: 'http://localhost:8002',
+        changeOrigin: true
+      },
+      '/health': {
+        target: 'http://localhost:8002',
+        changeOrigin: true
+      }
+    }
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'vendor': ['vue', 'vue-router', 'pinia'],
+          'ui': ['radix-vue', 'lucide-vue-next'],
+          'charts': ['chart.js', 'vue-chartjs']
+        }
+      }
+    }
+  }
+})

--- a/finetune_manager.py
+++ b/finetune_manager.py
@@ -1,0 +1,754 @@
+#!/usr/bin/env python3
+"""
+Fine-tune Manager - управление дообучением LoRA адаптеров для AI Secretary System.
+Поддерживает загрузку датасета, настройку параметров и мониторинг обучения.
+"""
+import subprocess
+import threading
+import asyncio
+import os
+import json
+import logging
+import re
+import shutil
+from pathlib import Path
+from dataclasses import dataclass, asdict, field
+from typing import Optional, List, Dict, AsyncGenerator
+from datetime import datetime
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TrainingConfig:
+    """Конфигурация обучения LoRA"""
+    # Model
+    base_model: str = "Qwen/Qwen2.5-7B-Instruct"
+
+    # LoRA params
+    lora_rank: int = 8
+    lora_alpha: int = 16
+    lora_dropout: float = 0.05
+
+    # Training params
+    batch_size: int = 1
+    gradient_accumulation_steps: int = 64
+    learning_rate: float = 2e-4
+    num_epochs: int = 1
+    warmup_ratio: float = 0.03
+    weight_decay: float = 0.01
+    max_seq_length: int = 768
+
+    # Output
+    output_dir: str = "qwen2.5-7b-lydia-lora-new"
+
+    # Advanced
+    gradient_checkpointing: bool = True
+    fp16: bool = True
+    logging_steps: int = 1
+    save_steps: int = 100
+
+
+@dataclass
+class AdapterInfo:
+    """Информация о LoRA адаптере"""
+    name: str
+    path: str
+    size_mb: float
+    modified: str
+    active: bool = False
+    config: Optional[dict] = None
+
+
+@dataclass
+class TrainingStatus:
+    """Статус текущего обучения"""
+    is_running: bool = False
+    current_step: int = 0
+    total_steps: int = 0
+    current_epoch: int = 0
+    total_epochs: int = 0
+    loss: float = 0.0
+    learning_rate: float = 0.0
+    elapsed_seconds: float = 0.0
+    eta_seconds: float = 0.0
+    error: Optional[str] = None
+
+
+@dataclass
+class DatasetStats:
+    """Статистика датасета"""
+    total_sessions: int = 0
+    total_messages: int = 0
+    total_tokens: int = 0
+    avg_tokens_per_message: float = 0.0
+    file_path: Optional[str] = None
+    file_size_mb: float = 0.0
+    modified: Optional[str] = None
+
+
+class FinetuneManager:
+    """
+    Менеджер дообучения LoRA адаптеров.
+
+    Функции:
+    - Загрузка и обработка датасетов (Telegram export)
+    - Настройка параметров обучения
+    - Запуск/остановка обучения
+    - Мониторинг прогресса (SSE)
+    - Управление адаптерами (активация, удаление)
+    """
+
+    # Пути по умолчанию
+    FINETUNE_DIR = Path(os.path.expanduser("~/qwen-finetune"))
+    ADAPTERS_BASE = FINETUNE_DIR / "qwen2.5-7b-lydia-lora"
+    VENV_PATH = FINETUNE_DIR / "venv"
+    DATASET_DIR = FINETUNE_DIR / "data"
+
+    # Скрипты
+    PREPARE_SCRIPT = "prepare_telegram.py"
+    ANALYZE_SCRIPT = "analyze_dataset.py"
+    AUGMENT_SCRIPT = "augment_dataset.py"
+    TRAIN_SCRIPT = "train_qlora.py"
+
+    def __init__(self, base_dir: Optional[Path] = None):
+        self.base_dir = base_dir or Path(__file__).parent
+        self.finetune_dir = self.FINETUNE_DIR
+        self.adapters_base = self.ADAPTERS_BASE
+
+        # Состояние обучения
+        self.training_process: Optional[subprocess.Popen] = None
+        self.training_config: Optional[TrainingConfig] = None
+        self.training_status = TrainingStatus()
+        self.training_log: List[str] = []
+        self.training_start_time: Optional[datetime] = None
+        self._training_lock = threading.Lock()
+
+        # Создаем директории
+        self.DATASET_DIR.mkdir(parents=True, exist_ok=True)
+        self.adapters_base.mkdir(parents=True, exist_ok=True)
+
+        # Текущий активный адаптер
+        self.active_adapter: Optional[str] = None
+        self._load_active_adapter()
+
+        logger.info(f"🎓 FinetuneManager инициализирован")
+        logger.info(f"   📁 Finetune dir: {self.finetune_dir}")
+        logger.info(f"   🔧 Adapters: {self.adapters_base}")
+
+    def _load_active_adapter(self):
+        """Загружает информацию об активном адаптере"""
+        active_file = self.adapters_base / ".active"
+        if active_file.exists():
+            self.active_adapter = active_file.read_text().strip()
+
+    def _save_active_adapter(self, adapter_name: str):
+        """Сохраняет активный адаптер"""
+        active_file = self.adapters_base / ".active"
+        active_file.write_text(adapter_name)
+        self.active_adapter = adapter_name
+
+    def _run_script(self, script_name: str, args: List[str] = None, capture_output: bool = True) -> dict:
+        """Запускает Python скрипт в venv finetune"""
+        script_path = self.finetune_dir / script_name
+        if not script_path.exists():
+            # Пробуем в base_dir
+            script_path = self.base_dir / script_name
+            if not script_path.exists():
+                return {"status": "error", "message": f"Скрипт не найден: {script_name}"}
+
+        python_path = self.VENV_PATH / "bin" / "python"
+        if not python_path.exists():
+            # Fallback на системный python
+            python_path = "python3"
+
+        cmd = [str(python_path), str(script_path)]
+        if args:
+            cmd.extend(args)
+
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=str(self.finetune_dir),
+                capture_output=capture_output,
+                text=True,
+                timeout=300  # 5 минут таймаут
+            )
+
+            if result.returncode == 0:
+                return {
+                    "status": "ok",
+                    "stdout": result.stdout,
+                    "stderr": result.stderr
+                }
+            else:
+                return {
+                    "status": "error",
+                    "message": result.stderr or result.stdout,
+                    "returncode": result.returncode
+                }
+        except subprocess.TimeoutExpired:
+            return {"status": "error", "message": "Таймаут выполнения скрипта"}
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+
+    # ============== Dataset Operations ==============
+
+    async def upload_dataset(self, content: bytes, filename: str) -> dict:
+        """
+        Сохраняет загруженный датасет (Telegram export JSON).
+        """
+        try:
+            # Определяем путь для сохранения
+            if filename.endswith('.json'):
+                dest_path = self.DATASET_DIR / "result.json"
+            else:
+                dest_path = self.DATASET_DIR / filename
+
+            dest_path.write_bytes(content)
+            file_size = len(content) / (1024 * 1024)
+
+            logger.info(f"📥 Датасет загружен: {dest_path} ({file_size:.2f} MB)")
+
+            return {
+                "status": "ok",
+                "message": f"Файл сохранён: {dest_path.name}",
+                "path": str(dest_path),
+                "size_mb": round(file_size, 2)
+            }
+        except Exception as e:
+            logger.error(f"❌ Ошибка загрузки датасета: {e}")
+            return {"status": "error", "message": str(e)}
+
+    async def process_dataset(self) -> dict:
+        """
+        Обрабатывает Telegram export и создает JSONL для обучения.
+        Запускает prepare_telegram.py
+        """
+        result = self._run_script(self.PREPARE_SCRIPT)
+
+        if result["status"] == "ok":
+            # Проверяем результат
+            output_file = self.DATASET_DIR / "train.jsonl"
+            if output_file.exists():
+                lines = len(output_file.read_text().strip().split('\n'))
+                return {
+                    "status": "ok",
+                    "message": f"Датасет обработан: {lines} примеров",
+                    "output_file": str(output_file),
+                    "examples_count": lines
+                }
+
+        return result
+
+    def get_dataset_stats(self) -> DatasetStats:
+        """
+        Возвращает статистику датасета.
+        """
+        stats = DatasetStats()
+
+        # Проверяем наличие обработанного датасета
+        train_file = self.DATASET_DIR / "train.jsonl"
+        if not train_file.exists():
+            return stats
+
+        try:
+            stat = train_file.stat()
+            stats.file_path = str(train_file)
+            stats.file_size_mb = round(stat.st_size / (1024 * 1024), 2)
+            stats.modified = datetime.fromtimestamp(stat.st_mtime).isoformat()
+
+            # Парсим JSONL
+            with open(train_file, 'r', encoding='utf-8') as f:
+                sessions = [json.loads(line) for line in f if line.strip()]
+
+            stats.total_sessions = len(sessions)
+
+            total_messages = 0
+            total_chars = 0
+
+            for session in sessions:
+                messages = session.get("conversations", session.get("messages", []))
+                total_messages += len(messages)
+                for msg in messages:
+                    content = msg.get("value", msg.get("content", ""))
+                    total_chars += len(content)
+
+            stats.total_messages = total_messages
+            # Приблизительная оценка токенов (1 токен ~ 4 символа для русского)
+            stats.total_tokens = total_chars // 3
+            stats.avg_tokens_per_message = round(stats.total_tokens / max(1, total_messages), 1)
+
+        except Exception as e:
+            logger.error(f"❌ Ошибка анализа датасета: {e}")
+
+        return stats
+
+    async def augment_dataset(self) -> dict:
+        """
+        Аугментирует датасет (увеличивает разнообразие).
+        Запускает augment_dataset.py
+        """
+        result = self._run_script(self.AUGMENT_SCRIPT)
+
+        if result["status"] == "ok":
+            stats = self.get_dataset_stats()
+            return {
+                "status": "ok",
+                "message": f"Датасет аугментирован. Теперь: {stats.total_sessions} сессий",
+                "stats": asdict(stats)
+            }
+
+        return result
+
+    # ============== Training Configuration ==============
+
+    def get_config(self) -> TrainingConfig:
+        """Возвращает текущую конфигурацию обучения"""
+        if self.training_config:
+            return self.training_config
+
+        # Загружаем из файла если есть
+        config_file = self.finetune_dir / "training_config.json"
+        if config_file.exists():
+            try:
+                data = json.loads(config_file.read_text())
+                self.training_config = TrainingConfig(**data)
+            except Exception:
+                self.training_config = TrainingConfig()
+        else:
+            self.training_config = TrainingConfig()
+
+        return self.training_config
+
+    def set_config(self, config: TrainingConfig) -> dict:
+        """Устанавливает конфигурацию обучения"""
+        self.training_config = config
+
+        # Сохраняем в файл
+        config_file = self.finetune_dir / "training_config.json"
+        try:
+            config_file.write_text(json.dumps(asdict(config), indent=2))
+            logger.info(f"⚙️ Конфигурация сохранена: {config_file}")
+            return {"status": "ok", "config": asdict(config)}
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+
+    def get_config_presets(self) -> Dict[str, TrainingConfig]:
+        """Возвращает предустановленные конфигурации"""
+        return {
+            "quick": TrainingConfig(
+                lora_rank=4,
+                lora_alpha=8,
+                batch_size=1,
+                gradient_accumulation_steps=32,
+                num_epochs=1,
+                max_seq_length=512,
+                output_dir="adapter-quick",
+            ),
+            "standard": TrainingConfig(
+                lora_rank=8,
+                lora_alpha=16,
+                batch_size=1,
+                gradient_accumulation_steps=64,
+                num_epochs=1,
+                max_seq_length=768,
+                output_dir="adapter-standard",
+            ),
+            "thorough": TrainingConfig(
+                lora_rank=16,
+                lora_alpha=32,
+                batch_size=1,
+                gradient_accumulation_steps=128,
+                num_epochs=2,
+                max_seq_length=1024,
+                output_dir="adapter-thorough",
+            ),
+        }
+
+    # ============== Training Operations ==============
+
+    async def start_training(self, config: Optional[TrainingConfig] = None) -> dict:
+        """
+        Запускает обучение в фоновом режиме.
+        """
+        if self.training_process and self.training_process.poll() is None:
+            return {"status": "error", "message": "Обучение уже запущено"}
+
+        # Используем переданную или текущую конфигурацию
+        if config:
+            self.training_config = config
+        elif not self.training_config:
+            self.training_config = TrainingConfig()
+
+        config = self.training_config
+
+        # Проверяем датасет
+        train_file = self.DATASET_DIR / "train.jsonl"
+        if not train_file.exists():
+            return {"status": "error", "message": "Датасет не найден. Сначала загрузите и обработайте данные."}
+
+        # Создаем директорию для адаптера
+        output_dir = self.adapters_base / config.output_dir
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Формируем команду обучения
+        python_path = self.VENV_PATH / "bin" / "python"
+        if not python_path.exists():
+            return {"status": "error", "message": "venv для обучения не найден. Запустите setup."}
+
+        train_script = self.finetune_dir / self.TRAIN_SCRIPT
+        if not train_script.exists():
+            return {"status": "error", "message": f"Скрипт обучения не найден: {train_script}"}
+
+        cmd = [
+            str(python_path),
+            str(train_script),
+            "--model_name", config.base_model,
+            "--dataset_path", str(train_file),
+            "--output_dir", str(output_dir),
+            "--lora_r", str(config.lora_rank),
+            "--lora_alpha", str(config.lora_alpha),
+            "--lora_dropout", str(config.lora_dropout),
+            "--per_device_train_batch_size", str(config.batch_size),
+            "--gradient_accumulation_steps", str(config.gradient_accumulation_steps),
+            "--learning_rate", str(config.learning_rate),
+            "--num_train_epochs", str(config.num_epochs),
+            "--warmup_ratio", str(config.warmup_ratio),
+            "--max_seq_length", str(config.max_seq_length),
+            "--logging_steps", str(config.logging_steps),
+            "--save_steps", str(config.save_steps),
+        ]
+
+        if config.gradient_checkpointing:
+            cmd.append("--gradient_checkpointing")
+        if config.fp16:
+            cmd.append("--fp16")
+
+        try:
+            # Очищаем предыдущий лог
+            with self._training_lock:
+                self.training_log = []
+                self.training_status = TrainingStatus(is_running=True, total_epochs=config.num_epochs)
+                self.training_start_time = datetime.now()
+
+            # Запускаем процесс
+            log_file = self.finetune_dir / "training.log"
+            self.training_process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                cwd=str(self.finetune_dir),
+                text=True,
+                bufsize=1,
+            )
+
+            # Запускаем поток для чтения вывода
+            threading.Thread(target=self._read_training_output, daemon=True).start()
+
+            logger.info(f"🎓 Обучение запущено: {' '.join(cmd[:5])}...")
+
+            return {
+                "status": "ok",
+                "message": "Обучение запущено",
+                "config": asdict(config),
+                "pid": self.training_process.pid
+            }
+
+        except Exception as e:
+            with self._training_lock:
+                self.training_status.is_running = False
+                self.training_status.error = str(e)
+            logger.error(f"❌ Ошибка запуска обучения: {e}")
+            return {"status": "error", "message": str(e)}
+
+    def _read_training_output(self):
+        """Читает вывод процесса обучения в фоне"""
+        if not self.training_process:
+            return
+
+        # Регулярки для парсинга прогресса
+        step_pattern = re.compile(r"Step (\d+)/(\d+)")
+        loss_pattern = re.compile(r"loss[=:\s]+([0-9.]+)", re.IGNORECASE)
+        epoch_pattern = re.compile(r"Epoch (\d+)/(\d+)")
+        lr_pattern = re.compile(r"lr[=:\s]+([0-9.e-]+)", re.IGNORECASE)
+
+        for line in iter(self.training_process.stdout.readline, ''):
+            if not line:
+                break
+
+            line = line.strip()
+
+            with self._training_lock:
+                self.training_log.append(line)
+
+                # Ограничиваем размер лога
+                if len(self.training_log) > 10000:
+                    self.training_log = self.training_log[-5000:]
+
+                # Парсим прогресс
+                step_match = step_pattern.search(line)
+                if step_match:
+                    self.training_status.current_step = int(step_match.group(1))
+                    self.training_status.total_steps = int(step_match.group(2))
+
+                loss_match = loss_pattern.search(line)
+                if loss_match:
+                    self.training_status.loss = float(loss_match.group(1))
+
+                epoch_match = epoch_pattern.search(line)
+                if epoch_match:
+                    self.training_status.current_epoch = int(epoch_match.group(1))
+                    self.training_status.total_epochs = int(epoch_match.group(2))
+
+                lr_match = lr_pattern.search(line)
+                if lr_match:
+                    self.training_status.learning_rate = float(lr_match.group(1))
+
+                # Вычисляем время
+                if self.training_start_time:
+                    elapsed = (datetime.now() - self.training_start_time).total_seconds()
+                    self.training_status.elapsed_seconds = elapsed
+
+                    # ETA
+                    if self.training_status.current_step > 0 and self.training_status.total_steps > 0:
+                        steps_remaining = self.training_status.total_steps - self.training_status.current_step
+                        time_per_step = elapsed / self.training_status.current_step
+                        self.training_status.eta_seconds = steps_remaining * time_per_step
+
+        # Процесс завершился
+        with self._training_lock:
+            self.training_status.is_running = False
+            returncode = self.training_process.wait()
+            if returncode != 0:
+                self.training_status.error = f"Процесс завершился с кодом {returncode}"
+            else:
+                logger.info("✅ Обучение завершено успешно")
+
+    async def stop_training(self) -> dict:
+        """Останавливает обучение"""
+        if not self.training_process or self.training_process.poll() is not None:
+            return {"status": "ok", "message": "Обучение не запущено"}
+
+        try:
+            self.training_process.terminate()
+            try:
+                self.training_process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.training_process.kill()
+
+            with self._training_lock:
+                self.training_status.is_running = False
+
+            logger.info("🛑 Обучение остановлено")
+            return {"status": "ok", "message": "Обучение остановлено"}
+
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+
+    def get_training_status(self) -> TrainingStatus:
+        """Возвращает текущий статус обучения"""
+        with self._training_lock:
+            return TrainingStatus(
+                is_running=self.training_status.is_running,
+                current_step=self.training_status.current_step,
+                total_steps=self.training_status.total_steps,
+                current_epoch=self.training_status.current_epoch,
+                total_epochs=self.training_status.total_epochs,
+                loss=self.training_status.loss,
+                learning_rate=self.training_status.learning_rate,
+                elapsed_seconds=self.training_status.elapsed_seconds,
+                eta_seconds=self.training_status.eta_seconds,
+                error=self.training_status.error,
+            )
+
+    def get_training_log(self, lines: int = 100, offset: int = 0) -> dict:
+        """Возвращает лог обучения"""
+        with self._training_lock:
+            total = len(self.training_log)
+            if offset > 0:
+                end_idx = max(0, total - offset)
+                start_idx = max(0, end_idx - lines)
+            else:
+                start_idx = max(0, total - lines)
+                end_idx = total
+
+            return {
+                "lines": self.training_log[start_idx:end_idx],
+                "total_lines": total,
+                "start_line": start_idx,
+                "end_line": end_idx,
+            }
+
+    async def stream_training_log(self, interval: float = 0.5) -> AsyncGenerator[str, None]:
+        """SSE streaming лога обучения"""
+        last_line_idx = 0
+
+        while True:
+            with self._training_lock:
+                # Отправляем новые строки
+                if len(self.training_log) > last_line_idx:
+                    new_lines = self.training_log[last_line_idx:]
+                    last_line_idx = len(self.training_log)
+
+                    for line in new_lines:
+                        yield json.dumps({
+                            "type": "log",
+                            "line": line,
+                            "timestamp": datetime.now().isoformat()
+                        })
+
+                # Отправляем статус
+                yield json.dumps({
+                    "type": "status",
+                    "status": asdict(self.training_status)
+                })
+
+                is_running = self.training_status.is_running
+
+            if not is_running:
+                yield json.dumps({"type": "done"})
+                break
+
+            await asyncio.sleep(interval)
+
+    # ============== Adapter Operations ==============
+
+    def list_adapters(self) -> List[AdapterInfo]:
+        """Возвращает список доступных LoRA адаптеров"""
+        adapters = []
+
+        if not self.adapters_base.exists():
+            return adapters
+
+        for adapter_dir in self.adapters_base.iterdir():
+            if not adapter_dir.is_dir() or adapter_dir.name.startswith('.'):
+                continue
+
+            # Проверяем наличие файлов адаптера
+            adapter_files = list(adapter_dir.glob("adapter_*.safetensors")) + list(adapter_dir.glob("adapter_*.bin"))
+            if not adapter_files:
+                # Проверяем подпапку final
+                final_dir = adapter_dir / "final"
+                if final_dir.exists():
+                    adapter_files = list(final_dir.glob("adapter_*.safetensors")) + list(final_dir.glob("adapter_*.bin"))
+
+            if not adapter_files:
+                continue
+
+            # Вычисляем размер
+            total_size = sum(f.stat().st_size for f in adapter_dir.rglob("*") if f.is_file())
+            size_mb = total_size / (1024 * 1024)
+
+            # Дата модификации
+            modified = datetime.fromtimestamp(adapter_dir.stat().st_mtime).isoformat()
+
+            # Конфиг если есть
+            config = None
+            config_file = adapter_dir / "adapter_config.json"
+            if not config_file.exists():
+                config_file = adapter_dir / "final" / "adapter_config.json"
+            if config_file.exists():
+                try:
+                    config = json.loads(config_file.read_text())
+                except Exception:
+                    pass
+
+            adapters.append(AdapterInfo(
+                name=adapter_dir.name,
+                path=str(adapter_dir),
+                size_mb=round(size_mb, 2),
+                modified=modified,
+                active=(adapter_dir.name == self.active_adapter),
+                config=config
+            ))
+
+        return sorted(adapters, key=lambda x: x.modified, reverse=True)
+
+    async def activate_adapter(self, adapter_name: str) -> dict:
+        """
+        Активирует LoRA адаптер (hot-swap в vLLM).
+        """
+        adapter_dir = self.adapters_base / adapter_name
+        if not adapter_dir.exists():
+            return {"status": "error", "message": f"Адаптер не найден: {adapter_name}"}
+
+        # Проверяем наличие файлов
+        final_dir = adapter_dir / "final"
+        if final_dir.exists():
+            adapter_path = final_dir
+        else:
+            adapter_path = adapter_dir
+
+        adapter_files = list(adapter_path.glob("adapter_*.safetensors")) + list(adapter_path.glob("adapter_*.bin"))
+        if not adapter_files:
+            return {"status": "error", "message": f"Файлы адаптера не найдены в {adapter_path}"}
+
+        # TODO: Реализовать hot-swap через vLLM API
+        # Пока просто сохраняем как активный
+        self._save_active_adapter(adapter_name)
+
+        logger.info(f"✅ Адаптер активирован: {adapter_name}")
+
+        return {
+            "status": "ok",
+            "message": f"Адаптер {adapter_name} активирован. Перезапустите vLLM для применения.",
+            "adapter": adapter_name,
+            "path": str(adapter_path),
+            "note": "Требуется перезапуск vLLM для применения нового адаптера"
+        }
+
+    async def delete_adapter(self, adapter_name: str) -> dict:
+        """Удаляет LoRA адаптер"""
+        adapter_dir = self.adapters_base / adapter_name
+        if not adapter_dir.exists():
+            return {"status": "error", "message": f"Адаптер не найден: {adapter_name}"}
+
+        if adapter_name == self.active_adapter:
+            return {"status": "error", "message": "Нельзя удалить активный адаптер"}
+
+        try:
+            shutil.rmtree(adapter_dir)
+            logger.info(f"🗑️ Адаптер удалён: {adapter_name}")
+            return {"status": "ok", "message": f"Адаптер {adapter_name} удалён"}
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+
+
+# Глобальный экземпляр
+_finetune_manager: Optional[FinetuneManager] = None
+
+
+def get_finetune_manager() -> FinetuneManager:
+    """Получает или создает глобальный FinetuneManager"""
+    global _finetune_manager
+    if _finetune_manager is None:
+        _finetune_manager = FinetuneManager()
+    return _finetune_manager
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    async def test():
+        manager = FinetuneManager()
+
+        print("=== Dataset Stats ===")
+        stats = manager.get_dataset_stats()
+        print(f"  Sessions: {stats.total_sessions}")
+        print(f"  Messages: {stats.total_messages}")
+        print(f"  Tokens: {stats.total_tokens}")
+
+        print("\n=== Training Config ===")
+        config = manager.get_config()
+        print(f"  LoRA rank: {config.lora_rank}")
+        print(f"  Batch size: {config.batch_size}")
+        print(f"  Learning rate: {config.learning_rate}")
+
+        print("\n=== Adapters ===")
+        for adapter in manager.list_adapters():
+            active = " (ACTIVE)" if adapter.active else ""
+            print(f"  - {adapter.name}: {adapter.size_mb} MB{active}")
+
+    asyncio.run(test())

--- a/service_manager.py
+++ b/service_manager.py
@@ -1,0 +1,607 @@
+#!/usr/bin/env python3
+"""
+Service Manager - управление процессами и сервисами AI Secretary System.
+Поддерживает запуск/остановку vLLM и других внешних сервисов.
+"""
+import subprocess
+import signal
+import psutil
+import asyncio
+import os
+import logging
+from pathlib import Path
+from typing import Dict, Optional, List, AsyncGenerator
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import time
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ServiceConfig:
+    """Конфигурация сервиса"""
+    name: str
+    display_name: str
+    start_script: Optional[str] = None
+    port: Optional[int] = None
+    health_endpoint: Optional[str] = None
+    log_file: Optional[str] = None
+    venv_path: Optional[str] = None
+    internal: bool = False  # True = управляется orchestrator, False = внешний процесс
+    gpu_required: bool = False
+    cpu_only: bool = False
+    pid_file: Optional[str] = None
+
+
+# Конфигурация всех сервисов системы
+SERVICE_CONFIGS: Dict[str, ServiceConfig] = {
+    "vllm": ServiceConfig(
+        name="vllm",
+        display_name="vLLM Server",
+        start_script="start_qwen.sh",
+        port=11434,
+        health_endpoint="/health",
+        log_file="logs/vllm.log",
+        venv_path=os.path.expanduser("~/vllm_env/venv"),
+        internal=False,
+        gpu_required=True,
+        pid_file="logs/vllm.pid",
+    ),
+    "xtts_gulya": ServiceConfig(
+        name="xtts_gulya",
+        display_name="XTTS Gulya",
+        internal=True,
+        gpu_required=True,
+    ),
+    "xtts_lidia": ServiceConfig(
+        name="xtts_lidia",
+        display_name="XTTS Lidia",
+        internal=True,
+        gpu_required=True,
+    ),
+    "piper": ServiceConfig(
+        name="piper",
+        display_name="Piper TTS",
+        internal=True,
+        cpu_only=True,
+    ),
+    "openvoice": ServiceConfig(
+        name="openvoice",
+        display_name="OpenVoice TTS",
+        internal=True,
+        gpu_required=True,
+    ),
+    "orchestrator": ServiceConfig(
+        name="orchestrator",
+        display_name="Orchestrator",
+        port=8002,
+        health_endpoint="/health",
+        log_file="logs/orchestrator.log",
+        internal=True,
+    ),
+}
+
+
+class ServiceManager:
+    """
+    Менеджер сервисов для запуска/остановки/мониторинга.
+
+    Особенности:
+    - Внешние сервисы (vLLM) запускаются через start_script
+    - Внутренние сервисы (XTTS, Piper) управляются orchestrator
+    - Поддерживает чтение логов и streaming
+    - Отслеживает PID и память процессов
+    """
+
+    def __init__(self, base_dir: Optional[Path] = None):
+        self.base_dir = base_dir or Path(__file__).parent
+        self.logs_dir = self.base_dir / "logs"
+        self.logs_dir.mkdir(exist_ok=True)
+
+        # Запущенные процессы (только внешние, управляемые этим классом)
+        self.processes: Dict[str, subprocess.Popen] = {}
+
+        # Последние ошибки
+        self.last_errors: Dict[str, str] = {}
+
+        # Время запуска сервисов
+        self.start_times: Dict[str, datetime] = {}
+
+        logger.info(f"🔧 ServiceManager инициализирован: {self.base_dir}")
+
+    def _get_config(self, service_name: str) -> ServiceConfig:
+        """Получает конфигурацию сервиса"""
+        if service_name not in SERVICE_CONFIGS:
+            raise ValueError(f"Неизвестный сервис: {service_name}")
+        return SERVICE_CONFIGS[service_name]
+
+    def _find_process_by_port(self, port: int) -> Optional[psutil.Process]:
+        """Находит процесс, слушающий указанный порт"""
+        for conn in psutil.net_connections(kind='inet'):
+            if conn.laddr.port == port and conn.status == 'LISTEN':
+                try:
+                    return psutil.Process(conn.pid)
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
+        return None
+
+    def _find_process_by_pid_file(self, pid_file: str) -> Optional[psutil.Process]:
+        """Находит процесс по PID файлу"""
+        pid_path = self.base_dir / pid_file
+        if pid_path.exists():
+            try:
+                pid = int(pid_path.read_text().strip())
+                proc = psutil.Process(pid)
+                if proc.is_running():
+                    return proc
+            except (ValueError, psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+        return None
+
+    def _is_service_running(self, service_name: str) -> tuple[bool, Optional[int], Optional[float]]:
+        """
+        Проверяет, запущен ли сервис.
+        Returns: (is_running, pid, memory_mb)
+        """
+        config = self._get_config(service_name)
+
+        # Проверяем внутренний процесс
+        if service_name in self.processes:
+            proc = self.processes[service_name]
+            if proc.poll() is None:  # Still running
+                try:
+                    ps_proc = psutil.Process(proc.pid)
+                    memory_mb = ps_proc.memory_info().rss / (1024 * 1024)
+                    return True, proc.pid, memory_mb
+                except psutil.NoSuchProcess:
+                    pass
+            # Процесс завершился
+            del self.processes[service_name]
+
+        # Проверяем по PID файлу
+        if config.pid_file:
+            proc = self._find_process_by_pid_file(config.pid_file)
+            if proc:
+                memory_mb = proc.memory_info().rss / (1024 * 1024)
+                return True, proc.pid, memory_mb
+
+        # Проверяем по порту
+        if config.port:
+            proc = self._find_process_by_port(config.port)
+            if proc:
+                memory_mb = proc.memory_info().rss / (1024 * 1024)
+                return True, proc.pid, memory_mb
+
+        return False, None, None
+
+    async def _check_health(self, service_name: str) -> bool:
+        """Проверяет health endpoint сервиса"""
+        config = self._get_config(service_name)
+
+        if not config.port or not config.health_endpoint:
+            return True  # Нет health check = считаем OK если процесс работает
+
+        import httpx
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                url = f"http://localhost:{config.port}{config.health_endpoint}"
+                response = await client.get(url)
+                return response.status_code == 200
+        except Exception:
+            return False
+
+    async def start_service(self, service_name: str) -> dict:
+        """
+        Запускает сервис.
+        Returns: {"status": "ok/error", "message": str, "pid": int}
+        """
+        config = self._get_config(service_name)
+
+        if config.internal:
+            return {
+                "status": "error",
+                "message": f"Сервис {config.display_name} управляется orchestrator, перезапустите orchestrator"
+            }
+
+        # Проверяем, не запущен ли уже
+        is_running, pid, _ = self._is_service_running(service_name)
+        if is_running:
+            return {
+                "status": "ok",
+                "message": f"{config.display_name} уже запущен",
+                "pid": pid
+            }
+
+        if not config.start_script:
+            return {
+                "status": "error",
+                "message": f"Нет скрипта запуска для {config.display_name}"
+            }
+
+        script_path = self.base_dir / config.start_script
+        if not script_path.exists():
+            return {
+                "status": "error",
+                "message": f"Скрипт не найден: {script_path}"
+            }
+
+        try:
+            # Запускаем процесс
+            log_file = self.logs_dir / f"{service_name}.log" if not config.log_file else self.base_dir / config.log_file
+
+            with open(log_file, 'a') as log:
+                log.write(f"\n{'='*60}\n")
+                log.write(f"Starting {config.display_name} at {datetime.now().isoformat()}\n")
+                log.write(f"{'='*60}\n")
+
+            env = os.environ.copy()
+
+            # Активируем venv если указан
+            if config.venv_path:
+                venv_bin = Path(config.venv_path) / "bin"
+                env["PATH"] = f"{venv_bin}:{env['PATH']}"
+                env["VIRTUAL_ENV"] = config.venv_path
+
+            proc = subprocess.Popen(
+                ["bash", str(script_path)],
+                stdout=open(log_file, 'a'),
+                stderr=subprocess.STDOUT,
+                cwd=str(self.base_dir),
+                env=env,
+                start_new_session=True,  # Отсоединяем от родительского процесса
+            )
+
+            self.processes[service_name] = proc
+            self.start_times[service_name] = datetime.now()
+
+            # Ждем немного и проверяем, что процесс не упал
+            await asyncio.sleep(2)
+
+            if proc.poll() is not None:
+                # Процесс завершился
+                return {
+                    "status": "error",
+                    "message": f"{config.display_name} завершился сразу после запуска. Проверьте логи."
+                }
+
+            # Сохраняем PID
+            if config.pid_file:
+                pid_path = self.base_dir / config.pid_file
+                pid_path.write_text(str(proc.pid))
+
+            logger.info(f"✅ {config.display_name} запущен (PID: {proc.pid})")
+
+            return {
+                "status": "ok",
+                "message": f"{config.display_name} запущен",
+                "pid": proc.pid
+            }
+
+        except Exception as e:
+            error_msg = str(e)
+            self.last_errors[service_name] = error_msg
+            logger.error(f"❌ Ошибка запуска {config.display_name}: {error_msg}")
+            return {
+                "status": "error",
+                "message": f"Ошибка запуска: {error_msg}"
+            }
+
+    async def stop_service(self, service_name: str) -> dict:
+        """Останавливает сервис"""
+        config = self._get_config(service_name)
+
+        if config.internal:
+            return {
+                "status": "error",
+                "message": f"Сервис {config.display_name} управляется orchestrator"
+            }
+
+        is_running, pid, _ = self._is_service_running(service_name)
+        if not is_running:
+            return {
+                "status": "ok",
+                "message": f"{config.display_name} уже остановлен"
+            }
+
+        try:
+            # Пытаемся остановить gracefully через SIGTERM
+            if service_name in self.processes:
+                proc = self.processes[service_name]
+                proc.terminate()
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                del self.processes[service_name]
+            else:
+                # Процесс не наш - ищем по PID/порту
+                proc = None
+                if config.pid_file:
+                    proc = self._find_process_by_pid_file(config.pid_file)
+                if not proc and config.port:
+                    proc = self._find_process_by_port(config.port)
+
+                if proc:
+                    proc.terminate()
+                    try:
+                        proc.wait(timeout=10)
+                    except psutil.TimeoutExpired:
+                        proc.kill()
+
+            # Удаляем PID файл
+            if config.pid_file:
+                pid_path = self.base_dir / config.pid_file
+                if pid_path.exists():
+                    pid_path.unlink()
+
+            # Убираем из времени запуска
+            self.start_times.pop(service_name, None)
+
+            logger.info(f"🛑 {config.display_name} остановлен")
+
+            return {
+                "status": "ok",
+                "message": f"{config.display_name} остановлен"
+            }
+
+        except Exception as e:
+            error_msg = str(e)
+            self.last_errors[service_name] = error_msg
+            logger.error(f"❌ Ошибка остановки {config.display_name}: {error_msg}")
+            return {
+                "status": "error",
+                "message": f"Ошибка остановки: {error_msg}"
+            }
+
+    async def restart_service(self, service_name: str) -> dict:
+        """Перезапускает сервис"""
+        config = self._get_config(service_name)
+
+        stop_result = await self.stop_service(service_name)
+        if stop_result["status"] == "error" and "управляется orchestrator" not in stop_result.get("message", ""):
+            return stop_result
+
+        # Даем время на освобождение порта
+        await asyncio.sleep(2)
+
+        return await self.start_service(service_name)
+
+    def get_service_status(self, service_name: str) -> dict:
+        """Получает статус сервиса"""
+        config = self._get_config(service_name)
+        is_running, pid, memory_mb = self._is_service_running(service_name)
+
+        status = {
+            "name": service_name,
+            "display_name": config.display_name,
+            "is_running": is_running,
+            "pid": pid,
+            "memory_mb": round(memory_mb, 2) if memory_mb else None,
+            "port": config.port,
+            "internal": config.internal,
+            "gpu_required": config.gpu_required,
+            "cpu_only": config.cpu_only,
+            "log_file": config.log_file,
+            "last_error": self.last_errors.get(service_name),
+        }
+
+        # Добавляем uptime
+        if service_name in self.start_times and is_running:
+            uptime = datetime.now() - self.start_times[service_name]
+            status["uptime_seconds"] = uptime.total_seconds()
+
+        return status
+
+    def get_all_status(self) -> dict:
+        """Получает статус всех сервисов"""
+        services = {}
+        for name in SERVICE_CONFIGS:
+            services[name] = self.get_service_status(name)
+        return {
+            "services": services,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def read_log(
+        self,
+        service_name: str,
+        lines: int = 100,
+        offset: int = 0,
+        search: Optional[str] = None
+    ) -> dict:
+        """
+        Читает логи сервиса.
+
+        Args:
+            service_name: Имя сервиса или имя лог-файла
+            lines: Количество строк
+            offset: Пропустить N строк с конца
+            search: Фильтр по подстроке
+
+        Returns:
+            {"lines": [...], "total_lines": int, "file": str}
+        """
+        # Определяем путь к логу
+        if service_name in SERVICE_CONFIGS:
+            config = SERVICE_CONFIGS[service_name]
+            if config.log_file:
+                log_path = self.base_dir / config.log_file
+            else:
+                log_path = self.logs_dir / f"{service_name}.log"
+        else:
+            # Возможно это имя файла
+            log_path = self.logs_dir / service_name
+            if not log_path.exists():
+                log_path = self.base_dir / service_name
+
+        if not log_path.exists():
+            return {
+                "lines": [],
+                "total_lines": 0,
+                "file": str(log_path),
+                "error": "Лог файл не найден"
+            }
+
+        try:
+            with open(log_path, 'r', encoding='utf-8', errors='replace') as f:
+                all_lines = f.readlines()
+
+            # Фильтруем по поиску если указан
+            if search:
+                all_lines = [l for l in all_lines if search.lower() in l.lower()]
+
+            total = len(all_lines)
+
+            # Применяем offset и limit
+            if offset > 0:
+                end_idx = max(0, total - offset)
+                start_idx = max(0, end_idx - lines)
+            else:
+                start_idx = max(0, total - lines)
+                end_idx = total
+
+            result_lines = all_lines[start_idx:end_idx]
+
+            return {
+                "lines": [l.rstrip('\n') for l in result_lines],
+                "total_lines": total,
+                "file": str(log_path),
+                "start_line": start_idx + 1,
+                "end_line": end_idx,
+            }
+
+        except Exception as e:
+            return {
+                "lines": [],
+                "total_lines": 0,
+                "file": str(log_path),
+                "error": str(e)
+            }
+
+    async def stream_log(
+        self,
+        service_name: str,
+        interval: float = 1.0
+    ) -> AsyncGenerator[str, None]:
+        """
+        Async generator для SSE streaming логов.
+        Возвращает новые строки по мере их появления.
+        """
+        # Определяем путь к логу
+        if service_name in SERVICE_CONFIGS:
+            config = SERVICE_CONFIGS[service_name]
+            if config.log_file:
+                log_path = self.base_dir / config.log_file
+            else:
+                log_path = self.logs_dir / f"{service_name}.log"
+        else:
+            log_path = self.logs_dir / service_name
+
+        if not log_path.exists():
+            yield json.dumps({"error": "Лог файл не найден", "file": str(log_path)})
+            return
+
+        # Начинаем с конца файла
+        last_position = log_path.stat().st_size
+
+        while True:
+            try:
+                current_size = log_path.stat().st_size
+
+                if current_size > last_position:
+                    # Есть новые данные
+                    with open(log_path, 'r', encoding='utf-8', errors='replace') as f:
+                        f.seek(last_position)
+                        new_content = f.read()
+                        last_position = f.tell()
+
+                    # Отправляем новые строки
+                    for line in new_content.splitlines():
+                        if line.strip():
+                            yield json.dumps({
+                                "line": line,
+                                "timestamp": datetime.now().isoformat()
+                            })
+
+                elif current_size < last_position:
+                    # Файл был перезаписан (rotate)
+                    last_position = 0
+
+                await asyncio.sleep(interval)
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                yield json.dumps({"error": str(e)})
+                await asyncio.sleep(interval)
+
+    def get_available_logs(self) -> List[dict]:
+        """Возвращает список доступных лог-файлов"""
+        logs = []
+
+        # Логи из конфигураций сервисов
+        for name, config in SERVICE_CONFIGS.items():
+            if config.log_file:
+                log_path = self.base_dir / config.log_file
+                if log_path.exists():
+                    stat = log_path.stat()
+                    logs.append({
+                        "name": name,
+                        "file": config.log_file,
+                        "display_name": config.display_name,
+                        "size_kb": round(stat.st_size / 1024, 2),
+                        "modified": datetime.fromtimestamp(stat.st_mtime).isoformat()
+                    })
+
+        # Дополнительные логи в папке logs
+        for log_file in self.logs_dir.glob("*.log"):
+            if not any(log_file.name == Path(c.log_file).name for c in SERVICE_CONFIGS.values() if c.log_file):
+                stat = log_file.stat()
+                logs.append({
+                    "name": log_file.stem,
+                    "file": str(log_file.relative_to(self.base_dir)),
+                    "display_name": log_file.stem,
+                    "size_kb": round(stat.st_size / 1024, 2),
+                    "modified": datetime.fromtimestamp(stat.st_mtime).isoformat()
+                })
+
+        return sorted(logs, key=lambda x: x["modified"], reverse=True)
+
+
+# Глобальный экземпляр для использования в orchestrator
+_service_manager: Optional[ServiceManager] = None
+
+
+def get_service_manager() -> ServiceManager:
+    """Получает или создает глобальный ServiceManager"""
+    global _service_manager
+    if _service_manager is None:
+        _service_manager = ServiceManager()
+    return _service_manager
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    async def test():
+        manager = ServiceManager()
+
+        print("=== Service Status ===")
+        status = manager.get_all_status()
+        for name, info in status["services"].items():
+            running = "✅" if info["is_running"] else "❌"
+            print(f"{running} {info['display_name']}: PID={info['pid']}, Memory={info['memory_mb']}MB")
+
+        print("\n=== Available Logs ===")
+        for log in manager.get_available_logs():
+            print(f"  - {log['display_name']}: {log['file']} ({log['size_kb']}KB)")
+
+        print("\n=== Recent vLLM Logs ===")
+        logs = manager.read_log("vllm", lines=10)
+        for line in logs["lines"]:
+            print(f"  {line}")
+
+    asyncio.run(test())


### PR DESCRIPTION
## Что сделано

- Полностью реализована новая админ-панель на Vue 3 + Vite + shadcn/vue + Tailwind + Pinia + TanStack Query
- Добавлено 7 основных экранов: Dashboard, Services, LLM, TTS, FAQ, Fine-tuning, Monitoring
- Реализованы SSE-стримы для логов и GPU-метрик
- Расширено API оркестратора — добавлено ~45 новых эндпоинтов под админку
- Введены два новых менеджера:
  - service_manager.py — управление сервисами (start/stop/restart, логи, SSE)
  - finetune_manager.py — загрузка датасетов, запуск обучения, управление адаптерами
- Расширены существующие сервисы:
  - vllm_llm_service: runtime params + set/get методы
  - voice_clone_service: поддержка кастомных пресетов (CRUD)

## Как проверить

### Бэкенд
1. Запустить оркестратор: `./start_gpu.sh`
2. Проверить статус: `curl http://localhost:8002/admin/services/status`
3. Посмотреть логи в реальном времени: `curl http://localhost:8002/admin/logs/stream/orchestrator.log`
4. Проверить новые эндпоинты LLM/TTS/FAQ/Finetune через Postman или Swagger

### Фронтенд
1. Перейти: http://localhost:8002/admin-new/
2. Убедиться, что грузятся все вкладки:
   - Dashboard → карточки сервисов + GPU-графики
   - Services → кнопки start/stop + просмотр логов
   - LLM → смена бэкенда, пресеты персоны, параметры
   - TTS → пресеты XTTS, кастомные пресеты
   - FAQ → CRUD записей + тест триггера
   - Finetune → загрузка датасета, запуск обучения
   - Monitoring → стриминг метрик GPU/CPU/RAM
3. Проверить перезапуск сервисов и отображение логов в реальном времени

## Связанные задачи / PR

- (если есть предыдущие PR — укажи ссылки)

## Дополнительно

- Миграция с legacy-админки (admin_web.html) → новая версия полностью заменяет старую
- Авторизация пока не добавлена (планируется в следующем PR)
- Размер бандла админки после сборки: ~180–250 кБ (gzipped)

 