### PR TITLE
fix: hide TTS page from web role

### DIFF
--- a/admin/src/components/AccordionNav.vue
+++ b/admin/src/components/AccordionNav.vue
@@ -60,7 +60,7 @@ const allNavGroups = computed(() => [
     icon: Brain,
     items: [
       { path: '/llm', nameKey: 'nav.llm', icon: Brain, minRole: 'user' as UserRole },
-      { path: '/tts', nameKey: 'nav.tts', icon: Mic, minRole: 'user' as UserRole },
+      { path: '/tts', nameKey: 'nav.tts', icon: Mic, minRole: 'user' as UserRole, excludeRoles: ['web'] as UserRole[] },
       { path: '/models', nameKey: 'nav.models', icon: AudioLines, minRole: 'admin' as UserRole },
       { path: '/finetune', nameKey: 'nav.finetune', icon: Sparkles, minRole: 'admin' as UserRole },
     ]

--- a/admin/src/router.ts
+++ b/admin/src/router.ts
@@ -57,7 +57,7 @@ const router = createRouter({
       path: '/tts',
       name: 'tts',
       component: TtsView,
-      meta: { title: 'TTS', icon: 'Mic', minRole: 'user' }
+      meta: { title: 'TTS', icon: 'Mic', minRole: 'user', excludeRoles: ['web'] }
     },
     {
       path: '/faq',

--- a/admin/src/stores/auth.ts
+++ b/admin/src/stores/auth.ts
@@ -30,7 +30,6 @@ export const ROLE_PERMISSIONS: Record<UserRole, string[]> = {
   web: [
     'chat.*',
     'llm.view', 'llm.cloud.*',
-    'tts.view', 'tts.test',
     'faq.*',
     'telegram.*',
     'widget.*',


### PR DESCRIPTION
## Summary
- Hide TTS page entirely from `web` role users (nav, route guard, permissions)
- Web role is cloud-only — TTS (XTTS/Piper/OpenVoice) is irrelevant for these users
- Follows existing `excludeRoles` pattern from PR #141

## Changes
- `AccordionNav.vue` — add `excludeRoles: ['web']` to TTS nav item
- `router.ts` — add `excludeRoles: ['web']` to `/tts` route meta
- `auth.ts` — remove `tts.view`, `tts.test` from web role permissions

## NEWS

🎯 Упростили интерфейс для веб-клиентов!
Теперь пользователи с ролью Web видят только нужные разделы — без лишних настроек синтеза речи. Чище, понятнее, быстрее.

## Test plan
- [ ] Login as `web` role user → TTS not visible in sidebar
- [ ] Direct navigation to `/tts` redirects to `/chat`
- [ ] `user` and `admin` roles still see TTS as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)