### PR TITLE
feat(telegram): Persist bot running state and auto-start on app launch

### DIFF
--- a/db/integration.py
+++ b/db/integration.py
@@ -459,6 +459,18 @@ class AsyncBotInstanceManager:
             repo = BotInstanceRepository(session)
             return await repo.set_enabled(instance_id, enabled)
 
+    async def set_auto_start(self, instance_id: str, auto_start: bool) -> bool:
+        """Set auto-start flag for bot instance."""
+        async with AsyncSessionLocal() as session:
+            repo = BotInstanceRepository(session)
+            return await repo.set_auto_start(instance_id, auto_start)
+
+    async def get_auto_start_instances(self) -> List[dict]:
+        """Get all bot instances that should auto-start."""
+        async with AsyncSessionLocal() as session:
+            repo = BotInstanceRepository(session)
+            return await repo.get_auto_start_instances()
+
     async def get_enabled_instances(self) -> List[dict]:
         """Get all enabled bot instances."""
         async with AsyncSessionLocal() as session:

--- a/scripts/migrations/add_auto_start.sql
+++ b/scripts/migrations/add_auto_start.sql
@@ -1,0 +1,4 @@
+-- Migration: Add auto_start column to bot_instances
+-- Run: sqlite3 data/secretary.db < scripts/migrations/add_auto_start.sql
+
+ALTER TABLE bot_instances ADD COLUMN auto_start BOOLEAN DEFAULT 0;


### PR DESCRIPTION
## Summary
- Add `auto_start` field to BotInstance model
- When bot is started via UI, set `auto_start=True`
- When bot is stopped via UI, set `auto_start=False`
- On app startup, automatically start all bots with `auto_start=True`
- Add migration script for existing databases

## How it works
1. User starts a Telegram bot → `auto_start` saved as `true` in DB
2. User stops a Telegram bot → `auto_start` saved as `false` in DB
3. App/container restarts → all bots with `auto_start=true` automatically start

## Migration
For existing databases, run:
```sql
ALTER TABLE bot_instances ADD COLUMN auto_start BOOLEAN DEFAULT 0;
```
Or the migration script will be created automatically on next schema update.

## Test plan
- [ ] Start a bot, restart container, verify bot auto-starts
- [ ] Stop a bot, restart container, verify bot stays stopped
- [ ] Check startup logs for "Auto-started Telegram bot" messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)