### PR TITLE
feat(docker): Use local vLLM by default, streamline Docker setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,279 +4,178 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AI Secretary System - virtual secretary with voice cloning (XTTS v2, OpenVoice), pre-trained voices (Piper), local LLM (vLLM + Qwen/Llama/DeepSeek), and cloud LLM fallback (Gemini, Kimi, OpenAI, Claude, DeepSeek, OpenRouter). Features a Vue 3 PWA admin panel with 13 tabs, i18n (ru/en), themes, ~100 API endpoints, website chat widgets (multi-instance), and Telegram bot integration (multi-instance).
+AI Secretary System - virtual secretary with voice cloning (XTTS v2, OpenVoice), pre-trained voices (Piper), local LLM (vLLM + Qwen/Llama/DeepSeek), and cloud LLM fallback (Gemini, Kimi, OpenAI, Claude, DeepSeek, OpenRouter). Features a Vue 3 PWA admin panel with 13 tabs, i18n (ru/en), themes, ~112 API endpoints across 11 routers, website chat widgets (multi-instance), and Telegram bot integration (multi-instance).
 
 ## Architecture
 
 ```
-                              ┌──────────────────────────────────────────┐
-                              │        Orchestrator (port 8002)          │
-                              │           orchestrator.py                │
-                              │                                          │
-                              │  ┌────────────────────────────────────┐  │
-                              │  │  Vue 3 Admin Panel (13 tabs, PWA)   │  │
-                              │  │         admin/dist/                │  │
-                              │  └────────────────────────────────────┘  │
-                              └──────────────────┬───────────────────────┘
-                                                 │
-      ┌──────────────┬──────────────┬────────────┼────────────┬─────────────┬──────────────┐
-      ↓              ↓              ↓            ↓            ↓             ↓              ↓
- Service        Finetune        LLM         Voice Clone   OpenVoice    Piper TTS       FAQ
- Manager        Manager       Service         XTTS v2       v2          (CPU)         System
-service_      finetune_      vLLM/Gemini   voice_clone_  openvoice_   piper_tts_   typical_
-manager.py    manager.py                   service.py    service.py   service.py   responses.json
+┌──────────────────────────────────────────────────────────────────────────┐
+│                     Orchestrator (port 8002)                              │
+│  orchestrator.py + app/routers/ (11 modular routers, ~112 endpoints)     │
+│                                                                          │
+│  ┌───────────────────────────────────────────────────────────────────┐   │
+│  │              Vue 3 Admin Panel (13 tabs, PWA)                      │   │
+│  │                      admin/dist/                                   │   │
+│  └───────────────────────────────────────────────────────────────────┘   │
+└────────────────────────────────┬─────────────────────────────────────────┘
+                                 │
+    ┌────────────┬───────────────┼───────────────┬───────────────┐
+    ↓            ↓               ↓               ↓               ↓
+┌────────┐  ┌────────┐     ┌──────────┐    ┌──────────┐    ┌──────────┐
+│ vLLM   │  │ Cloud  │     │ XTTS v2  │    │ Piper    │    │ Vosk/    │
+│ Local  │  │ LLM    │     │ OpenVoice│    │ (CPU)    │    │ Whisper  │
+│ LLM    │  │ Factory│     │ TTS      │    │ TTS      │    │ STT      │
+└────────┘  └────────┘     └──────────┘    └──────────┘    └──────────┘
 ```
 
-**GPU Mode (Single GPU - RTX 3060 12GB):**
-- vLLM Qwen2.5-7B + Lydia LoRA: ~6GB (50% GPU, port 11434)
-- XTTS v2 voice cloning: ~5GB (remaining)
+**GPU Mode (RTX 3060 12GB):** vLLM ~6GB (50% GPU) + XTTS v2 ~5GB
 
-**Request flow:**
-1. User message → FAQ check (instant) OR vLLM/Gemini LLM
-2. Response text → TTS (XTTS/Piper based on `current_voice_config`)
-3. Audio returned to user
+**Request flow:** User message → FAQ check (instant) OR LLM → TTS → Audio returned
 
 ## Commands
 
