### PR TITLE
feat(admin): responsive instance headers + logo sidebar toggle

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -102,7 +102,7 @@ function toggleLocale() {
         >
           <!-- Logo -->
           <div class="flex items-center justify-between h-16 px-4 border-b border-border">
-            <div class="flex items-center gap-3">
+            <div class="flex items-center gap-3 cursor-pointer" @click="isMobile ? (mobileMenuOpen = false) : (sidebarOpen = !sidebarOpen)">
               <div class="w-8 h-8 rounded-lg bg-primary/20 flex items-center justify-center">
                 <Settings class="w-5 h-5 text-primary" />
               </div>

--- a/admin/src/views/TelegramView.vue
+++ b/admin/src/views/TelegramView.vue
@@ -749,7 +749,7 @@ watch(instances, (newInstances) => {
         </button>
 
         <!-- Instance Header -->
-        <div class="flex items-center justify-between mb-6">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
           <div>
             <h1 class="text-2xl font-bold flex items-center gap-2">
               {{ selectedInstance.name }}
@@ -767,7 +767,7 @@ watch(instances, (newInstances) => {
               {{ selectedInstance.description }}
             </p>
           </div>
-          <div class="flex items-center gap-2">
+          <div class="flex items-center gap-2 flex-wrap">
             <!-- Control buttons -->
             <button
               v-if="!selectedInstance.running"

--- a/admin/src/views/WidgetView.vue
+++ b/admin/src/views/WidgetView.vue
@@ -442,7 +442,7 @@ function handleTestKeydown(e: KeyboardEvent) {
         </button>
 
         <!-- Instance Header -->
-        <div class="flex items-center justify-between mb-6">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
           <div>
             <h1 class="text-2xl font-bold flex items-center gap-2">
               {{ selectedInstance.name }}
@@ -460,7 +460,7 @@ function handleTestKeydown(e: KeyboardEvent) {
               {{ selectedInstance.description }}
             </p>
           </div>
-          <div class="flex items-center gap-2">
+          <div class="flex items-center gap-2 flex-wrap">
             <a
               :href="`${apiUrl}/widget.js${selectedInstance.id !== 'default' ? '?instance=' + selectedInstance.id : ''}`"
               target="_blank"


### PR DESCRIPTION
## Summary
- **Logo as sidebar toggle**: clicking the logo in the sidebar now toggles collapse/expand on desktop, and closes the mobile drawer — same behavior as the bottom toggle button
- **Responsive instance headers** in TelegramView and WidgetView: action buttons no longer cause horizontal scroll on mobile (flex-col layout on small screens + flex-wrap on buttons)

Follows up on #147 (responsive admin panel).

## NEWS
Улучшена мобильная версия админки: кнопки действий в Telegram-ботах и виджетах больше не вылезают за экран на телефонах. Логотип теперь сворачивает/разворачивает боковое меню.

## Test plan
- [ ] Open TelegramView instance detail on 375px screen — no horizontal scroll
- [ ] Open WidgetView instance detail on 375px screen — no horizontal scroll
- [ ] Click logo on desktop — sidebar collapses/expands
- [ ] Click logo on mobile — drawer closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)