### PR TITLE
fix: complete CLAUDE.md docs + force SW cache clear

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -65,9 +65,17 @@
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
 
-    <!-- Service Worker Registration -->
+    <!-- Force clear old SW caches, then register new SW -->
     <script>
       if ('serviceWorker' in navigator) {
+        // Unregister all old service workers first
+        navigator.serviceWorker.getRegistrations().then(regs => {
+          regs.forEach(r => r.unregister());
+        });
+        // Clear all caches
+        if ('caches' in window) {
+          caches.keys().then(names => names.forEach(n => caches.delete(n)));
+        }
         window.addEventListener('load', () => {
           navigator.serviceWorker.register('./sw.js')
             .then(reg => console.log('SW registered:', reg.scope))


### PR DESCRIPTION
## Summary

- Complete CLAUDE.md Database Migrations section with all 10 migration/seed scripts
- Document pytest `asyncio_mode = "auto"`, custom markers (`slow`, `integration`, `gpu`)
- Add mypy strict scope and pre-commit hooks to Codebase Conventions
- Expand service layers description (orchestration services, openvoice)
- Add widget test chat architecture note
- Force-clear old service worker caches on PWA load to prevent stale assets after deploys

Relates to #105

## Test plan

- [ ] CLAUDE.md renders correctly on GitHub with all migration scripts listed
- [ ] Admin panel loads without stale SW cache after deploy (hard refresh scenario)

## NEWS

🔧 Улучшили стабильность админки — теперь при обновлении автоматически очищается старый кеш, и вы всегда видите актуальную версию. А для разработчиков обновили документацию со всеми командами миграции и тестирования.

🤖 Generated with [Claude Code](https://claude.com/claude-code)