### PR TITLE
refactor: Remove legacy JSON sync, migrate fully to SQLite + Redis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,11 +195,6 @@ python quantize_awq.py      # W4A16 quantization
 | File | Purpose |
 |------|---------|
 | `data/secretary.db` | SQLite database (primary storage) |
-| `typical_responses.json` | FAQ (legacy, synced from DB) |
-| `custom_presets.json` | TTS presets (legacy, synced from DB) |
-| `chat_sessions.json` | Chat history (legacy, synced from DB) |
-| `widget_config.json` | Widget settings (legacy, synced from DB) |
-| `telegram_config.json` | Telegram settings (legacy, synced from DB) |
 | `./Гуля/`, `./Лидия/` | Voice sample WAV files |
 | `web-widget/` | Embeddable chat widget source |
 | `finetune/datasets/` | Training data symlinks (not in git) |

--- a/voice_clone_service.py
+++ b/voice_clone_service.py
@@ -322,9 +322,8 @@ class VoiceCloneService:
             logger.error(f"❌ Ошибка загрузки модели: {e}")
             raise
 
-        # Пользовательские пресеты
-        self.custom_presets_file = Path("custom_presets.json")
-        self.custom_presets = self._load_custom_presets()
+        # Пользовательские пресеты (загружаются через reload_presets из БД)
+        self.custom_presets: dict = {}
 
         # Загружаем ВСЕ образцы голоса
         self.voice_samples = self._get_voice_samples()
@@ -342,36 +341,40 @@ class VoiceCloneService:
         self._latents_cache_hash = None
         self._precompute_latents()
 
-    def _load_custom_presets(self) -> dict:
-        """Загружает пользовательские пресеты из файла"""
-        if self.custom_presets_file.exists():
-            try:
-                import json
-                return json.loads(self.custom_presets_file.read_text())
-            except Exception as e:
-                logger.warning(f"⚠️ Ошибка загрузки пользовательских пресетов: {e}")
-        return {}
+    def reload_presets(self, presets_dict: dict = None):
+        """
+        Перезагружает пользовательские пресеты (hot reload).
+
+        Args:
+            presets_dict: Словарь пресетов из БД {name: params}.
+                         Если не передан, пресеты очищаются.
+        """
+        if presets_dict:
+            self.custom_presets = presets_dict.copy()
+        else:
+            self.custom_presets = {}
+        logger.info(f"🔄 Пресеты перезагружены: {len(self.custom_presets)} записей")
 
     def save_custom_preset(self, name: str, params: dict):
         """
-        Сохраняет пользовательский пресет.
+        Сохраняет пользовательский пресет в память.
+        Сохранение в БД выполняется через orchestrator.
 
         Args:
             name: Имя пресета
             params: Параметры пресета (temperature, speed, top_k, top_p, etc.)
         """
-        import json
         self.custom_presets[name] = params
-        self.custom_presets_file.write_text(json.dumps(self.custom_presets, indent=2, ensure_ascii=False))
-        logger.info(f"💾 Пресет '{name}' сохранён")
+        logger.info(f"💾 Пресет '{name}' сохранён в память")
 
     def delete_custom_preset(self, name: str):
-        """Удаляет пользовательский пресет"""
-        import json
+        """
+        Удаляет пользовательский пресет из памяти.
+        Удаление из БД выполняется через orchestrator.
+        """
         if name in self.custom_presets:
             del self.custom_presets[name]
-            self.custom_presets_file.write_text(json.dumps(self.custom_presets, indent=2, ensure_ascii=False))
-            logger.info(f"🗑️ Пресет '{name}' удалён")
+            logger.info(f"🗑️ Пресет '{name}' удалён из памяти")
 
     def get_all_presets(self) -> dict:
         """Возвращает все пресеты (встроенные + пользовательские)"""


### PR DESCRIPTION
## Summary
- Remove `_sync_to_legacy_file()` from all repositories (faq, preset, config, telegram)
- Update LLM services to load FAQ from DB via `reload_faq(dict)` parameter
- Update voice_clone_service to load presets from DB via `reload_presets(dict)`
- Remove legacy ChatManager class (~175 lines) from orchestrator.py
- Remove unused get/save_widget_config, get/save_telegram_config functions
- Add startup warning for deprecated JSON files
- Add automatic loading of FAQ and presets from DB at startup

This eliminates the dual storage system (SQLite + JSON) that was causing maintenance overhead and data synchronization risks.

## Changes
| File | Change |
|------|--------|
| `db/repositories/faq.py` | Removed sync |
| `db/repositories/preset.py` | Removed sync |
| `db/repositories/config.py` | Removed sync |
| `db/repositories/telegram.py` | Removed sync |
| `llm_service.py` | `reload_faq(dict)` |
| `vllm_llm_service.py` | `reload_faq(dict)` |
| `cloud_llm_service.py` | `reload_faq(dict)` |
| `voice_clone_service.py` | `reload_presets(dict)` |
| `orchestrator.py` | Removed ChatManager, added helper functions |
| `BACKLOG.md` | Updated task 5.7 as completed |
| `CLAUDE.md` | Removed legacy files from Data Files |

## Deprecated files (can be removed after migration)
```
typical_responses.json      # → data/secretary.db (faq_entries)
custom_presets.json         # → data/secretary.db (tts_presets)
widget_config.json          # → data/secretary.db (system_config)
telegram_config.json        # → data/secretary.db (system_config)
chat_sessions.json          # → data/secretary.db (chat_sessions + chat_messages)
```

## Test plan
- [ ] Run `python3 -m py_compile` on all modified Python files (passed)
- [ ] Start orchestrator and verify FAQ/presets load from DB
- [ ] Test FAQ CRUD operations in admin panel
- [ ] Test TTS preset CRUD operations in admin panel
- [ ] Verify startup warning appears when legacy JSON files exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)