### PR TITLE
fix: amoCRM proxy for Docker/VPN + always-visible credentials UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ GitHub Actions (`.github/workflows/ci.yml`) runs on push to `main`/`develop` and
 
 **Cloud LLM routing**: `cloud_llm_service.py` has `CloudLLMService` with a factory pattern. OpenAI-compatible providers use `OpenAICompatibleProvider` automatically. Custom SDKs (Gemini) get their own provider class inheriting `BaseLLMProvider`. Provider types defined in `PROVIDER_TYPES` dict in `db/models.py`.
 
-**amoCRM integration**: `app/services/amocrm_service.py` is a pure async HTTP client (no DB). `app/routers/amocrm.py` handles OAuth2 flow, token auto-refresh, and proxies API calls. Config/tokens stored via `AsyncAmoCRMManager` in `db/integration.py`. Webhook at `POST /webhooks/amocrm`.
+**amoCRM integration**: `app/services/amocrm_service.py` is a pure async HTTP client (no DB) with optional proxy support (`AMOCRM_PROXY` env var for Docker/VPN environments). `app/routers/amocrm.py` handles OAuth2 flow, token auto-refresh, and proxies API calls. Config/tokens stored via `AsyncAmoCRMManager` in `db/integration.py`. Webhook at `POST /webhooks/amocrm`. For private amoCRM integrations, auth codes are obtained from the integration settings (not OAuth redirect). If Docker can't reach amoCRM (VPN on host), run `scripts/amocrm_proxy.py` on the host.
 
 ## Code Patterns
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,8 @@ services:
       - DATABASE_URL=sqlite+aiosqlite:///data/secretary.db
       # Security
       - ADMIN_JWT_SECRET=${ADMIN_JWT_SECRET:-}
+      # amoCRM proxy (run scripts/amocrm_proxy.py on host)
+      - AMOCRM_PROXY=${AMOCRM_PROXY:-http://host.docker.internal:8899}
       # TTS
       - COQUI_TOS_AGREED=1
       - TTS_CACHE_PATH=/root/.local/share/tts

--- a/scripts/amocrm_proxy.py
+++ b/scripts/amocrm_proxy.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Minimal HTTP CONNECT proxy for amoCRM API.
+
+Allows the Docker container to reach amoCRM via the host's network (and VPN).
+Run on the host: python3 scripts/amocrm_proxy.py
+Then set AMOCRM_PROXY=http://host.docker.internal:8899 in docker-compose.yml.
+"""
+
+import asyncio
+import logging
+import sys
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [proxy] %(message)s")
+logger = logging.getLogger(__name__)
+
+LISTEN_HOST = "0.0.0.0"
+LISTEN_PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8899
+
+
+async def _forward(src: asyncio.StreamReader, dst: asyncio.StreamWriter):
+    try:
+        while True:
+            data = await src.read(65536)
+            if not data:
+                break
+            dst.write(data)
+            await dst.drain()
+    except (ConnectionResetError, BrokenPipeError, asyncio.CancelledError):
+        pass
+    finally:
+        try:
+            dst.close()
+        except Exception:
+            pass
+
+
+async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+    try:
+        header = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=10)
+    except (asyncio.TimeoutError, asyncio.IncompleteReadError):
+        writer.close()
+        return
+
+    first_line = header.split(b"\r\n")[0].decode()
+    parts = first_line.split()
+    if len(parts) < 3 or parts[0] != "CONNECT":
+        writer.write(b"HTTP/1.1 405 Method Not Allowed\r\n\r\n")
+        writer.close()
+        return
+
+    target = parts[1]
+    if ":" in target:
+        host, port_str = target.rsplit(":", 1)
+        port = int(port_str)
+    else:
+        host, port = target, 443
+
+    try:
+        t_reader, t_writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout=15)
+    except Exception as e:
+        logger.warning(f"Cannot connect to {host}:{port}: {e}")
+        writer.write(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+        writer.close()
+        return
+
+    logger.info(f"CONNECT {host}:{port}")
+    writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+    await writer.drain()
+
+    await asyncio.gather(
+        _forward(reader, t_writer),
+        _forward(t_reader, writer),
+    )
+
+
+async def main():
+    server = await asyncio.start_server(handle_client, LISTEN_HOST, LISTEN_PORT)
+    logger.info(f"amoCRM proxy listening on {LISTEN_HOST}:{LISTEN_PORT}")
+    async with server:
+        await server.serve_forever()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.info("Proxy stopped")


### PR DESCRIPTION
## Summary
- **amoCRM proxy**: Added `AMOCRM_PROXY` env var and `scripts/amocrm_proxy.py` HTTP CONNECT proxy — fixes Docker containers that can't reach amoCRM due to host VPN (AmneziaVPN/WireGuard)
- **OAuth fix**: Removed `mode=post_message` from OAuth URL which broke private amoCRM integrations
- **CRM admin UI**: Credentials form (subdomain, client_id, client_secret, redirect_uri) is now always visible and editable, not hidden after connection
- **Docs**: Updated CLAUDE.md with proxy setup instructions

Closes #90

## Test plan
- [ ] Verify amoCRM API works from Docker container through proxy (`scripts/amocrm_proxy.py` running on host)
- [ ] Verify CRM admin panel shows credentials fields in both connected and disconnected states
- [ ] Verify saving settings preserves credentials, sends secret only when changed
- [ ] Verify token auto-refresh works through proxy

## NEWS

🔗 amoCRM теперь полностью подключен к AI Secretary!
Контакты, сделки и воронки синхронизируются автоматически.
Настройка прямо из админ-панели — субдомен, ключи и статус всегда на виду.
Работает даже через VPN — никаких ограничений сети.

🤖 Generated with [Claude Code](https://claude.com/claude-code)