### PR TITLE
fix(ui): hide section headers in collapsed sidebar

### DIFF
--- a/admin/src/components/AccordionNav.vue
+++ b/admin/src/components/AccordionNav.vue
@@ -176,8 +176,9 @@ function hasActiveItem(group: typeof navGroups.value[0]) {
 <template>
   <nav class="flex-1 p-2 space-y-1 overflow-y-auto">
     <template v-for="group in navGroups" :key="group.id">
-      <!-- Group Header -->
+      <!-- Group Header (hidden when sidebar is collapsed) -->
       <button
+        v-if="!collapsed"
         :class="[
           'flex items-center w-full px-3 py-2 rounded-lg transition-all duration-200',
           'text-muted-foreground hover:bg-secondary/50 hover:text-foreground',
@@ -186,11 +187,10 @@ function hasActiveItem(group: typeof navGroups.value[0]) {
         @click="toggleGroup(group.id)"
       >
         <component :is="group.icon" class="w-5 h-5 shrink-0" />
-        <span v-if="!collapsed" class="flex-1 ml-3 text-left font-medium truncate">
+        <span class="flex-1 ml-3 text-left font-medium truncate">
           {{ t(group.nameKey) }}
         </span>
         <ChevronDown
-          v-if="!collapsed"
           :class="[
             'w-4 h-4 transition-transform duration-200',
             isGroupExpanded(group.id) ? 'rotate-180' : ''


### PR DESCRIPTION
## Summary

- Hide group header icons (Monitoring, AI, Channels, Business, System) when sidebar is collapsed
- Only individual tab icons (Dashboard, LLM, Chat, etc.) remain visible in collapsed mode
- Removes visual clutter and duplication in narrow sidebar

## Test plan
- [ ] Collapse sidebar — only tab icons visible, no section headers
- [ ] Expand sidebar — section headers with accordion work as before
- [ ] Active tab highlighting works in both modes

## NEWS

🎨 Навели порядок в боковом меню!
В свёрнутом виде теперь видны только иконки вкладок — без лишних заголовков разделов.
Меньше визуального шума, больше места для работы.

🤖 Generated with [Claude Code](https://claude.com/claude-code)