### PR TITLE
fix(tts): enable Piper/OpenVoice voice switching in admin panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,9 @@ tail -f logs/vllm.log
 **Single entry point:** http://localhost:8002/admin/ (login: admin / admin)
 
 ```bash
+# First-time setup
+cd admin && npm install     # Install dependencies once
+
 # Production mode (default) - serve built Vue app
 cd admin && npm run build   # Build once
 ./start_gpu.sh              # Start orchestrator
@@ -201,11 +204,15 @@ ADMIN_JWT_SECRET=...                # Auto-generated if empty
 
 ## Known Issues
 
-1. **Vosk model required** — Download `vosk-model-ru-0.42` (~1.5GB) to `models/vosk/` for STT
-2. **XTTS requires CC >= 7.0** — RTX 3060 or newer
+1. **Vosk model required** — Download `vosk-model-ru-0.42` (~1.5GB) to `models/vosk/` for STT:
+   ```bash
+   mkdir -p models/vosk && cd models/vosk
+   wget https://alphacephei.com/vosk/models/vosk-model-ru-0.42.zip && unzip vosk-model-ru-0.42.zip
+   ```
+2. **XTTS requires CC >= 7.0** — RTX 3060 or newer; use OpenVoice for older GPUs (CC >= 6.1)
 3. **GPU memory sharing** — vLLM 50% (~6GB) + XTTS ~5GB on 12GB GPU
-4. **OpenWebUI Docker** — Use `172.17.0.1` not `localhost`
-5. **Model quality** — Lydia LoRA may produce repetitive responses; adjust repetition_penalty
+4. **OpenWebUI Docker** — Use `172.17.0.1` not `localhost` for API URL
+5. **Model quality** — Lydia LoRA may produce repetitive responses; adjust `repetition_penalty` in LLM tab
 
 ## Roadmap & Backlog
 


### PR DESCRIPTION
## Summary
- Fix `/admin/tts/test` endpoint to correctly route to Piper/OpenVoice TTS engines based on `current_voice_config`
- Add visual indication of active TTS engine in admin panel (dimmed inactive sections, "Active" badge)
- Add Play test buttons for all voice types (XTTS, OpenVoice, Piper)

## Problem
When selecting Dmitri or Irina (Piper voices) in the TTS tab, the test synthesis was still using XTTS (Gulya/Lidia) instead of Piper. The endpoint only checked for XTTS engines.

## Solution
Updated `/admin/tts/test` endpoint to check `current_voice_config.engine` and route to the appropriate service:
- `piper` → `piper_service.synthesize_to_file()`
- `openvoice` → `openvoice_service.synthesize_to_file()`
- `xtts` → `gulya_voice_service` or `voice_service`

## Test plan
- [ ] Select Dmitri (Piper) in TTS tab → section shows "Active" badge
- [ ] Click Play on Dmitri card → hear Piper male voice
- [ ] Use "Test Synthesis" block → uses current Piper voice
- [ ] Switch to Gulya (XTTS) → XTTS section becomes active, Piper dimmed
- [ ] Repeat test → hear XTTS female voice

🤖 Generated with [Claude Code](https://claude.ai/code)