### PR TITLE
fix(cors): handle full URLs in widget allowed_domains

### DIFF
--- a/app/cors_middleware.py
+++ b/app/cors_middleware.py
@@ -65,8 +65,14 @@ class DynamicCORSMiddleware:
             instances = await async_widget_instance_manager.list_instances()
             for inst in instances:
                 for domain in inst.get("allowed_domains", []):
-                    d = domain.strip().lower()
-                    if d:
+                    d = domain.strip().lower().rstrip("/")
+                    if not d:
+                        continue
+                    if d.startswith("https://") or d.startswith("http://"):
+                        # Already a full origin (e.g. "https://shaerware.digital")
+                        origins.add(d)
+                    else:
+                        # Bare domain (e.g. "shaerware.digital")
                         origins.add(f"https://{d}")
                         origins.add(f"http://{d}")
         except Exception as e:


### PR DESCRIPTION
## Summary
- Fix for #152: widget `allowed_domains` in DB are stored as full URLs (`https://shaerware.digital`), not bare domains
- The middleware was prepending `https://` again → `https://https://shaerware.digital` — never matched any Origin
- Now handles both full URLs and bare domains correctly

## Test plan
- [ ] CORS preflight from shaerware.digital returns 200 with `Access-Control-Allow-Origin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)