### PR TITLE
fix(docker): Remove /v1 suffix from VLLM_API_URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     environment:
       # LLM - connect to LOCAL vLLM on host
       - LLM_BACKEND=${LLM_BACKEND:-vllm}
-      - VLLM_API_URL=http://host.docker.internal:11434/v1
+      - VLLM_API_URL=http://host.docker.internal:11434
       - VLLM_MODEL_NAME=${VLLM_MODEL_NAME:-}
       - SECRETARY_PERSONA=${SECRETARY_PERSONA:-gulya}
       # Cloud LLM fallback


### PR DESCRIPTION
The vllm_llm_service.py code already adds /v1 to the URL, so having it in the env var causes double path: /v1/v1/models

🤖 Generated with [Claude Code](https://claude.ai/code)