### PR TITLE
refactor(llm): remove standalone gemini backend, unify with cloud provider system

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -13,7 +13,8 @@
 # LLM Configuration
 # -----------------------------------------------------------------------------
 
-# LLM Backend: "vllm" (local GPU) or "gemini" (cloud) or "cloud:{provider_id}"
+# LLM Backend: "vllm" (local GPU) or "cloud:{provider_id}" (cloud AI provider)
+# Legacy "gemini" value is auto-migrated to cloud provider on startup
 LLM_BACKEND=vllm
 
 # vLLM Model (for GPU mode)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ python scripts/migrate_amocrm.py             # amoCRM config tables
 python scripts/migrate_sales_bot.py          # Sales funnel tables
 python scripts/migrate_add_payment_fields.py # Payment fields for sales
 python scripts/migrate_legal_compliance.py   # Legal compliance tables
+python scripts/migrate_gemini_to_cloud.py    # Migrate standalone gemini backend to cloud provider
 python scripts/seed_tz_generator.py          # Seed TZ generator bot data
 python scripts/seed_tz_widget.py             # Seed TZ widget data
 ```
@@ -209,7 +210,7 @@ GitHub Actions (`.github/workflows/ci.yml`) runs on push to `main`/`develop` and
 ## Key Environment Variables
 
 ```bash
-LLM_BACKEND=vllm                    # "vllm", "gemini", or "cloud:{provider_id}"
+LLM_BACKEND=vllm                    # "vllm" or "cloud:{provider_id}" (legacy "gemini" auto-migrates)
 VLLM_API_URL=http://localhost:11434 # Auto-normalized: trailing /v1 is stripped
 SECRETARY_PERSONA=anna             # "anna" or "marina"
 ORCHESTRATOR_PORT=8002

--- a/admin/src/api/demo/llm.ts
+++ b/admin/src/api/demo/llm.ts
@@ -111,7 +111,7 @@ export const llmRoutes: DemoRoute[] = [
       return {
         status: 'ok',
         backend,
-        model: backend === 'vllm' ? 'Qwen2.5-7B-Instruct-AWQ' : 'gemini-2.0-flash',
+        model: backend === 'vllm' ? 'Qwen2.5-7B-Instruct-AWQ' : 'unknown',
         message: `Backend switched to ${backend}`,
       }
     },

