### PR TITLE
feat(admin): Multiple VLESS proxy support with fallback

### DIFF
--- a/admin/src/api/llm.ts
+++ b/admin/src/api/llm.ts
@@ -58,6 +58,16 @@ export interface LlmModelInfo {
 }
 
 // VLESS Proxy types
+export interface ProxyInfo {
+  index: number
+  remark: string
+  server: string
+  security: string
+  enabled: boolean
+  fail_count: number
+  is_current: boolean
+}
+
 export interface ProxyStatus {
   xray_available: boolean
   xray_path?: string | null
@@ -65,6 +75,19 @@ export interface ProxyStatus {
   socks_port?: number
   http_port?: number
   configured: boolean
+  fallback_enabled?: boolean
+  total_proxies?: number
+  enabled_proxies?: number
+  current_proxy_index?: number
+  current_proxy?: {
+    remark: string
+    server: string
+    security: string
+    fail_count: number
+    enabled: boolean
+  } | null
+  proxies?: ProxyInfo[]
+  // Legacy single proxy fields
   vless_server?: string | null
   vless_security?: string | null
 }
@@ -74,10 +97,20 @@ export interface ProxyTestResult {
   success: boolean
   message?: string
   error?: string
+  proxy_index?: number
+  proxy_remark?: string
   details?: {
     target?: string
     status_code?: number
   }
+}
+
+export interface ProxyTestMultipleResult {
+  status: string
+  total: number
+  successful: number
+  results: ProxyTestResult[]
+  error?: string
 }
 
 export interface VlessValidation {
@@ -186,6 +219,15 @@ export const llmApi = {
   testProxy: (vlessUrl: string) =>
     api.post<ProxyTestResult>('/admin/llm/proxy/test', { vless_url: vlessUrl }),
 
+  testMultipleProxies: (vlessUrls: string[]) =>
+    api.post<ProxyTestMultipleResult>('/admin/llm/proxy/test-multiple', { vless_urls: vlessUrls }),
+
   validateVlessUrl: (vlessUrl: string) =>
     api.get<VlessValidation>(`/admin/llm/proxy/validate?vless_url=${encodeURIComponent(vlessUrl)}`),
+
+  resetProxies: () =>
+    api.post<{ status: string; message: string }>('/admin/llm/proxy/reset'),
+
+  switchToNextProxy: () =>
+    api.post<{ status: string; proxy: ProxyStatus }>('/admin/llm/proxy/switch-next'),
 }


### PR DESCRIPTION
## Summary
- Add textarea for multiple VLESS URLs (one per line) in Gemini provider settings
- Show proxy count badge on provider cards (e.g. "2 Proxy")
- Add "Test All Proxies" button with per-proxy test results
- Support automatic failover when a proxy becomes unavailable

## Changes
- `admin/src/api/llm.ts`: Add ProxyInfo, ProxyTestMultipleResult types and new API methods
- `admin/src/views/LlmView.vue`: Update VLESS proxy UI to support multiple URLs

## Test plan
- [ ] Create Gemini provider with multiple VLESS URLs
- [ ] Test all proxies - verify individual results shown
- [ ] Save provider - verify vless_urls array in config
- [ ] Edit provider - verify URLs loaded correctly
- [ ] Backend fallback tested separately via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)