### PR TITLE
feat(widget): test chat tab in widget editor

### DIFF
--- a/admin/src/api/client.ts
+++ b/admin/src/api/client.ts
@@ -13,7 +13,7 @@ export interface ApiResponse<T> {
 }
 
 // Get auth headers from localStorage
-function getAuthHeaders(): Record<string, string> {
+export function getAuthHeaders(): Record<string, string> {
   const token = localStorage.getItem('admin_token')
   if (token) {
     return { 'Authorization': `Bearer ${token}` }

--- a/admin/src/plugins/i18n.ts
+++ b/admin/src/plugins/i18n.ts
@@ -305,7 +305,8 @@ const messages = {
         appearance: 'Внешний вид',
         domains: 'Домены',
         ai: 'AI настройки',
-        code: 'Код'
+        code: 'Код',
+        test: 'Тест'
       },
       tunnelUrl: 'URL туннеля',
       tunnelUrlDesc: 'Публичный URL для доступа к API (ngrok, Cloudflare Tunnel)',
@@ -357,7 +358,14 @@ const messages = {
       helperScript: 'Скрипт для запуска',
       helperScriptDesc: 'Запустите AI Secretary вместе с туннелем одной командой',
       recommended: 'рекомендуется',
-      or: 'или'
+      or: 'или',
+      testChat: 'Тест чата',
+      testChatDesc: 'Проверьте работу виджета прямо здесь',
+      testSend: 'Отправить',
+      testClearChat: 'Очистить чат',
+      testPlaceholder: 'Введите сообщение...',
+      testSessionCreated: 'Сессия создана',
+      testNoMessages: 'Начните диалог для проверки виджета'
     },
     // Telegram
     telegram: {
@@ -1009,7 +1017,8 @@ const messages = {
         appearance: 'Appearance',
         domains: 'Domains',
         ai: 'AI Settings',
-        code: 'Code'
+        code: 'Code',
+        test: 'Test'
       },
       tunnelUrl: 'Tunnel URL',
       tunnelUrlDesc: 'Public URL to access API (ngrok, Cloudflare Tunnel)',
@@ -1061,7 +1070,14 @@ const messages = {
       helperScript: 'Startup script',
       helperScriptDesc: 'Start AI Secretary with tunnel in one command',
       recommended: 'recommended',
-      or: 'or'
+      or: 'or',
+      testChat: 'Test Chat',
+      testChatDesc: 'Test widget chat right here',
+      testSend: 'Send',
+      testClearChat: 'Clear chat',
+      testPlaceholder: 'Type a message...',
+      testSessionCreated: 'Session created',
+      testNoMessages: 'Start a conversation to test the widget'
     },
     // Telegram
     telegram: {


### PR DESCRIPTION
## Summary

- Add "Test" tab to widget instance editor with embedded live chat
- Chat uses the widget's own LLM backend and system prompt via `widget_instance_id`
- Streaming responses with animated typing indicator
- Session auto-creation per widget instance, clear/reset support
- Export `getAuthHeaders` from API client for authenticated SSE streaming
- i18n translations (ru/en) for all test chat UI elements

Relates to #120

## Test plan

- [ ] Open Widget editor → select a widget → click "Test" tab
- [ ] Send a message, verify streaming response appears
- [ ] Switch to another widget, verify chat resets
- [ ] Click "Clear chat" to reset session
- [ ] Verify widget greeting displays when no messages
- [ ] Check that LLM backend badge shows correct provider

## NEWS

💬 Теперь виджеты можно тестировать прямо в админке! Открываете настройки виджета, переходите на вкладку «Тест» — и общаетесь с ботом как настоящий посетитель сайта. Никаких переключений между окнами, всё в одном месте.

🤖 Generated with [Claude Code](https://claude.com/claude-code)