### PR TITLE
fix(telegram): remove paid service buttons from news keyboard

### DIFF
--- a/telegram_bot/handlers/news.py
+++ b/telegram_bot/handlers/news.py
@@ -39,23 +39,9 @@ def news_upsell_kb() -> InlineKeyboardMarkup:
     buttons.append(
         [
             InlineKeyboardButton(
-                text="📦 Обновить самостоятельно",
+                text="📦 Установить самостоятельно",
                 url=GITHUB_URL,
             )
-        ]
-    )
-
-    # Paid options
-    buttons.append(
-        [
-            InlineKeyboardButton(
-                text="⚡ Обновить за 2,000₽",
-                callback_data="news:upsell_update",
-            ),
-            InlineKeyboardButton(
-                text="🚀 Установить за 5,000₽",
-                callback_data="news:upsell_install",
-            ),
         ]
     )
 


### PR DESCRIPTION
## Summary
- Removed paid upsell buttons ("Обновить за 2,000₽", "Установить за 5,000₽") from the news keyboard
- Kept only the free "Установить самостоятельно" link to GitHub and "Главное меню" button
- Callback handlers for paid buttons retained for backward compat with old messages

## NEWS
🧹 Убрали лишние кнопки из новостей

- Теперь при просмотре новостей — только кнопка «Установить самостоятельно» с ссылкой на GitHub
- Никаких навязчивых предложений платных услуг — чистый и удобный интерфейс

## Test plan
- [ ] Send `/news` in Telegram bot — verify only "Установить самостоятельно" and "Главное меню" buttons appear
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)