### PR TITLE
fix(ui): show only Cloud AI for web role on Finetune page

### DIFF
--- a/admin/src/components/AccordionNav.vue
+++ b/admin/src/components/AccordionNav.vue
@@ -62,7 +62,7 @@ const allNavGroups = computed(() => [
       { path: '/llm', nameKey: 'nav.llm', icon: Brain, minRole: 'user' as UserRole },
       { path: '/tts', nameKey: 'nav.tts', icon: Mic, minRole: 'user' as UserRole, excludeRoles: ['web'] as UserRole[] },
       { path: '/models', nameKey: 'nav.models', icon: AudioLines, minRole: 'admin' as UserRole },
-      { path: '/finetune', nameKey: 'nav.finetune', icon: Sparkles, minRole: 'admin' as UserRole },
+      { path: '/finetune', nameKey: 'nav.finetune', icon: Sparkles },
     ]
   },
   {

--- a/admin/src/views/FinetuneView.vue
+++ b/admin/src/views/FinetuneView.vue
@@ -36,14 +36,17 @@ import {
   BookOpenCheck
 } from 'lucide-vue-next'
 import { ref, computed, watch, onUnmounted } from 'vue'
+import { useAuthStore } from '@/stores/auth'
 
 const queryClient = useQueryClient()
+const authStore = useAuthStore()
 
 // Active tab
 const activeTab = ref<'llm' | 'tts'>('llm')
 
 // LLM sub-mode: local LoRA vs cloud AI knowledge
-const llmMode = ref<'local' | 'cloud'>('local')
+// Web role users only see Cloud AI
+const llmMode = ref<'local' | 'cloud'>(authStore.isWeb ? 'cloud' : 'local')
 
 // ============== Cloud AI (Wiki RAG) State ==============
 const searchQuery = ref('')
@@ -504,6 +507,7 @@ onUnmounted(() => {
         LLM Training
       </button>
       <button
+        v-if="!authStore.isWeb"
         :class="[
           'flex items-center gap-2 px-4 py-2 rounded-lg transition-colors',
           activeTab === 'tts' ? 'bg-primary text-primary-foreground' : 'bg-secondary hover:bg-secondary/80'
@@ -517,8 +521,8 @@ onUnmounted(() => {
 
     <!-- ============== LLM TAB ============== -->
     <template v-if="activeTab === 'llm'">
-      <!-- Local / Cloud AI Toggle -->
-      <div class="bg-card rounded-lg border border-border p-4">
+      <!-- Local / Cloud AI Toggle (hidden for web role — they only see Cloud AI) -->
+      <div v-if="!authStore.isWeb" class="bg-card rounded-lg border border-border p-4">
         <div class="grid grid-cols-2 gap-2 p-1 bg-secondary rounded-lg max-w-md">
           <button
             :class="[


### PR DESCRIPTION
## Summary
- Web role users now see only the **Cloud AI** section (Wiki RAG, Knowledge Base, Test Search) on the Finetune page
- Hidden for web role: TTS Training tab, Local/Cloud toggle, LoRA training sections
- Finetune nav item in sidebar now visible for all authenticated roles (was admin-only)

Relates to #164

## Test plan
- [ ] Login as `web` role → Finetune visible in sidebar
- [ ] Web role sees only Cloud AI section (no LoRA, no TTS tab, no toggle)
- [ ] Login as `admin` → all tabs, toggles, and sections visible as before
- [ ] Login as `user` → same as admin (full access)

## NEWS

🎓 Обучение ИИ теперь доступно всем пользователям!
Роль «веб» получила доступ к странице Cloud AI — загружайте документы в базу знаний и управляйте контекстом облачного ИИ прямо из админки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)