### PR TITLE
feat: Add chat management features and rename Gemini to Cloud AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,26 @@ docker compose down
 - NVIDIA Container Toolkit (GPU mode only)
 - 12GB+ VRAM (GPU) or Gemini API key (CPU)
 
+**vLLM в Docker режиме:**
+
+vLLM автоматически запускается как отдельный контейнер при переключении LLM backend в админ-панели.
+
+```bash
+# Первый раз: скачать образ vLLM (~9GB, одноразово)
+docker pull vllm/vllm-openai:latest
+
+# После этого переключение на vLLM в Admin Panel → LLM → Backend
+# автоматически создаст и запустит vLLM контейнер
+
+# Проверить статус vLLM контейнера
+docker ps | grep vllm
+
+# Логи vLLM
+docker logs ai-secretary-vllm
+```
+
+Загрузка модели при первом запуске занимает 2-3 минуты.
+
 ## Quick Start (Local Development)
 
 ```bash
@@ -148,7 +168,7 @@ open http://localhost:8002/admin
 | Tab | Description |
 |-----|-------------|
 | **Dashboard** | Статусы сервисов, GPU спарклайны, health индикаторы |
-| **Chat** | Чат с ИИ, Voice Mode (auto-TTS), голосовой ввод (STT), редактирование промптов |
+| **Chat** | Чат с ИИ, Voice Mode (auto-TTS), голосовой ввод (STT), редактирование промптов, управление чатами (rename, bulk delete, grouping) |
 | **Services** | Запуск/остановка vLLM, SSE логи в реальном времени |
 | **LLM** | Выбор модели (Qwen/Llama/DeepSeek), персоны, параметры генерации |
 | **TTS** | Выбор голоса, пресеты XTTS, тестирование синтеза |
@@ -175,6 +195,7 @@ open http://localhost:8002/admin
 | **Voice Mode** | Auto-play TTS при получении ответа |
 | **Voice Input** | Голосовой ввод через микрофон (STT) |
 | **Prompt Editor** | Редактирование дефолтного промпта из чата |
+| **Chat Management** | Переименование, групповое удаление, группировка по источнику (Admin/Telegram/Widget) |
 | **Charts** | Спарклайны и графики на Chart.js |
 | **Command Palette** | Быстрый поиск ⌘K / Ctrl+K |
 | **Audit Log** | Логирование всех действий пользователей |
@@ -285,7 +306,7 @@ curl -X POST http://localhost:8002/admin/stt/transcribe \
 
 | Таблица | Назначение |
 |---------|------------|
-| `chat_sessions` | Сессии чата (id, title, system_prompt) |
+| `chat_sessions` | Сессии чата (id, title, system_prompt, source, source_id) |
 | `chat_messages` | Сообщения (role, content, timestamp) |
 | `faq_entries` | FAQ вопрос-ответ |
 | `tts_presets` | Пользовательские пресеты TTS |
@@ -493,7 +514,7 @@ open http://localhost:8002/admin → LLM tab
 |---------|-------|-------|--------------|
 | `vllm` | Qwen2.5-7B + LoRA | Fast | GPU 12GB+ |
 | `vllm` | Llama-3.1-8B GPTQ | Fast | GPU 12GB+ |
-| `gemini` | Gemini 2.5 Pro | Variable | API key |
+| `gemini` (Cloud AI) | Any cloud provider | Variable | API key |
 
 **Switching Backend:**
 ```bash
@@ -672,9 +693,11 @@ GET  /admin/telegram/instances/{id}/logs    # Bot logs
 
 # Chat
 GET  /admin/chat/sessions            # List chat sessions
-POST /admin/chat/sessions            # Create session
+GET  /admin/chat/sessions?group_by=source # List grouped by source (admin/telegram/widget)
+POST /admin/chat/sessions            # Create session (with source tracking)
+POST /admin/chat/sessions/bulk-delete # Bulk delete sessions
 GET  /admin/chat/sessions/{id}       # Get session
-PUT  /admin/chat/sessions/{id}       # Update session
+PUT  /admin/chat/sessions/{id}       # Update session (rename)
 DELETE /admin/chat/sessions/{id}     # Delete session
 POST /admin/chat/sessions/{id}/messages # Send message
 POST /admin/chat/sessions/{id}/stream   # SSE streaming chat
@@ -1018,6 +1041,8 @@ npm run build
 - [x] **Multi-Instance Bots/Widgets** — несколько ботов и виджетов с независимыми настройками
 - [x] **Docker Compose** — one-command deployment (GPU + CPU режимы)
 - [x] **Code Quality** — ruff, mypy, eslint, pre-commit hooks
+- [x] **Chat Management** — переименование, групповое удаление, группировка по источнику
+- [x] **Source Tracking** — отслеживание источника чат-сессий (admin/telegram/widget)
 
 **В планах:**
 - [ ] Телефония SIM7600G-H (AT-команды)

