### PR TITLE
fix: skip empty Authorization header for bridge provider

### DIFF
--- a/cloud_llm_service.py
+++ b/cloud_llm_service.py
@@ -206,10 +206,10 @@ class OpenAICompatibleProvider(BaseLLMProvider):
         logger.info(f"[{self.provider_id}] Initialized OpenAI-compatible provider: {self.base_url}")
 
     def _get_headers(self) -> dict:
-        return {
-            "Authorization": f"Bearer {self.api_key}",
-            "Content-Type": "application/json",
-        }
+        headers: dict = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
 
     def is_available(self) -> bool:
         try:


### PR DESCRIPTION
## Summary

- `OpenAICompatibleProvider._get_headers()` sent `Authorization: Bearer ` (empty token) for `claude_bridge` provider which has no API key
- httpx rejected this as an illegal header value, causing widget chat to fail with "Не удалось отправить сообщение"
- Now skips the Authorization header entirely when `api_key` is empty

Relates to #107

## Test plan

- [ ] Open admin panel → Widgets → select widget with bridge backend → send message in test chat
- [ ] Verify stream response arrives without errors
- [ ] Verify providers with API keys (Gemini, OpenRouter) still work

## NEWS

🔧 Исправлен чат-виджет при работе через Claude Bridge!
Раньше виджет показывал ошибку "Не удалось отправить сообщение" — теперь всё работает как надо.

🤖 Generated with [Claude Code](https://claude.com/claude-code)