-### Docker Deployment (Recommended)
+### Quick Start (Docker - Recommended)
 
 ```bash
-# Quick start (GPU mode)
-cp .env.docker .env
-# Edit .env with your settings (GEMINI_API_KEY, etc.)
-docker compose up -d
+cp .env.docker .env && docker compose up -d     # GPU mode
+# OR
+docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d  # CPU mode
 
-# CPU-only mode (no GPU required, uses Gemini API)
-docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d
-
-# View logs
-docker compose logs -f orchestrator
-
-# Rebuild after code changes
-docker compose build --no-cache orchestrator && docker compose up -d
-
-# Stop
-docker compose down
-
-# Stop and remove data (WARNING: deletes database)
-docker compose down -v
+docker compose logs -f orchestrator             # View logs
+docker compose build --no-cache orchestrator && docker compose up -d  # Rebuild
 ```
-
-**Requirements:**
-- Docker & Docker Compose v2
-- NVIDIA Container Toolkit (for GPU mode)
-- 12GB+ VRAM (GPU mode) or Gemini API key (CPU mode)
 
 ### Local Development
 
 ```bash
 # Start system
-./start_gpu.sh              # GPU: XTTS + Qwen2.5-7B + LoRA (recommended)
-./start_gpu.sh --llama      # GPU: XTTS + Llama-3.1-8B
-./start_gpu.sh --deepseek   # GPU: XTTS + DeepSeek-LLM-7B
+./start_gpu.sh              # GPU: XTTS + Qwen2.5-7B + LoRA
 ./start_cpu.sh              # CPU: Piper + Gemini API
-./start_qwen.sh             # Start only vLLM (debugging)
 
 # Health check
 curl http://localhost:8002/health
-
-# System integration test (requires running system)
-./test_system.sh
-
-# View logs
-tail -f logs/orchestrator.log
-tail -f logs/vllm.log
 ```
 
-### Admin Panel
+### Admin Panel Development
 
-**Single entry point:** http://localhost:8002/admin/ (login: admin / admin)
+**Entry point:** http://localhost:8002/admin/ (login: admin / admin)
 
 ```bash
-# First-time setup
-cd admin && npm install     # Install dependencies once
+cd admin && npm install                # First-time setup
+cd admin && npm run build              # Production build
+cd admin && npm run dev                # Dev mode (:5173)
+DEV_MODE=1 ./start_gpu.sh              # Backend proxies to Vite
+```
 
-# Production mode (default) - serve built Vue app
-cd admin && npm run build   # Build once
-./start_gpu.sh              # Start orchestrator
+### Code Quality
 
-# Development mode - hot reload via Vite proxy
-cd admin && npm run dev     # Start Vite at :5173
-DEV_MODE=1 ./start_gpu.sh   # Orchestrator proxies /admin to Vite
+```bash
+source .venv/bin/activate              # Activate venv
 
-# Always access via: http://localhost:8002/admin/
-# (DEV_MODE proxies static files to Vite for hot reload)
+# Python
+ruff check .                           # Lint
+ruff check . --fix                     # Auto-fix
+ruff format .                          # Format
 
-# Lint
+# Vue/TypeScript
 cd admin && npm run lint
+
+# All checks
+pre-commit run --all-files
 ```
 
-### External Access (ngrok/Cloudflare Tunnel)
-
-For website widget and Telegram bot to work with external services, you need to expose the local server:
+### Testing
 
 ```bash
-# Option 1: ngrok (recommended for development)
-# Install: https://ngrok.com/download
-ngrok http 8002
+# Backend tests
+source .venv/bin/activate
+pytest tests/                          # All tests
+pytest tests/unit/test_db.py -v        # Single file
+pytest -k "test_chat" -v               # By name pattern
+pytest -m "not slow" -v                # Exclude slow tests
 
-# Option 2: Cloudflare Tunnel (recommended for production)
-# Install: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation/
-cloudflared tunnel --url http://localhost:8002
+# Frontend tests
+cd admin && npm test
 
-# Option 3: Helper script (auto-detects available tool)
-./start_with_tunnel.sh
+# Integration test (requires running system)
+./test_system.sh
 ```
 
