### PR TITLE
feat(llm): Add automatic vLLM Docker container management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,7 +288,7 @@ Key patterns:
 3. **GPU memory sharing** — vLLM 50% (~6GB) + XTTS ~5GB on 12GB GPU
 4. **OpenWebUI Docker** — Use `172.17.0.1` not `localhost` for API URL
 5. **Ruff ignores Cyrillic** — RUF001/002/003 disabled to allow Russian strings in code
-6. **Docker + vLLM** — vLLM runs on host, not in container. Start `./start_qwen.sh` before switching to vLLM in admin panel
+6. **Docker + vLLM** — vLLM автоматически запускается как контейнер при переключении в админке. Первый раз нужно скачать образ: `docker pull vllm/vllm-openai:latest` (~9GB)
 
 ## Configuration Files
 
@@ -308,6 +308,7 @@ See [BACKLOG.md](./BACKLOG.md) for task tracking and [docs/IMPROVEMENT_PLAN.md](
 **Current focus:** Foundation (security, testing) → Monetization → GSM Telephony
 
 **Recently completed:**
+- ✅ **vLLM Docker Management** — Auto-start vLLM container from admin panel via Docker SDK
 - ✅ **Chat Management** — Inline rename, bulk delete, grouping by source (Admin/Telegram/Widget)
 - ✅ **Source Tracking** — Chat sessions track origin (admin panel, telegram bot, widget)
 - ✅ **Cloud AI Label** — Renamed "Gemini" to "Cloud AI" for generic cloud provider support

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,16 @@
 # AI Secretary System - Docker Compose
 # =============================================================================
 #
-# Default: Uses LOCAL vLLM (start with ./start_qwen.sh before docker compose)
-#
 # Usage:
-#   ./start_qwen.sh                    # Start local vLLM first
 #   docker compose up -d               # Start orchestrator + redis
 #   docker compose logs -f orchestrator
 #
-# For FULL containerized setup (downloads ~9GB vLLM image):
-#   docker compose -f docker-compose.yml -f docker-compose.full.yml up -d
+# vLLM is started automatically from Admin Panel when switching LLM backend.
+# First start downloads ~9GB vLLM image.
+#
+# For manual vLLM control:
+#   docker compose up -d vllm          # Start vLLM manually
+#   docker compose stop vllm           # Stop vLLM
 #
 # =============================================================================
 
@@ -38,17 +39,23 @@ services:
       # Mount LOCAL caches (no re-download)
       - ${HOME}/.cache/huggingface:/root/.cache/huggingface
       - ${HOME}/.local/share/tts:/root/.local/share/tts
+      # Docker socket for managing vLLM container
+      - /var/run/docker.sock:/var/run/docker.sock
       # DEV: Mount source code for hot-reload (remove in production)
       - ./orchestrator.py:/app/orchestrator.py:ro
       - ./cloud_llm_service.py:/app/cloud_llm_service.py:ro
       - ./voice_clone_service.py:/app/voice_clone_service.py:ro
+      - ./service_manager.py:/app/service_manager.py:ro
       - ./db:/app/db:ro
       - ./app:/app/app:ro
       - ./admin/dist:/app/admin/dist:ro
     environment:
-      # LLM - connect to LOCAL vLLM on host
-      - LLM_BACKEND=${LLM_BACKEND:-vllm}
-      - VLLM_API_URL=http://host.docker.internal:11434
+      # Docker mode detection
+      - DOCKER_CONTAINER=1
+      - VLLM_CONTAINER_NAME=ai-secretary-vllm
+      # LLM - connect to vLLM container
+      - LLM_BACKEND=${LLM_BACKEND:-gemini}
+      - VLLM_API_URL=http://ai-secretary-vllm:8000/v1
       - VLLM_MODEL_NAME=${VLLM_MODEL_NAME:-}
       - SECRETARY_PERSONA=${SECRETARY_PERSONA:-gulya}
       # Cloud LLM fallback
@@ -99,6 +106,46 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    restart: unless-stopped
+    networks:
+      - ai-secretary
+
+  # ---------------------------------------------------------------------------
+  # vLLM - Local LLM Inference Server (started on demand from Admin Panel)
+  # ---------------------------------------------------------------------------
+  vllm:
+    image: vllm/vllm-openai:latest
+    container_name: ai-secretary-vllm
+    profiles: ["vllm"]  # Not started by default, use: docker compose --profile vllm up -d
+    command: >
+      --model ${VLLM_MODEL:-Qwen/Qwen2.5-7B-Instruct-AWQ}
+      --gpu-memory-utilization 0.5
+      --max-model-len 4096
+      --dtype float16
+      --max-num-seqs 32
+      --enforce-eager
+      --trust-remote-code
+      --host 0.0.0.0
+      --port 8000
+    volumes:
+      - ${HOME}/.cache/huggingface:/root/.cache/huggingface
+      - ./finetune/adapters:/app/adapters:ro
+    environment:
+      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+      - VLLM_LOGGING_LEVEL=WARNING
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ['0']  # Use first available GPU for vLLM
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+      start_period: 180s
     restart: unless-stopped
     networks:
       - ai-secretary

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,6 @@ aiosqlite==0.19.0
 sqlalchemy[asyncio]==2.0.25
 alembic==1.18.1
 redis>=5.0.0
+
+# Docker management (for starting vLLM from container)
+docker>=7.0.0


### PR DESCRIPTION
## Summary

- Add Docker SDK integration to `service_manager.py` for vLLM container control
- Auto-start vLLM container when switching LLM backend in admin panel
- Works in both Docker and local development modes

## Changes

- **service_manager.py**: New methods for Docker container management (`_start_vllm_container`, `_stop_vllm_container`, `_is_vllm_container_running`)
- **docker-compose.yml**: Added vLLM service with profile, docker.sock mount
- **app/routers/llm.py**: Updated to use service manager for vLLM control
- **requirements.txt**: Added `docker>=7.0.0`
- **CLAUDE.md, README.md**: Updated documentation

## How it works

```
Admin Panel → Switch to vLLM → service_manager._start_vllm_container() → Docker SDK → vLLM container starts
```

## First-time setup

```bash
docker pull vllm/vllm-openai:latest  # ~9GB, one-time download
```

## Test plan

- [ ] Test switching to vLLM in Docker mode
- [ ] Test switching to vLLM in local mode
- [ ] Test stopping vLLM container
- [ ] Verify vLLM container connects to orchestrator network

🤖 Generated with [Claude Code](https://claude.com/claude-code)