--- a/admin/src/stores/llm.ts
+++ b/admin/src/stores/llm.ts
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 import { llmApi, type LlmParams } from '@/api'
 
 export const useLlmStore = defineStore('llm', () => {
-  const backend = ref<'vllm' | 'gemini'>('vllm')
+  const backend = ref<string>('vllm')
   const model = ref<string>('')
   const persona = ref<string>('anna')
   const params = ref<LlmParams>({
@@ -17,7 +17,7 @@ export const useLlmStore = defineStore('llm', () => {
   async function fetchBackend() {
     try {
       const response = await llmApi.getBackend()
-      backend.value = response.backend as 'vllm' | 'gemini'
+      backend.value = response.backend
       model.value = response.model
     } catch (e) {
       console.error('Failed to fetch backend:', e)
@@ -42,7 +42,7 @@ export const useLlmStore = defineStore('llm', () => {
     }
   }
 
-  async function switchBackend(newBackend: 'vllm' | 'gemini') {
+  async function switchBackend(newBackend: string) {
     isLoading.value = true
     try {
       await llmApi.setBackend(newBackend)

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -167,13 +167,6 @@ const availableLlmOptions = computed<LlmOption[]>(() => {
     }
   }
 
-  // Add gemini as fallback option
-  options.push({
-    value: 'gemini',
-    label: t('llm.cloudAI'),
-    type: 'cloud'
-  })
-
   return options
 })
 

--- a/admin/src/views/WidgetView.vue
+++ b/admin/src/views/WidgetView.vue
@@ -30,7 +30,7 @@ import {
   MessageCircle,
   RotateCcw
 } from 'lucide-vue-next'
-import { widgetInstancesApi, type WidgetInstance } from '@/api'
+import { widgetInstancesApi, llmApi, type WidgetInstance, type CloudProvider } from '@/api'
 import { chatApi, type ChatMessage } from '@/api/chat'
 import { useToastStore } from '@/stores/toast'
 
@@ -79,6 +79,13 @@ const { data: instancesData, isLoading: instancesLoading, refetch: refetchInstan
 })
 
 const instances = computed(() => instancesData.value?.instances || [])
+
+// Cloud providers for LLM backend dropdown
+const { data: cloudProvidersData } = useQuery({
+  queryKey: ['llm-providers'],
+  queryFn: () => llmApi.getProviders(),
+})
+const cloudProviders = computed(() => (cloudProvidersData.value?.providers || []).filter((p: CloudProvider) => p.enabled))
 
 const selectedInstance = computed(() =>
   instances.value.find(i => i.id === selectedInstanceId.value)
@@ -1015,7 +1022,11 @@ function handleTestKeydown(e: KeyboardEvent) {
                   class="w-full px-3 py-2 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 >
                   <option value="vllm">vLLM</option>
-                  <option value="gemini">{{ t('llm.cloudAI') }}</option>
+                  <option
+                    v-for="cp in cloudProviders"
+                    :key="cp.id"
+                    :value="`cloud:${cp.id}`"
+                  >{{ cp.name }} ({{ cp.model_name }})</option>
                 </select>
               </div>
               <div>

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -12,7 +12,8 @@ from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
-    from llm_service import LLMService
+    from typing import Any
+
     from piper_tts_service import PiperTTSService
     from stt_service import STTService
     from voice_clone_service import VoiceCloneService
@@ -33,8 +34,8 @@ class ServiceContainer:
         self.piper_service: PiperTTSService | None = None  # Piper CPU
         self.openvoice_service = None  # OpenVoice v2
 
-        # LLM service
-        self.llm_service: LLMService | None = None
+        # LLM service (VLLMLLMService or CloudLLMService)
+        self.llm_service: Any = None
 
         # STT service
         self.stt_service: STTService | None = None
@@ -44,6 +45,9 @@ class ServiceContainer:
 
         # Streaming TTS manager
         self.streaming_tts_manager = None
+
+        # Wiki RAG service
+        self.wiki_rag_service = None
 
         # Current voice configuration
         self.current_voice_config = {

--- a/finetune_manager.py
+++ b/finetune_manager.py
@@ -1226,10 +1226,10 @@ class FinetuneManager:
                         "Как переключить LLM-бэкенд?",
                         "В админке → вкладка LLM → выберите бэкенд:\n\n"
                         "• vllm — локальная модель (нужен GPU)\n"
-                        "• gemini — Google Gemini API\n"
-                        "• cloud:{id} — любой облачный провайдер из списка\n\n"
+                        "• cloud:{id} — любой облачный провайдер из списка "
+                        "(Gemini, OpenAI, Claude, DeepSeek и др.)\n\n"
                         "Или через переменную окружения:\n"
-                        "```\nLLM_BACKEND=vllm  # или gemini, cloud:openrouter-1\n```\n\n"
+                        "```\nLLM_BACKEND=vllm  # или cloud:gemini-default, cloud:openrouter-1\n```\n\n"
                         "Переключение без перезагрузки — моментально.",
                     ),
                 ]

--- a/llm_service.py
+++ b/llm_service.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """
-Сервис интеграции с Gemini API для генерации ответов секретаря
+DEPRECATED: Standalone Gemini LLM service.
+
+This module is superseded by CloudLLMService + GeminiProvider in cloud_llm_service.py.
+Use cloud provider system instead: LLM_BACKEND=cloud:{provider_id}
+
+Kept for backward compatibility with legacy OpenAI-compatible endpoints (/v1/chat/completions).
 """
 
 import logging

--- a/scripts/migrate_gemini_to_cloud.py
+++ b/scripts/migrate_gemini_to_cloud.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Migration script: Convert standalone 'gemini' LLM backend to cloud provider system.
+
+This script:
+1. Creates a default Gemini cloud provider if none exists (using GEMINI_API_KEY env var)
+2. Updates widget_instances and bot_instances with llm_backend='gemini' to use the new cloud provider
+3. Prints the provider ID for reference
+
+Usage:
+    python scripts/migrate_gemini_to_cloud.py
+"""
+
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+# Allow running from project root or scripts/
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from dotenv import load_dotenv  # noqa: E402
+
+
+load_dotenv(PROJECT_ROOT / ".env")
+
+DB_PATH = PROJECT_ROOT / "data" / "secretary.db"
+
+DEFAULT_PROVIDER_ID = "gemini-default"
+DEFAULT_PROVIDER_NAME = "Gemini (Auto-migrated)"
+
+
+def migrate():
+    if not DB_PATH.exists():
+        print(f"Database not found at {DB_PATH}, skipping migration.")
+        return
+
+    conn = sqlite3.connect(str(DB_PATH))
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+
+    # Check if cloud_llm_providers table exists
+    cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='cloud_llm_providers'"
+    )
+    if not cursor.fetchone():
+        print("Table cloud_llm_providers does not exist yet. Skipping migration.")
+        print("(It will be created on app startup by SQLAlchemy)")
+        conn.close()
+        return
+
+    # Check if a Gemini provider already exists
+    cursor.execute("SELECT id FROM cloud_llm_providers WHERE provider_type = 'gemini' LIMIT 1")
+    existing = cursor.fetchone()
+
+    if existing:
+        provider_id = existing["id"]
+        print(f"Gemini cloud provider already exists: {provider_id}")
+    else:
+        # Create a default Gemini provider from env vars
+        api_key = os.getenv("GEMINI_API_KEY", "")
+        model_name = os.getenv("GEMINI_MODEL", "gemini-2.0-flash")
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+        if not api_key:
+            print("WARNING: GEMINI_API_KEY not set. Creating provider without API key.")
+            print("You will need to configure it in the admin panel.")
+
+        provider_id = DEFAULT_PROVIDER_ID
+
+        cursor.execute(
+            """INSERT INTO cloud_llm_providers
+               (id, name, provider_type, api_key, base_url, model_name,
+                enabled, is_default, owner_id, config, description, created, updated)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                provider_id,
+                DEFAULT_PROVIDER_NAME,
+                "gemini",
+                api_key,
+                None,
+                model_name,
+                1,  # enabled
+                1,  # is_default
+                None,  # owner_id (admin-owned)
+                json.dumps({"temperature": 0.7}),
+                "Auto-migrated from standalone gemini backend",
+                now,
+                now,
+            ),
+        )
+        conn.commit()
+        print(f"Created Gemini cloud provider: {provider_id} (model: {model_name})")
+
+    # Update widget_instances with llm_backend='gemini'
+    cloud_backend = f"cloud:{provider_id}"
+
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='widget_instances'")
+    if cursor.fetchone():
+        cursor.execute("SELECT COUNT(*) as cnt FROM widget_instances WHERE llm_backend = 'gemini'")
+        count = cursor.fetchone()["cnt"]
+        if count > 0:
+            cursor.execute(
+                "UPDATE widget_instances SET llm_backend = ? WHERE llm_backend = 'gemini'",
+                (cloud_backend,),
+            )
+            conn.commit()
+            print(f"Updated {count} widget instance(s): gemini -> {cloud_backend}")
+        else:
+            print("No widget instances with llm_backend='gemini' found.")
+
+    # Update bot_instances with llm_backend='gemini'
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='bot_instances'")
+    if cursor.fetchone():
+        cursor.execute("SELECT COUNT(*) as cnt FROM bot_instances WHERE llm_backend = 'gemini'")
+        count = cursor.fetchone()["cnt"]
+        if count > 0:
+            cursor.execute(
+                "UPDATE bot_instances SET llm_backend = ? WHERE llm_backend = 'gemini'",
+                (cloud_backend,),
+            )
+            conn.commit()
+            print(f"Updated {count} bot instance(s): gemini -> {cloud_backend}")
+        else:
+            print("No bot instances with llm_backend='gemini' found.")
+
+    conn.close()
+    print(f"\nMigration complete. Default Gemini provider ID: {provider_id}")
+    print(f"Use LLM_BACKEND={cloud_backend} in your .env file.")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/scripts/seed_tz_widget.py
+++ b/scripts/seed_tz_widget.py
@@ -154,7 +154,7 @@ def main() -> None:
             "right",
             "[]",
             "",
-            "gemini",
+            "cloud:gemini-default",
             "anna",
             TZ_SYSTEM_PROMPT,
             json.dumps({"temperature": 0.7, "max_tokens": 4096}),


### PR DESCRIPTION
## Summary

- **Remove `LLM_BACKEND=gemini` as a standalone backend mode.** The legacy `LLMService` (hardcoded Google Gemini SDK) duplicated what `CloudLLMService` + `GeminiProvider` already provides — but without VLESS proxy support, DB-driven config, or multi-provider flexibility.
- **Now only 2 backend modes exist:** `vllm` (local GPU) and `cloud:{provider_id}` (any cloud provider including Gemini).
- **Full backward compatibility:** `LLM_BACKEND=gemini` auto-migrates to `cloud:{id}` on startup; DB records get a migration script; frontend dynamically lists cloud providers instead of hardcoding "gemini".

## Changes

### Backend (Python)
- **`orchestrator.py`**: Added `_get_or_create_default_gemini_provider()` async helper; rewrote startup LLM init to auto-migrate `gemini` → `cloud:{id}`; removed all `LLMService()` instantiations; updated health/status/models endpoints
- **`app/routers/llm.py`**: Removed `LLMService` import; `admin_set_llm_backend("gemini")` auto-converts to cloud provider; removed gemini switch branch
- **`app/routers/chat.py`**: Both gemini override blocks now resolve to default Gemini cloud provider via `CloudLLMService`
- **`app/dependencies.py`**: Updated type annotation (`LLMService` → `Any`)
- **`llm_service.py`**: Marked as deprecated (kept for reference)

### Frontend (Vue 3)
- **`LlmView.vue`**: "Cloud AI" button now switches to default cloud provider (`cloud:{id}`) instead of hardcoded `"gemini"`
- **`ChatView.vue`**: Removed hardcoded `{ value: 'gemini', label: 'Cloud AI' }` fallback
- **`WidgetView.vue`**: Replaced static `<option value="gemini">` with dynamic cloud providers dropdown
- **`stores/llm.ts`**: Relaxed backend type from `'vllm' | 'gemini'` to `string`

### Migration & Config
- **NEW `scripts/migrate_gemini_to_cloud.py`**: DB migration for existing records with `llm_backend="gemini"`
- **`.env.docker.example`**: Updated `LLM_BACKEND` comment
- **`CLAUDE.md`**: Updated docs, added migration script reference
- **`scripts/seed_tz_widget.py`**, **`finetune_manager.py`**: Updated references

## Test plan

- [ ] Start with `LLM_BACKEND=gemini` → verify auto-migration to `cloud:{id}`, health shows cloud provider
- [ ] Start with `LLM_BACKEND=cloud:{id}` → works as before
- [ ] Admin LLM page: vLLM button + cloud providers list (Gemini appears as regular provider)
- [ ] Chat view: LLM dropdown shows vLLM + cloud providers (no separate "gemini" entry)
- [ ] Widget LLM dropdown shows cloud providers dynamically
- [ ] Run `python scripts/migrate_gemini_to_cloud.py` on DB with gemini records
- [ ] `ruff check .` ✅ `npm run build` ✅ `npm run lint` ✅ (0 errors)

## NEWS

Standalone `LLM_BACKEND=gemini` mode removed. Gemini now accessed exclusively through the unified cloud provider system (`cloud:{provider_id}`). Existing configurations auto-migrate on startup. Run `python scripts/migrate_gemini_to_cloud.py` to migrate DB records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)