### PR TITLE
feat(llm): hot-switching between vLLM and Gemini backends

### DIFF
--- a/admin/src/api/llm.ts
+++ b/admin/src/api/llm.ts
@@ -23,8 +23,8 @@ export const llmApi = {
   getBackend: () =>
     api.get<LlmBackend>('/admin/llm/backend'),
 
-  setBackend: (backend: 'vllm' | 'gemini') =>
-    api.post<{ status: string; backend: string; message?: string }>('/admin/llm/backend', { backend }),
+  setBackend: (backend: 'vllm' | 'gemini', stopUnused: boolean = false) =>
+    api.post<{ status: string; backend: string; model?: string; message?: string }>('/admin/llm/backend', { backend, stop_unused: stopUnused }),
 
   getPersonas: () =>
     api.get<{ personas: Record<string, Persona> }>('/admin/llm/personas'),


### PR DESCRIPTION
## Summary
- Enable hot-switching between vLLM and Gemini from admin panel without restarting orchestrator
- Auto-start vLLM via ServiceManager when selecting it (waits up to 2 min for startup)
- Option to stop vLLM when switching to Gemini to free ~6GB GPU memory

## Changes

### Backend (`orchestrator.py`)
- `POST /admin/llm/backend` now performs hot-switching:
  - **vLLM selected**: checks if running, starts via ServiceManager if not, waits for health
  - **Gemini selected**: switches immediately, optionally stops vLLM with `stop_unused: true`
- Added `stop_unused` field to `AdminBackendRequest` model

### Frontend (`LlmView.vue`)
- Loading spinner during backend switch
- Checkbox "Остановить vLLM при переключении на Gemini"
- Toast notifications for success/error
- Buttons disabled during switching

## Test plan
- [ ] Switch to vLLM when not running → starts automatically (~60s)
- [ ] Switch to vLLM when running → instant
- [ ] Switch to Gemini with checkbox off → vLLM keeps running
- [ ] Switch to Gemini with checkbox on → vLLM stops, GPU freed
- [ ] Error handling: vLLM fails to start → error toast shown

## Performance
- vLLM cold start: ~55-60 seconds
- vLLM hot switch: instant
- Gemini switch: instant

🤖 Generated with [Claude Code](https://claude.ai/code)