### PR TITLE
fix(deps): Pin transformers<4.45.0 for TTS compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,15 +29,15 @@ aiohttp==3.9.1
 
 # Utils
 python-dotenv==1.0.0
-pydantic==2.5.3
+pydantic>=2.7.0
 numpy==1.24.3
 
 # PyTorch (installed separately in Dockerfile for CUDA support)
 # torch==2.3.1
 # torchaudio==2.3.1
 
-# Pin transformers for TTS compatibility
-transformers>=4.41.0,<5.0.0
+# Pin transformers for TTS compatibility (4.45+ breaks BeamSearchScorer import)
+transformers>=4.41.0,<4.45.0
 
 # System monitoring
 psutil==5.9.8


### PR DESCRIPTION
transformers 4.45+ removed BeamSearchScorer which breaks XTTS voice cloning.

Also updates pydantic>=2.7.0 for fastapi compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)