### PR TITLE
fix: allow web role to access Finetune page

### DIFF
--- a/admin/src/router.ts
+++ b/admin/src/router.ts
@@ -69,7 +69,7 @@ const router = createRouter({
       path: '/finetune',
       name: 'finetune',
       component: FinetuneView,
-      meta: { title: 'Fine-tune', icon: 'Sparkles', minRole: 'admin' }
+      meta: { title: 'Fine-tune', icon: 'Sparkles' }
     },
     {
       path: '/monitoring',


### PR DESCRIPTION
## Summary

- Remove `minRole: 'admin'` from `/finetune` route in `admin/src/router.ts`
- Web role users can now access the Finetune page to manage Cloud AI knowledge base and wiki RAG
- Local LoRA training sections remain visible but require backend `require_not_guest` auth

## NEWS

🎓 Страница обучения теперь доступна всем пользователям!
Управляйте базой знаний для Cloud AI прямо из панели — загружайте документы, тестируйте поиск.
Больше не нужен доступ администратора.

🤖 Generated with [Claude Code](https://claude.com/claude-code)