-After starting tunnel, use the generated HTTPS URL in:
-- Widget settings (Admin → Widget → API URL)
-- Telegram webhook will be set automatically when bot starts
-
-### Telegram Bot
+### External Access (for Widget/Telegram)
 
 ```bash
-# Start default Telegram bot (requires orchestrator running)
-./start_telegram_bot.sh
-
-# Or via admin panel: Admin → Telegram → select bot → Start
-```
-
-**Setup (single bot):**
-1. Create bot via [@BotFather](https://t.me/BotFather), get token
-2. Add token in Admin → Telegram → select default bot → Edit → Bot Token
-3. Set API URL (cloudflare/ngrok tunnel URL)
-4. Configure allowed users (optional whitelist)
-5. Start bot
-
-**Multi-instance bots:**
-Each bot instance has independent:
-- Telegram token and user whitelist
-- LLM backend, persona, system prompt
-- TTS engine, voice, preset
-- Session isolation (users in different bots have separate chat histories)
-
-```bash
-# Create new bot instance via API
-curl -X POST http://localhost:8002/admin/telegram/instances \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{"name":"Sales Bot","bot_token":"...","api_url":"https://..."}'
-
-# Start specific bot instance
-curl -X POST http://localhost:8002/admin/telegram/instances/sales-bot/start
+ngrok http 8002                        # Dev tunnel
+cloudflared tunnel --url http://localhost:8002  # Production tunnel
 ```
 
 ### Fine-tuning (separate venv)
 
 ```bash
 cd finetune
-
-# Create and activate training venv (if needed)
-python -m venv train_venv
-source train_venv/bin/activate
+python -m venv train_venv && source train_venv/bin/activate
 pip install -r requirements.txt
-
-# Training workflow
-python prepare_dataset.py   # Convert Telegram export to JSONL
-python train.py             # Train LoRA adapters
-python merge_lora.py        # Merge LoRA with base (needs ~30GB RAM)
-
-# For quantization (different venv due to dependency conflicts)
-python -m venv quant_venv
-source quant_venv/bin/activate
-pip install auto-gptq autoawq
-python quantize_awq.py      # W4A16 quantization
+python prepare_dataset.py && python train.py
 ```
 
 ## Key Components
 
-### Backend (Python)
+### Backend Structure
 
+```
+orchestrator.py              # FastAPI entry point, global state, legacy endpoints
+app/
+├── dependencies.py          # ServiceContainer for DI
+└── routers/                 # 11 modular routers (~112 endpoints)
+    ├── auth.py              # 3 endpoints  - JWT login/logout/refresh
+    ├── audit.py             # 4 endpoints  - Audit log viewing/export
+    ├── services.py          # 6 endpoints  - vLLM start/stop/restart
+    ├── monitor.py           # 7 endpoints  - GPU stats, health, SSE metrics
+    ├── faq.py               # 7 endpoints  - FAQ CRUD, reload, test
+    ├── stt.py               # 4 endpoints  - STT status, transcribe
+    ├── llm.py               # 24 endpoints - Backend, persona, cloud providers
+    ├── tts.py               # 13 endpoints - Presets, params, test, cache
+    ├── chat.py              # 10 endpoints - Sessions, messages, streaming
+    ├── telegram.py          # 22 endpoints - Bot instances CRUD, control
+    └── widget.py            # 7 endpoints  - Widget instances CRUD
+```
+
+**Core Services:**
 | File | Purpose |
 |------|---------|
-| `orchestrator.py` | FastAPI server, ~100 endpoints, serves admin panel |
-| `multi_bot_manager.py` | Subprocess manager for multiple Telegram bots |
 | `cloud_llm_service.py` | Cloud LLM factory (Gemini, Kimi, OpenAI, Claude, DeepSeek, OpenRouter) |
-| `auth_manager.py` | JWT authentication |
-| `service_manager.py` | Process control (vLLM) |
-| `finetune_manager.py` | LoRA training pipeline |
-| `voice_clone_service.py` | XTTS v2 with custom presets |
-| `openvoice_service.py` | OpenVoice v2 (older GPUs) |
-| `piper_tts_service.py` | Piper ONNX CPU TTS |
-| `stt_service.py` | Vosk (realtime) + Whisper (batch) STT |
 | `vllm_llm_service.py` | vLLM API + `SECRETARY_PERSONAS` dict |
-| `llm_service.py` | Gemini API fallback |
-| `telegram_bot_service.py` | Async Telegram bot (python-telegram-bot) |
+| `voice_clone_service.py` | XTTS v2 with custom presets |
+| `stt_service.py` | Vosk (realtime) + Whisper (batch) STT |
+| `multi_bot_manager.py` | Subprocess manager for multiple Telegram bots |
 
 ### Admin Panel (Vue 3)
 
-**Tabs:** Dashboard, Chat, Services, LLM, TTS, FAQ, Finetune, Monitoring, Models, Widget, Telegram, Audit, Settings
-
-| Directory | Purpose |
-|-----------|---------|
-| `admin/src/views/` | 13 main views + LoginView |
-| `admin/src/api/` | API clients + SSE helpers |
-| `admin/src/stores/` | Pinia stores (auth, theme, toast, audit, services, llm) |
-| `admin/src/composables/` | useSSE, useRealtimeMetrics, useExportImport |
-| `admin/src/plugins/i18n.ts` | vue-i18n translations (ru/en) |
-
-**Chat features:**
-- Streaming LLM responses (SSE)
-- Message edit/regenerate/delete
-- Custom system prompts per session
-- TTS playback for assistant messages (Volume2 button on hover)
-- Voice mode toggle (auto-play TTS on response)
-- Voice input via microphone (STT transcription)
-- Default prompt editing from chat settings
-
-### Data Files
-
-| File | Purpose |
-|------|---------|
-| `data/secretary.db` | SQLite database (primary storage) |
-| `./Гуля/`, `./Лидия/` | Voice sample WAV files |
-| `web-widget/` | Embeddable chat widget source |
-| `finetune/datasets/` | Training data symlinks (not in git) |
-| `finetune/adapters/` | LoRA model symlinks (not in git) |
+```
+admin/src/
+├── views/                   # 13 tabs + LoginView
+├── api/                     # API clients + SSE helpers
+├── stores/                  # Pinia (auth, theme, toast, audit, services, llm)
+├── composables/             # useSSE, useRealtimeMetrics, useExportImport
+└── plugins/i18n.ts          # vue-i18n translations (ru/en)
+```
 
 ### Database (SQLite + Redis)
 
-**SQLite tables:**
-| Table | Purpose |
-|-------|---------|
-| `chat_sessions` | Chat session metadata |
-| `chat_messages` | Individual chat messages |
-| `faq_entries` | FAQ question-answer pairs |
-| `tts_presets` | Custom TTS voice presets |
-| `system_config` | Key-value system config (telegram, widget, etc.) |
-| `telegram_sessions` | Telegram user → chat session mapping (composite key: bot_id, user_id) |
-| `audit_log` | System audit trail |
-| `cloud_llm_providers` | Cloud LLM provider credentials (API keys, URLs) |
-| `bot_instances` | Telegram bot instances with individual config (token, users, AI, TTS) |
-| `widget_instances` | Website widget instances with individual config (appearance, AI, TTS) |
+**Location:** `data/secretary.db`
 
-**Redis keys (optional, for caching):**
-| Key Pattern | Purpose | TTL |
-|-------------|---------|-----|
-| `chat:session:{id}` | Cached chat sessions | 5 min |
-| `faq:cache` | FAQ question→answer dict | 10 min |
-| `config:{key}` | System config cache | 5 min |
-| `ratelimit:{ip}:{endpoint}` | Rate limiting | 1 min |
+**Key tables:** `chat_sessions`, `chat_messages`, `faq_entries`, `tts_presets`, `system_config`, `telegram_sessions`, `audit_log`, `cloud_llm_providers`, `bot_instances`, `widget_instances`
 
-**Migration from JSON:**
+**Redis (optional):** Used for caching with graceful fallback if unavailable.
+
 ```bash
-# First time setup - migrate existing JSON data to SQLite
-python scripts/migrate_json_to_db.py
-
-# Migrate to multi-instance (creates 'default' bot/widget instances)
-python scripts/migrate_to_instances.py
+python scripts/migrate_json_to_db.py      # First-time migration
+python scripts/migrate_to_instances.py    # Multi-instance migration
 ```
-
-**Database location:** `data/secretary.db`
 
 ## Environment Variables
 
 ```bash
-LLM_BACKEND=vllm                    # "vllm" or "gemini"
+LLM_BACKEND=vllm                    # "vllm", "gemini", or "cloud:{provider_id}"
 VLLM_API_URL=http://localhost:11434
 VLLM_MODEL_NAME=lydia               # LoRA adapter name
 SECRETARY_PERSONA=gulya             # "gulya" or "lidia"
@@ -289,35 +188,33 @@ REDIS_URL=redis://localhost:6379/0  # Optional, for caching
 
 ## Code Patterns
 
-**Adding a new XTTS voice:**
-1. Create folder with WAV samples: `./NewVoice/`
-2. Add service instance in `orchestrator.py`
-3. Add voice ID to admin endpoints
-4. Voice appears in admin panel TTS tab
-
-**Adding a new secretary persona:**
-1. Add entry to `SECRETARY_PERSONAS` dict in `vllm_llm_service.py`
-2. Persona available via API and admin panel
-
-**Adding a new theme:**
-1. Add CSS variables in `admin/src/assets/main.css`
-2. Update `Theme` type in `admin/src/stores/theme.ts`
-3. Add translations in `admin/src/plugins/i18n.ts`
-
-**Adding i18n translations:**
-1. Edit `admin/src/plugins/i18n.ts`
-2. Add keys to both `ru` and `en` message objects
-3. Use in templates: `{{ t('key.path') }}`
-
-**Adding new role permission:**
-1. Add permission to `ROLE_PERMISSIONS` in `admin/src/stores/auth.ts`
-2. Check with `authStore.hasPermission('resource.action')`
+**Adding a new API endpoint:**
+1. Create or edit router in `app/routers/`
+2. Use `ServiceContainer` from `app/dependencies.py` for DI
+3. Router is auto-registered via `app/routers/__init__.py`
 
 **Adding a new cloud LLM provider type:**
 1. Add entry to `PROVIDER_TYPES` dict in `db/models.py`
 2. If OpenAI-compatible, `OpenAICompatibleProvider` in `cloud_llm_service.py` handles it
 3. For custom SDK, create new provider class inheriting `BaseLLMProvider`
 4. Register in `CloudLLMService.PROVIDER_CLASSES`
+
+**Adding a new XTTS voice:**
+1. Create folder with WAV samples: `./NewVoice/`
+2. Add service instance in `orchestrator.py`
+3. Add voice ID to admin endpoints
+
+**Adding a new secretary persona:**
+1. Add entry to `SECRETARY_PERSONAS` dict in `vllm_llm_service.py`
+
+**Adding i18n translations:**
+1. Edit `admin/src/plugins/i18n.ts`
+2. Add keys to both `ru` and `en` message objects
+
+**Adding a new theme:**
+1. Add CSS variables in `admin/src/assets/main.css`
+2. Update `Theme` type in `admin/src/stores/theme.ts`
+3. Add translations in `admin/src/plugins/i18n.ts`
 
 ## API Quick Reference
 
@@ -326,107 +223,37 @@ REDIS_URL=redis://localhost:6379/0  # Optional, for caching
 - `POST /v1/audio/speech` — TTS with current voice
 - `GET /v1/models` — Available models
 
-**Admin Chat API:**
-- `GET/POST /admin/chat/sessions` — List/create sessions
-- `GET/PUT/DELETE /admin/chat/sessions/{id}` — Session CRUD
-- `POST /admin/chat/sessions/{id}/stream` — SSE streaming chat
-- `POST /admin/chat/sessions/{id}/messages/{msg_id}/regenerate` — Regenerate response
+**Admin API (JWT required):** See `app/routers/` for complete endpoint definitions.
 
-**Admin API (JWT required):**
-- `POST /admin/auth/login` — Get JWT token
-- `GET/POST /admin/services/*` — Service control
-- `GET/POST /admin/llm/*` — Backend, persona, params
-- `GET/POST/PUT/DELETE /admin/llm/providers/*` — Cloud LLM providers CRUD
-- `GET/POST /admin/tts/*` — TTS config, test playback
-- `GET/POST /admin/stt/*` — STT status, transcribe, test
-- `GET/POST/PUT/DELETE /admin/faq/*` — FAQ CRUD
-- `POST /admin/finetune/*` — Training pipeline
-- `GET /admin/monitor/*` — GPU stats, SSE metrics
-- `GET/POST /admin/widget/*` — Widget config (legacy, uses 'default' instance)
-- `GET/POST/PUT/DELETE /admin/widget/instances/*` — Widget instances CRUD
-- `GET/POST /admin/telegram/*` — Telegram bot config (legacy, uses 'default' instance)
-- `GET/POST/PUT/DELETE /admin/telegram/instances/*` — Bot instances CRUD
-- `POST /admin/telegram/instances/{id}/start|stop|restart` — Bot control
-- `GET /admin/telegram/instances/{id}/status|sessions|logs` — Bot monitoring
-- `GET /admin/audit/*` — Audit log viewing, filtering, export
-- `GET /widget.js` — Dynamic widget script (public)
+Key patterns:
+- `GET/POST /admin/{resource}` — List/create
+- `GET/PUT/DELETE /admin/{resource}/{id}` — CRUD
+- `POST /admin/{resource}/{id}/action` — Actions (start, stop, test)
+- `GET /admin/{resource}/stream` — SSE endpoints
 
 ## Known Issues
 
-1. **Vosk model required** — Download `vosk-model-ru-0.42` (~1.5GB) to `models/vosk/` for STT:
+1. **Vosk model required** — Download to `models/vosk/` for STT:
    ```bash
    mkdir -p models/vosk && cd models/vosk
    wget https://alphacephei.com/vosk/models/vosk-model-ru-0.42.zip && unzip vosk-model-ru-0.42.zip
    ```
-2. **XTTS requires CC >= 7.0** — RTX 3060 or newer; use OpenVoice for older GPUs (CC >= 6.1)
+2. **XTTS requires CC >= 7.0** — RTX 3060+; use OpenVoice for older GPUs (CC >= 6.1)
 3. **GPU memory sharing** — vLLM 50% (~6GB) + XTTS ~5GB on 12GB GPU
 4. **OpenWebUI Docker** — Use `172.17.0.1` not `localhost` for API URL
-5. **Model quality** — Lydia LoRA may produce repetitive responses; adjust `repetition_penalty` in LLM tab
 
-## Code Quality
+## Configuration Files
 
-The project uses automated code quality tools:
-
-```bash
-# Activate venv for Python tools
-source .venv/bin/activate
-
-# Python linting (ruff)
-ruff check .              # Check for issues
-ruff check . --fix        # Auto-fix issues
-ruff format .             # Format code
-
-# Vue/TypeScript linting (eslint)
-cd admin && npm run lint
-
-# Pre-commit hooks (all checks)
-pre-commit run --all-files
-
-# Install pre-commit hooks
-pre-commit install
-```
-
-**Configuration files:**
 | File | Purpose |
 |------|---------|
 | `pyproject.toml` | ruff, mypy, pytest, coverage config |
 | `.pre-commit-config.yaml` | Pre-commit hooks |
 | `admin/.eslintrc.cjs` | ESLint config |
 | `admin/.prettierrc` | Prettier config |
+| `.env.docker` | Docker environment template |
 
-## Testing
+## Roadmap
 
-```bash
-# System integration test (requires running orchestrator)
-./test_system.sh
+See [BACKLOG.md](./BACKLOG.md) for task tracking and [docs/IMPROVEMENT_PLAN.md](./docs/IMPROVEMENT_PLAN.md) for production readiness plan.
 
-# Backend unit tests
-source .venv/bin/activate
-pytest tests/
-
-# Frontend tests
-cd admin && npm test
-```
-
-## Roadmap & Planning
-
-| Document | Purpose |
-|----------|---------|
-| [BACKLOG.md](./BACKLOG.md) | Task tracking and development history |
-| [docs/IMPROVEMENT_PLAN.md](./docs/IMPROVEMENT_PLAN.md) | Production readiness plan with timeline, budget, ROI |
-
-**Current focus:** Offline-first + GSM telephony via SIM7600G-H Waveshare
-
-**Strategic phases:**
-
-| Phase | Focus | Timeline | Status |
-|-------|-------|----------|--------|
-| 0 | Foundation (CI/CD, restructuring, security) | 2 weeks | In Progress |
-| 0.5 | Monetization (Stripe/YooKassa, billing) | 3 weeks | Planned |
-| 1 | Telephony SIM7600G-H | 4 weeks | Planned |
-| 2 | Observability (logging, metrics, testing) | 2 weeks | Planned |
-
-**Next steps:**
-1. ~~CI/CD Pipeline~~ — Done (GitHub Actions + Dependabot)
-2. Code Restructuring — Split orchestrator.py into routers
-3. Stripe/YooKassa — Subscription billing
+**Current focus:** Foundation (security, testing) → Monetization → GSM Telephony

--- a/README.md
+++ b/README.md
@@ -87,10 +87,14 @@ cd AI_Secretary_System
 cp .env.docker .env
 # Edit .env: set GEMINI_API_KEY for cloud fallback
 
-# GPU Mode (XTTS + vLLM) - requires NVIDIA GPU 12GB+
-docker compose up -d
+# Option 1: Use LOCAL vLLM (recommended - faster, no 9GB download)
+./start_qwen.sh                    # Start local vLLM first
+docker compose up -d               # Start orchestrator + redis
 
-# CPU Mode (Piper + Gemini) - no GPU required
+# Option 2: FULL containerized (downloads ~9GB vLLM image)
+docker compose -f docker-compose.yml -f docker-compose.full.yml up -d
+
+# Option 3: CPU Mode (Piper + Gemini) - no GPU required
 docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d
 
 # Check status

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,15 +1,11 @@
 # =============================================================================
-# AI Secretary System - Docker Compose Override (CPU Mode)
+# AI Secretary System - CPU Mode (no GPU required)
 # =============================================================================
+#
+# Uses Piper TTS (CPU) + Gemini API instead of XTTS + vLLM.
 #
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d
-#
-# This override file:
-#   - Uses CPU-only image (smaller, no CUDA)
-#   - Disables vLLM service
-#   - Sets Gemini as default LLM backend
-#   - Uses Piper TTS instead of XTTS
 #
 # =============================================================================
 
@@ -19,25 +15,13 @@ services:
       target: cpu
     image: ai-secretary:cpu
     environment:
-      # Override to use cloud LLM
+      # Use cloud LLM instead of local vLLM
       - LLM_BACKEND=gemini
       - VLLM_API_URL=
+      - GEMINI_API_KEY=${GEMINI_API_KEY:?GEMINI_API_KEY required for CPU mode}
       # Disable CUDA
       - CUDA_VISIBLE_DEVICES=
-    depends_on:
-      redis:
-        condition: service_healthy
-      # Remove vLLM dependency
     deploy:
       resources:
         reservations:
-          devices: []
-
-  # Disable vLLM service in CPU mode
-  vllm:
-    profiles:
-      - gpu-only
-
-  # Redis still used for caching
-  redis:
-    # No changes needed
+          devices: []  # No GPU

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -1,0 +1,79 @@
+# =============================================================================
+# AI Secretary System - Full Containerized Setup (with vLLM container)
+# =============================================================================
+#
+# Use this for production deployment or CI/CD where you need everything in Docker.
+# WARNING: vLLM image is ~9GB, first pull takes time.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.full.yml up -d
+#
+# =============================================================================
+
+services:
+  orchestrator:
+    environment:
+      # Override to use containerized vLLM
+      - VLLM_API_URL=http://vllm:8000/v1
+    extra_hosts: []  # Remove host.docker.internal
+    depends_on:
+      redis:
+        condition: service_healthy
+      vllm:
+        condition: service_healthy
+    volumes:
+      # Persistent data
+      - ./data:/app/data
+      - ./logs:/app/logs
+      - ./models:/app/models
+      # Voice samples
+      - ./Гуля:/app/Гуля:ro
+      - ./Лидия:/app/Лидия:ro
+      # Named volumes for caches (not host mounts)
+      - tts_cache:/root/.local/share/tts
+      - hf_cache:/root/.cache/huggingface
+
+  # ---------------------------------------------------------------------------
+  # vLLM - Local LLM Inference Server (containerized)
+  # ---------------------------------------------------------------------------
+  vllm:
+    image: vllm/vllm-openai:latest
+    container_name: ai-secretary-vllm
+    command: >
+      --model ${VLLM_MODEL:-Qwen/Qwen2.5-7B-Instruct-AWQ}
+      --gpu-memory-utilization 0.5
+      --max-model-len 4096
+      --dtype float16
+      --max-num-seqs 32
+      --enforce-eager
+      --trust-remote-code
+      --host 0.0.0.0
+      --port 8000
+    volumes:
+      - hf_cache:/root/.cache/huggingface
+      - ./finetune/adapters:/app/adapters:ro
+    environment:
+      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+      - VLLM_LOGGING_LEVEL=WARNING
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+      start_period: 180s
+    restart: unless-stopped
+    networks:
+      - ai-secretary
+
+volumes:
+  tts_cache:
+    driver: local
+  hf_cache:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
 # =============================================================================
-# AI Secretary System - Docker Compose (GPU Mode)
+# AI Secretary System - Docker Compose
 # =============================================================================
 #
-# Usage:
-#   docker compose up -d                    # Start all services
-#   docker compose logs -f orchestrator     # View logs
-#   docker compose down                     # Stop all services
+# Default: Uses LOCAL vLLM (start with ./start_qwen.sh before docker compose)
 #
-# Requirements:
-#   - NVIDIA GPU with 12GB+ VRAM
-#   - NVIDIA Container Toolkit installed
-#   - Docker Compose v2.x
+# Usage:
+#   ./start_qwen.sh                    # Start local vLLM first
+#   docker compose up -d               # Start orchestrator + redis
+#   docker compose logs -f orchestrator
+#
+# For FULL containerized setup (downloads ~9GB vLLM image):
+#   docker compose -f docker-compose.yml -f docker-compose.full.yml up -d
 #
 # =============================================================================
 
@@ -32,19 +32,19 @@ services:
       - ./data:/app/data
       - ./logs:/app/logs
       - ./models:/app/models
-      # Voice samples (read-only, already in image but can override)
+      # Voice samples
       - ./Гуля:/app/Гуля:ro
       - ./Лидия:/app/Лидия:ro
-      # Model caches (named volumes for persistence)
-      - tts_cache:/root/.cache/tts_models
-      - hf_cache:/root/.cache/huggingface
+      # Mount LOCAL caches (no re-download)
+      - ${HOME}/.cache/huggingface:/root/.cache/huggingface
+      - ${HOME}/.local/share/tts:/root/.local/share/tts
     environment:
-      # LLM Configuration
+      # LLM - connect to LOCAL vLLM on host
       - LLM_BACKEND=${LLM_BACKEND:-vllm}
-      - VLLM_API_URL=http://vllm:8000/v1
+      - VLLM_API_URL=http://host.docker.internal:11434/v1
       - VLLM_MODEL_NAME=${VLLM_MODEL_NAME:-}
       - SECRETARY_PERSONA=${SECRETARY_PERSONA:-gulya}
-      # Cloud LLM (optional fallback)
+      # Cloud LLM fallback
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       # Database
       - REDIS_URL=redis://redis:6379/0
@@ -53,11 +53,11 @@ services:
       - ADMIN_JWT_SECRET=${ADMIN_JWT_SECRET:-}
       # TTS
       - COQUI_TOS_AGREED=1
-      - TTS_CACHE_PATH=/root/.cache/tts_models
+      - TTS_CACHE_PATH=/root/.local/share/tts
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       redis:
-        condition: service_healthy
-      vllm:
         condition: service_healthy
     deploy:
       resources:
@@ -75,45 +75,6 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
-
-  # ---------------------------------------------------------------------------
-  # vLLM - Local LLM Inference Server
-  # ---------------------------------------------------------------------------
-  vllm:
-    image: vllm/vllm-openai:latest
-    container_name: ai-secretary-vllm
-    command: >
-      --model ${VLLM_MODEL:-Qwen/Qwen2.5-7B-Instruct-AWQ}
-      --gpu-memory-utilization 0.5
-      --max-model-len 4096
-      --dtype float16
-      --max-num-seqs 32
-      --enforce-eager
-      --trust-remote-code
-      --host 0.0.0.0
-      --port 8000
-    volumes:
-      - hf_cache:/root/.cache/huggingface
-      - ./finetune/adapters:/app/adapters:ro
-    environment:
-      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
-      - VLLM_LOGGING_LEVEL=WARNING
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 20
-      start_period: 180s
-    restart: unless-stopped
-    networks:
-      - ai-secretary
 
   # ---------------------------------------------------------------------------
   # Redis - Caching and Rate Limiting
@@ -138,10 +99,6 @@ services:
 # =============================================================================
 volumes:
   redis_data:
-    driver: local
-  tts_cache:
-    driver: local
-  hf_cache:
     driver: local
 
 # =============================================================================

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pydub==0.25.1
 python-telegram-bot==21.0.1
 
 # AI Integration
-google-generativeai==0.3.2
+google-generativeai>=0.5.0
 requests==2.31.0
 aiohttp==3.9.1
 
@@ -31,8 +31,13 @@ aiohttp==3.9.1
 python-dotenv==1.0.0
 pydantic==2.5.3
 numpy==1.24.3
-torch==2.1.2
-torchaudio==2.1.2
+
+# PyTorch (installed separately in Dockerfile for CUDA support)
+# torch==2.3.1
+# torchaudio==2.3.1
+
+# Pin transformers for TTS compatibility
+transformers>=4.41.0,<5.0.0
 
 # System monitoring
 psutil==5.9.8


### PR DESCRIPTION
## Summary
- Docker compose now uses local vLLM by default (faster startup, no 9GB image download)
- Added `docker-compose.full.yml` for full containerized deployment when needed
- Updated Dockerfile to use nvidia/cuda base image with pip install PyTorch
- Fixed google-generativeai version (>=0.5.0) for system_instruction support
- Streamlined CLAUDE.md documentation (~40% reduction)

## Docker Usage Options

| Command | Description |
|---------|-------------|
| `./start_qwen.sh && docker compose up -d` | Local vLLM (recommended) |
| `docker compose -f docker-compose.yml -f docker-compose.full.yml up -d` | Full containerized |
| `docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d` | CPU mode (Gemini) |

## Test plan
- [x] Local vLLM + Docker orchestrator tested
- [x] Pre-commit hooks pass
- [ ] Full containerized mode (requires 9GB download)

🤖 Generated with [Claude Code](https://claude.ai/code)