### PR TITLE
fix(admin): show enabled providers on LLM page, dashboard after login

### DIFF
--- a/admin/src/views/LlmView.vue
+++ b/admin/src/views/LlmView.vue
@@ -162,6 +162,11 @@ const currentCloudProviderId = computed(() => {
 // Check if current provider form is for Gemini
 const isGeminiProvider = computed(() => providerForm.value.provider_type === 'gemini')
 
+// Enabled cloud providers (for status display)
+const enabledProviders = computed(() =>
+  (providersData.value?.providers || []).filter((p: CloudProvider) => p.enabled),
+)
+
 // Get the default (or first enabled) cloud provider ID for the toggle button
 const defaultCloudProviderId = computed(() => {
   const providers = providersData.value?.providers || []
@@ -666,18 +671,31 @@ function switchToCloudProvider(providerId: string) {
           </div>
 
           <!-- Status -->
-          <div class="flex items-center gap-2 text-sm">
-            <Loader2 v-if="setBackendMutation.isPending.value" class="w-4 h-4 animate-spin text-primary" />
-            <CheckCircle2 v-else class="w-4 h-4 text-green-500" />
-            <span v-if="setBackendMutation.isPending.value" class="text-muted-foreground">
-              Переключение... (vLLM может запускаться до 2 минут)
-            </span>
-            <span v-else>
-              Current: <strong>{{ backendData?.backend }}</strong>
-              <span v-if="backendData?.model" class="text-muted-foreground">
-                ({{ backendData.model }})
+          <div class="text-sm">
+            <div v-if="setBackendMutation.isPending.value" class="flex items-center gap-2">
+              <Loader2 class="w-4 h-4 animate-spin text-primary" />
+              <span class="text-muted-foreground">
+                Переключение... (vLLM может запускаться до 2 минут)
               </span>
-            </span>
+            </div>
+            <div v-else-if="enabledProviders.length" class="flex flex-wrap items-center gap-2">
+              <span
+                v-for="p in enabledProviders"
+                :key="p.id"
+                :class="[
+                  'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs border cursor-pointer transition-colors',
+                  currentCloudProviderId === p.id
+                    ? 'border-green-500/50 bg-green-500/10 text-green-600 font-medium'
+                    : 'border-border bg-secondary/50 text-muted-foreground hover:border-primary/50'
+                ]"
+                @click="switchToCloudProvider(p.id)"
+              >
+                <CheckCircle2 v-if="currentCloudProviderId === p.id" class="w-3 h-3" />
+                <Cloud v-else class="w-3 h-3" />
+                {{ p.name }}
+                <span class="opacity-70">{{ p.model_name }}</span>
+              </span>
+            </div>
           </div>
 
           <!-- Stop vLLM checkbox (show when using vLLM) -->

--- a/admin/src/views/LoginView.vue
+++ b/admin/src/views/LoginView.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useToastStore } from '@/stores/toast'
 
 const router = useRouter()
+const route = useRoute()
 const authStore = useAuthStore()
 const toastStore = useToastStore()
 
@@ -92,7 +93,8 @@ async function handleSubmit() {
 
     if (success) {
       toastStore.success('Добро пожаловать!', `Вы вошли как ${username.value}`)
-      router.push('/')
+      const redirect = (route.query.redirect as string) || '/'
+      router.push(redirect)
     } else {
       toastStore.error('Ошибка входа', authStore.error || 'Неверные учётные данные')
     }


### PR DESCRIPTION
## Summary

- **LLM page**: replaced raw status text `Current: gemini (gemini-2.0-flash)` with clickable chips showing all enabled cloud providers. Active provider highlighted in green, clicking another switches the backend instantly. If all providers disabled — nothing shown.
- **Login redirect**: after successful login, user now lands on Dashboard (`/`) by default. Also respects `redirect` query param (e.g. if user was redirected to login from another page, they return there after auth).

## Test plan

- [ ] Open LLM page — see enabled cloud providers as clickable chips (active one in green)
- [ ] Click a different provider chip — backend switches
- [ ] Disable all providers — status area is empty
- [ ] Log out, log in as admin — lands on Dashboard
- [ ] Log out, navigate to `/admin/#/widget`, get redirected to login, log in — returns to Widget page

## NEWS

🎨 Обновили страницу LLM в админке — теперь вместо технической строки видно все подключённые AI-провайдеры как удобные кнопки. Один клик — и бэкенд переключается. А после входа в систему вы сразу попадаете на дашборд, а не в чат.

🤖 Generated with [Claude Code](https://claude.com/claude-code)