### PR TITLE
feat(llm): Add OpenRouter as cloud LLM provider

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -27,7 +27,7 @@ Roadmap и план работ для AI Secretary System. Этот файл и�
 - [x] **Prompt Editor** — редактирование дефолтного промпта из настроек чата
 - [x] **DeepSeek LLM** — третья модель для vLLM (--deepseek flag)
 - [x] **LLM Models UI** — отображение доступных моделей с характеристиками
-- [x] **Cloud LLM Providers** — универсальное подключение облачных LLM (Gemini, Kimi, OpenAI, Claude, DeepSeek, custom)
+- [x] **Cloud LLM Providers** — универсальное подключение облачных LLM (Gemini, Kimi, OpenAI, Claude, DeepSeek, OpenRouter, custom)
 - [ ] **Телефония SIM7600** — в планах
 - [ ] **Enterprise-функции** — в планах
 
@@ -1053,7 +1053,7 @@ pip install zipfile36  # или стандартный zipfile
 
 ### 2026-01-27 (update 8) — Cloud LLM Providers
 - **Cloud LLM Providers** — универсальная система управления облачными LLM
-  - Поддержка 6 типов провайдеров: Gemini, Kimi, OpenAI, Claude, DeepSeek, Custom
+  - Поддержка 7 типов провайдеров: Gemini, Kimi, OpenAI, Claude, DeepSeek, OpenRouter, Custom
   - CRUD операции из админ-панели
   - Хранение credentials (API keys, URLs) в SQLite
   - Factory pattern для унифицированного интерфейса

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AI Secretary System - virtual secretary with voice cloning (XTTS v2, OpenVoice), pre-trained voices (Piper), local LLM (vLLM + Qwen/Llama/DeepSeek), and Gemini fallback. Features a Vue 3 PWA admin panel with 13 tabs, i18n (ru/en), themes, ~80 API endpoints, website chat widget, and Telegram bot integration.
+AI Secretary System - virtual secretary with voice cloning (XTTS v2, OpenVoice), pre-trained voices (Piper), local LLM (vLLM + Qwen/Llama/DeepSeek), and cloud LLM fallback (Gemini, Kimi, OpenAI, Claude, DeepSeek). Features a Vue 3 PWA admin panel with 13 tabs, i18n (ru/en), themes, ~100 API endpoints, website chat widgets (multi-instance), and Telegram bot integration (multi-instance).
 
 ## Architecture
 
@@ -14,7 +14,7 @@ AI Secretary System - virtual secretary with voice cloning (XTTS v2, OpenVoice),
                               │           orchestrator.py                │
                               │                                          │
                               │  ┌────────────────────────────────────┐  │
-                              │  │  Vue 3 Admin Panel (13 tabs, PWA)  │  │
+                              │  │  Vue 3 Admin Panel (13 tabs, PWA)   │  │
                               │  │         admin/dist/                │  │
                               │  └────────────────────────────────────┘  │
                               └──────────────────┬───────────────────────┘
@@ -188,7 +188,7 @@ python quantize_awq.py      # W4A16 quantization
 |------|---------|
 | `orchestrator.py` | FastAPI server, ~100 endpoints, serves admin panel |
 | `multi_bot_manager.py` | Subprocess manager for multiple Telegram bots |
-| `cloud_llm_service.py` | Cloud LLM factory (Gemini, Kimi, OpenAI, Claude, DeepSeek) |
+| `cloud_llm_service.py` | Cloud LLM factory (Gemini, Kimi, OpenAI, Claude, DeepSeek, OpenRouter) |
 | `auth_manager.py` | JWT authentication |
 | `service_manager.py` | Process control (vLLM) |
 | `finetune_manager.py` | LoRA training pipeline |
@@ -375,13 +375,12 @@ REDIS_URL=redis://localhost:6379/0  # Optional, for caching
 - ✅ Prompt Editor — редактирование дефолтного промпта из чата
 - ✅ DeepSeek LLM — третья модель (./start_gpu.sh --deepseek)
 - ✅ LLM Models UI — отображение доступных моделей в админке
-- ✅ Cloud LLM Providers — подключение облачных LLM (Gemini, Kimi, OpenAI, Claude, DeepSeek)
+- ✅ Cloud LLM Providers — подключение облачных LLM (Gemini, Kimi, OpenAI, Claude, DeepSeek, OpenRouter)
 - ✅ Multi-Instance Bots — несколько Telegram ботов с независимыми настройками
 - ✅ Multi-Instance Widgets — несколько виджетов с независимыми настройками
 
 **Ближайшие задачи (Фаза 1):**
 1. Telephony Gateway — интеграция с SIM7600 (AT-команды)
 2. Backup & Restore — полный бэкап системы
