### PR TITLE
fix(widget): normalize allowed_domains in widget.js domain check

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -3285,7 +3285,12 @@ async def get_widget_script(request: Request, instance: Optional[str] = None):
         origin_domain = (
             origin.replace("https://", "").replace("http://", "").split("/")[0].split(":")[0]
         )
-        if not any(d in origin_domain for d in allowed_domains):
+        # Normalize allowed_domains: strip protocol prefix for comparison
+        normalized = [
+            d.replace("https://", "").replace("http://", "").split("/")[0].split(":")[0]
+            for d in allowed_domains
+        ]
+        if not any(d in origin_domain for d in normalized):
             return Response(
                 content=f"// Widget not allowed for domain: {origin_domain}",
                 media_type="application/javascript",


### PR DESCRIPTION
## Summary
- `allowed_domains` in DB may contain full URLs (`https://shaerware.digital`) from admin panel
- The widget.js endpoint stripped protocol from origin but compared against raw `allowed_domains`
- This caused widget to not load: `// Widget not allowed for domain: shaerware.digital`
- Now normalizes both sides before comparison (same fix as #154 for CORS)

## Test plan
- [ ] Open shaerware.digital — widget icon should appear
- [ ] Widget should respond to messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)