--- a/admin/src/plugins/i18n.ts
+++ b/admin/src/plugins/i18n.ts
@@ -72,7 +72,10 @@ const messages = {
       topP: 'Top P',
       repetitionPenalty: 'Штраф повтора',
       systemPrompt: 'Системный промпт',
-      resetPrompt: 'Сбросить промпт'
+      resetPrompt: 'Сбросить промпт',
+      vllmLocal: 'vLLM (Local)',
+      cloudAI: 'Облачный ИИ',
+      stopVllmHint: 'Остановить vLLM при переключении на облачный ИИ (освободит ~6GB GPU)'
     },
     // Cloud Providers
     cloudProviders: {
@@ -170,6 +173,29 @@ const messages = {
       settings: 'Настройки',
       copy: 'Копировать',
       copied: 'Скопировано'
+    },
+    // Chat View
+    chatView: {
+      title: 'Чаты',
+      newChat: 'Новый чат',
+      deleteChat: 'Удалить чат',
+      deleteSelected: 'Удалить выбранные',
+      selectAll: 'Выбрать все',
+      deselectAll: 'Снять выделение',
+      selectedCount: 'Выбрано: {count}',
+      rename: 'Переименовать',
+      confirmDelete: 'Удалить чат "{title}"?',
+      confirmBulkDelete: 'Удалить {count} чатов?',
+      deleteWarning: 'Это действие нельзя отменить',
+      noChats: 'Нет чатов',
+      noChatsInGroup: 'Нет чатов в этой группе',
+      createFirst: 'Создать первый чат',
+      groups: {
+        admin: 'Админ-панель',
+        telegram: 'Telegram',
+        widget: 'Виджет',
+        unknown: 'Другие'
+      }
     },
     // Auth
     auth: {
@@ -493,7 +519,10 @@ const messages = {
       topP: 'Top P',
       repetitionPenalty: 'Repetition Penalty',
       systemPrompt: 'System Prompt',
-      resetPrompt: 'Reset Prompt'
+      resetPrompt: 'Reset Prompt',
+      vllmLocal: 'vLLM (Local)',
+      cloudAI: 'Cloud AI',
+      stopVllmHint: 'Stop vLLM when switching to Cloud AI (will free ~6GB GPU)'
     },
     // Cloud LLM Providers
     cloudProviders: {
@@ -591,6 +620,29 @@ const messages = {
       settings: 'Settings',
       copy: 'Copy',
       copied: 'Copied'
+    },
+    // Chat View
+    chatView: {
+      title: 'Chats',
+      newChat: 'New Chat',
+      deleteChat: 'Delete chat',
+      deleteSelected: 'Delete selected',
+      selectAll: 'Select all',
+      deselectAll: 'Deselect all',
+      selectedCount: 'Selected: {count}',
+      rename: 'Rename',
+      confirmDelete: 'Delete chat "{title}"?',
+      confirmBulkDelete: 'Delete {count} chats?',
+      deleteWarning: 'This action cannot be undone',
+      noChats: 'No chats',
+      noChatsInGroup: 'No chats in this group',
+      createFirst: 'Create first chat',
+      groups: {
+        admin: 'Admin Panel',
+        telegram: 'Telegram',
+        widget: 'Widget',
+        unknown: 'Other'
+      }
     },
     // Auth
     auth: {

--- a/admin/src/views/LlmView.vue
+++ b/admin/src/views/LlmView.vue
@@ -24,8 +24,10 @@ import {
   RefreshCw
 } from 'lucide-vue-next'
 import { ref, computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useToastStore } from '@/stores/toast'
 
+const { t } = useI18n()
 const queryClient = useQueryClient()
 const toast = useToastStore()
 
@@ -338,7 +340,7 @@ function switchToCloudProvider(providerId: string) {
                 @click="setBackendMutation.mutate('gemini')"
               >
                 <Loader2 v-if="setBackendMutation.isPending.value && isVllm" class="w-4 h-4 animate-spin" />
-                Gemini (Cloud)
+                {{ t('llm.cloudAI') }}
               </button>
             </div>
           </div>
@@ -367,7 +369,7 @@ function switchToCloudProvider(providerId: string) {
               class="w-4 h-4 rounded border-border"
             />
             <label for="stopVllm" class="text-sm text-muted-foreground">
-              Остановить vLLM при переключении на Gemini (освободит ~6GB GPU)
+              {{ t('llm.stopVllmHint') }}
             </label>
           </div>
 

--- a/admin/src/views/TelegramView.vue
+++ b/admin/src/views/TelegramView.vue
@@ -933,7 +933,7 @@ watch(instances, (newInstances) => {
                   class="w-full px-3 py-2 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 >
                   <option value="vllm">vLLM</option>
-                  <option value="gemini">Gemini</option>
+                  <option value="gemini">{{ t('llm.cloudAI') }}</option>
                 </select>
               </div>
               <div>
@@ -1146,8 +1146,8 @@ watch(instances, (newInstances) => {
                 class="w-full px-3 py-2 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
               >
                 <option value="">{{ t('telegram.useDefaultBackend') }}</option>
-                <option value="vllm">vLLM (Local)</option>
-                <option value="gemini">Gemini</option>
+                <option value="vllm">{{ t('llm.vllmLocal') }}</option>
+                <option value="gemini">{{ t('llm.cloudAI') }}</option>
               </select>
               <p class="text-xs text-muted-foreground mt-1">
                 Cloud providers can be configured as "cloud:provider-id"

--- a/admin/src/views/WidgetView.vue
+++ b/admin/src/views/WidgetView.vue
@@ -767,7 +767,7 @@ watch(instances, (newInstances) => {
                   class="w-full px-3 py-2 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 >
                   <option value="vllm">vLLM</option>
-                  <option value="gemini">Gemini</option>
+                  <option value="gemini">{{ t('llm.cloudAI') }}</option>
                 </select>
               </div>
               <div>

--- a/db/integration.py
+++ b/db/integration.py
@@ -116,11 +116,13 @@ class AsyncChatManager:
         self,
         title: str = None,
         system_prompt: str = None,
+        source: str = None,
+        source_id: str = None,
     ) -> dict:
         """Create new session."""
         async with AsyncSessionLocal() as session:
             repo = ChatRepository(session)
-            return await repo.create_session(title, system_prompt)
+            return await repo.create_session(title, system_prompt, source, source_id)
 
     async def update_session(
         self,
@@ -138,6 +140,18 @@ class AsyncChatManager:
         async with AsyncSessionLocal() as session:
             repo = ChatRepository(session)
             return await repo.delete_session(session_id)
+
+    async def delete_sessions_bulk(self, session_ids: List[str]) -> int:
+        """Delete multiple sessions by ID list."""
+        async with AsyncSessionLocal() as session:
+            repo = ChatRepository(session)
+            return await repo.delete_sessions_bulk(session_ids)
+
+    async def list_sessions_grouped(self) -> dict:
+        """Get sessions grouped by source."""
+        async with AsyncSessionLocal() as session:
+            repo = ChatRepository(session)
+            return await repo.list_sessions_grouped()
 
     async def add_message(
         self,

--- a/db/models.py
+++ b/db/models.py
@@ -49,6 +49,10 @@ class ChatSession(Base):
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
     )
 
+    # Source tracking (admin, telegram, widget)
+    source: Mapped[Optional[str]] = mapped_column(String(20), nullable=True, index=True)
+    source_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+
     # Relationships
     messages: Mapped[List["ChatMessage"]] = relationship(
         "ChatMessage",
@@ -62,6 +66,8 @@ class ChatSession(Base):
             "id": self.id,
             "title": self.title,
             "system_prompt": self.system_prompt,
+            "source": self.source,
+            "source_id": self.source_id,
             "created": self.created.isoformat() if self.created else None,
             "updated": self.updated.isoformat() if self.updated else None,
         }
@@ -78,6 +84,8 @@ class ChatSession(Base):
             "title": self.title,
             "message_count": len(messages),
             "last_message": last_msg,
+            "source": self.source,
+            "source_id": self.source_id,
             "created": self.created.isoformat() if self.created else None,
             "updated": self.updated.isoformat() if self.updated else None,
         }

--- a/telegram_bot_service.py
+++ b/telegram_bot_service.py
@@ -309,6 +309,8 @@ class TelegramBotService:
                 json={
                     "title": title,
                     "system_prompt": self.config.get("system_prompt"),
+                    "source": "telegram",
+                    "source_id": f"{self.instance_id}:{user_id}",
                 },
             ) as resp:
                 if resp.status == 200:


### PR DESCRIPTION
## Summary
- ✨ **Chat Management** — inline rename, bulk delete, grouping by source (Admin/Telegram/Widget)
- 🏷️ **Source Tracking** — chat sessions track origin for better organization
- ☁️ **Cloud AI Label** — renamed "Gemini" to "Cloud AI" for generic cloud provider support

## Changes

### Chat Management (Frontend)
- Inline rename: double-click chat title to edit
- Bulk delete: toggle selection mode, select multiple chats, delete at once
- Grouping: collapsible sections by source (Admin Panel, Telegram, Widget, Other)
- Individual delete buttons on hover for each chat

### Backend
- Added `source`, `source_id` fields to `ChatSession` model
- New endpoint: `POST /admin/chat/sessions/bulk-delete`
- New query: `GET /admin/chat/sessions?group_by=source`
- Updated `create_session()` to accept source parameter
- Telegram bot passes `source="telegram"` when creating sessions

### UI Labels
- "Gemini (Cloud)" → "Cloud AI" / "Облачный ИИ"
- Updated in LLM settings, Telegram, and Widget configuration pages

## Test plan
- [ ] Create new chat from admin panel → should have `source="admin"`
- [ ] Create chat from Telegram bot → should have `source="telegram"`
- [ ] Double-click chat title → inline edit appears
- [ ] Toggle selection mode → checkboxes appear
- [ ] Select multiple chats and delete → confirmation dialog → all deleted
- [ ] Groups should be collapsible

🤖 Generated with [Claude Code](https://claude.ai/claude-code)