-3. Docker Compose — one-command deployment
 
 **Hardware:** Raspberry Pi + SIM7600G-H для GSM-телефонии

--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ curl -X POST http://localhost:8002/admin/llm/backend \
 | **OpenAI** | `openai` | gpt-4o, gpt-4o-mini | api.openai.com |
 | **Anthropic Claude** | `claude` | claude-opus-4, claude-sonnet-4 | api.anthropic.com |
 | **DeepSeek** | `deepseek` | deepseek-chat, deepseek-reasoner | api.deepseek.com |
+| **OpenRouter** | `openrouter` | gemma-2-9b:free, llama-3.2-3b:free, qwen-2-7b:free | openrouter.ai |
 | **Custom** | `custom` | (user-defined) | (user-defined) |
 
 ### Управление провайдерами

--- a/cloud_llm_service.py
+++ b/cloud_llm_service.py
@@ -8,6 +8,7 @@ Supports:
 - OpenAI (OpenAI-compatible API)
 - Anthropic Claude (OpenAI-compatible API)
 - DeepSeek (OpenAI-compatible API)
+- OpenRouter (aggregator with many free models)
 - Custom OpenAI-compatible endpoints
 """
 
@@ -62,6 +63,18 @@ PROVIDER_TYPES = {
         "name": "DeepSeek",
         "default_base_url": "https://api.deepseek.com/v1",
         "default_models": ["deepseek-chat", "deepseek-coder"],
+        "requires_base_url": True,
+    },
+    "openrouter": {
+        "name": "OpenRouter",
+        "default_base_url": "https://openrouter.ai/api/v1",
+        "default_models": [
+            "google/gemma-2-9b-it:free",
+            "meta-llama/llama-3.2-3b-instruct:free",
+            "qwen/qwen-2-7b-instruct:free",
+            "mistralai/mistral-7b-instruct:free",
+            "nousresearch/hermes-3-llama-3.1-405b:free",
+        ],
         "requires_base_url": True,
     },
     "custom": {
@@ -418,6 +431,7 @@ class CloudLLMService:
         "openai": OpenAICompatibleProvider,
         "claude": OpenAICompatibleProvider,
         "deepseek": OpenAICompatibleProvider,
+        "openrouter": OpenAICompatibleProvider,
         "custom": OpenAICompatibleProvider,
     }
 

--- a/db/models.py
+++ b/db/models.py
@@ -531,6 +531,18 @@ PROVIDER_TYPES = {
         "default_models": ["deepseek-chat", "deepseek-coder"],
         "requires_base_url": True,
     },
+    "openrouter": {
+        "name": "OpenRouter",
+        "default_base_url": "https://openrouter.ai/api/v1",
+        "default_models": [
+            "google/gemma-2-9b-it:free",
+            "meta-llama/llama-3.2-3b-instruct:free",
+            "qwen/qwen-2-7b-instruct:free",
+            "mistralai/mistral-7b-instruct:free",
+            "nousresearch/hermes-3-llama-3.1-405b:free",
+        ],
+        "requires_base_url": True,
+    },
     "custom": {
         "name": "Custom OpenAI-Compatible",
         "default_base_url": "",


### PR DESCRIPTION
## Summary

Add OpenRouter as a new cloud LLM provider type. OpenRouter is an API aggregator that provides access to many LLM models (including free tiers) through a single OpenAI-compatible endpoint.

## Changes

- Added `openrouter` to `PROVIDER_TYPES` in `db/models.py` and `cloud_llm_service.py`
- Added to `PROVIDER_CLASSES` mapping (uses `OpenAICompatibleProvider`)
- Updated documentation

## Default Free Models

| Model | ID |
|-------|-----|
| Google Gemma 2 9B | `google/gemma-2-9b-it:free` |
| Meta Llama 3.2 3B | `meta-llama/llama-3.2-3b-instruct:free` |
| Qwen 2 7B | `qwen/qwen-2-7b-instruct:free` |
| Mistral 7B | `mistralai/mistral-7b-instruct:free` |
| Hermes 3 405B | `nousresearch/hermes-3-llama-3.1-405b:free` |

## Usage

1. Get API key from [openrouter.ai](https://openrouter.ai)
2. Admin → LLM → Cloud LLM Providers → Add Provider
3. Select type: **OpenRouter**
4. Enter API key and choose model
5. Test Connection → Use

## Test plan

- [ ] Create OpenRouter provider in admin panel
- [ ] Test connection with free model
- [ ] Send test message and verify response

🤖 Generated with [Claude Code](https://claude.com/claude-code)