### PR TITLE
feat(demo): add WhatsApp mock data for demo mode

### DIFF
--- a/admin/src/api/demo/index.ts
+++ b/admin/src/api/demo/index.ts
@@ -18,6 +18,7 @@ import { sttRoutes } from './stt'
 import { ttsFinetueRoutes } from './ttsFinetune'
 import { botSalesRoutes } from './botSales'
 import { amocrmRoutes } from './amocrm'
+import { whatsappRoutes, initWhatsAppData } from './whatsapp'
 
 // All routes — order matters: more specific patterns first
 const allRoutes: DemoRoute[] = [
@@ -25,6 +26,7 @@ const allRoutes: DemoRoute[] = [
   ...amocrmRoutes,
   ...botSalesRoutes,  // Must be before telegramRoutes (more specific patterns)
   ...telegramRoutes,
+  ...whatsappRoutes,
   ...widgetRoutes,
   ...chatRoutes,
   ...faqRoutes,
@@ -110,6 +112,7 @@ export function setupDemoInterceptor() {
   initFaqData()
   initChatData()
   initTelegramData()
+  initWhatsAppData()
   initWidgetData()
   initLlmData()
   initAuditData()

--- a/admin/src/api/demo/store.ts
+++ b/admin/src/api/demo/store.ts
@@ -5,6 +5,7 @@ interface StoreState {
   faq: Record<string, string>
   chatSessions: ChatSessionData[]
   botInstances: BotInstanceData[]
+  whatsappInstances: WhatsAppInstanceData[]
   widgetInstances: WidgetInstanceData[]
   cloudProviders: CloudProviderData[]
   llmPresets: LlmPresetData[]
@@ -12,6 +13,34 @@ interface StoreState {
   usageLimits: UsageLimitData[]
   customTtsPresets: Record<string, Record<string, number>>
   initialized: boolean
+}
+
+export interface WhatsAppInstanceData {
+  id: string
+  name: string
+  description?: string
+  enabled: boolean
+  auto_start: boolean
+  phone_number_id: string
+  waba_id?: string
+  access_token_masked?: string
+  verify_token?: string
+  app_secret?: string
+  webhook_port: number
+  llm_backend: string
+  system_prompt?: string
+  tts_enabled: boolean
+  tts_engine: string
+  tts_voice: string
+  tts_preset?: string
+  allowed_phones: string[]
+  blocked_phones: string[]
+  rate_limit_count?: number | null
+  rate_limit_hours?: number | null
+  running?: boolean
+  pid?: number
+  created?: string
+  updated?: string
 }
 
 export interface ChatSessionData {
@@ -164,6 +193,7 @@ const store: StoreState = {
   faq: {},
   chatSessions: [],
   botInstances: [],
+  whatsappInstances: [],
   widgetInstances: [],
   cloudProviders: [],
   llmPresets: [],

--- a/admin/src/api/demo/whatsapp.ts
+++ b/admin/src/api/demo/whatsapp.ts
@@ -1,0 +1,208 @@
+import type { DemoRoute } from './types'
+import type { WhatsAppInstanceData } from './store'
+import { daysAgo, generateId, getStore, minutesAgo, nowISO } from './store'
+
+const defaultInstances: WhatsAppInstanceData[] = [
+  {
+    id: 'wa_demo_main',
+    name: 'AI Секретарь',
+    description: 'Основной WhatsApp бот для продаж и поддержки',
+    enabled: true,
+    auto_start: true,
+    phone_number_id: '100200300400500',
+    waba_id: 'WABA_001',
+    access_token_masked: 'EAAx...***...Xz9',
+    verify_token: 'demo_verify_token',
+    webhook_port: 8003,
+    llm_backend: 'cloud:gemini-1',
+    system_prompt: 'Ты — AI-секретарь компании. Отвечай вежливо и по делу.',
+    tts_enabled: false,
+    tts_engine: 'piper',
+    tts_voice: 'anna',
+    allowed_phones: [],
+    blocked_phones: [],
+    rate_limit_count: 30,
+    rate_limit_hours: 1,
+    running: true,
+    pid: 4521,
+    created: daysAgo(14),
+    updated: minutesAgo(30),
+  },
+  {
+    id: 'wa_demo_support',
+    name: 'Техподдержка',
+    description: 'Бот для техподдержки клиентов',
+    enabled: true,
+    auto_start: false,
+    phone_number_id: '100200300400501',
+    waba_id: 'WABA_001',
+    access_token_masked: 'EAAy...***...Ab2',
+    verify_token: 'demo_verify_token_2',
+    webhook_port: 8004,
+    llm_backend: 'vllm',
+    system_prompt: 'Ты — техподдержка. Помогай решать проблемы с установкой и настройкой.',
+    tts_enabled: false,
+    tts_engine: 'piper',
+    tts_voice: 'anna',
+    allowed_phones: [],
+    blocked_phones: [],
+    rate_limit_count: 60,
+    rate_limit_hours: 1,
+    running: false,
+    pid: undefined,
+    created: daysAgo(7),
+    updated: daysAgo(1),
+  },
+]
+
+export function initWhatsAppData() {
+  const store = getStore()
+  if (!store.whatsappInstances || store.whatsappInstances.length === 0) {
+    store.whatsappInstances = defaultInstances.map(i => ({ ...i }))
+  }
+}
+
+const demoLogs = `[2026-02-12 10:00:01] INFO WhatsApp bot starting up
+[2026-02-12 10:00:01] INFO WhatsApp sales database initialized: data/wa_sales_wa_demo_main.db
+[2026-02-12 10:00:02] INFO Starting WhatsApp webhook server on 0.0.0.0:8003
+[2026-02-12 10:00:02] INFO Webhook verified successfully
+[2026-02-12 10:00:15] INFO Incoming text message from 79001234567
+[2026-02-12 10:00:15] INFO Interactive reply from 79001234567: sales:start_quiz (type=button_reply)
+[2026-02-12 10:00:16] INFO Interactive reply from 79001234567: sales:qt_diy (type=button_reply)
+[2026-02-12 10:00:18] INFO Interactive reply from 79001234567: sales:qi_gpu (type=list_reply)
+[2026-02-12 10:00:20] INFO Interactive reply from 79001234567: sales:gpu_rtx_30xx_low (type=list_reply)
+[2026-02-12 10:00:22] INFO Interactive reply from 79001234567: sales:diy_github (type=button_reply)
+`
+
+export const whatsappRoutes: DemoRoute[] = [
+  // List instances
+  {
+    method: 'GET',
+    pattern: /^\/admin\/whatsapp\/instances$/,
+    handler: () => {
+      initWhatsAppData()
+      return { instances: getStore().whatsappInstances }
+    },
+  },
+
+  // Get instance
+  {
+    method: 'GET',
+    pattern: /^\/admin\/whatsapp\/instances\/([^/]+)$/,
+    handler: ({ matches }) => {
+      initWhatsAppData()
+      const instance = getStore().whatsappInstances.find(
+        (i: WhatsAppInstanceData) => i.id === matches[1],
+      )
+      return { instance: instance || getStore().whatsappInstances[0] }
+    },
+  },
+
+  // Create instance
+  {
+    method: 'POST',
+    pattern: /^\/admin\/whatsapp\/instances$/,
+    handler: ({ body }) => {
+      initWhatsAppData()
+      const store = getStore()
+      const newInstance: WhatsAppInstanceData = {
+        id: `wa_${generateId()}`,
+        name: 'Новый WhatsApp бот',
+        enabled: true,
+        auto_start: false,
+        phone_number_id: '',
+        webhook_port: 8005,
+        llm_backend: 'vllm',
+        tts_enabled: false,
+        tts_engine: 'piper',
+        tts_voice: 'anna',
+        allowed_phones: [],
+        blocked_phones: [],
+        rate_limit_count: 30,
+        rate_limit_hours: 1,
+        running: false,
+        created: nowISO(),
+        updated: nowISO(),
+        ...(body as object),
+      }
+      store.whatsappInstances.push(newInstance)
+      return { instance: newInstance }
+    },
+  },
+
+  // Update instance
+  {
+    method: 'PUT',
+    pattern: /^\/admin\/whatsapp\/instances\/([^/]+)$/,
+    handler: ({ matches, body }) => {
+      initWhatsAppData()
+      const store = getStore()
+      const idx = store.whatsappInstances.findIndex(
+        (i: WhatsAppInstanceData) => i.id === matches[1],
+      )
+      if (idx >= 0) {
+        Object.assign(store.whatsappInstances[idx], body, { updated: nowISO() })
+        return { instance: store.whatsappInstances[idx] }
+      }
+      return { instance: body }
+    },
+  },
+
+  // Delete instance
+  {
+    method: 'DELETE',
+    pattern: /^\/admin\/whatsapp\/instances\/([^/]+)$/,
+    handler: ({ matches }) => {
+      initWhatsAppData()
+      const store = getStore()
+      store.whatsappInstances = store.whatsappInstances.filter(
+        (i: WhatsAppInstanceData) => i.id !== matches[1],
+      )
+      return { status: 'ok', message: 'Instance deleted' }
+    },
+  },
+
+  // Start / Stop / Restart
+  {
+    method: 'POST',
+    pattern: /^\/admin\/whatsapp\/instances\/([^/]+)\/(start|stop|restart)$/,
+    handler: ({ matches }) => {
+      initWhatsAppData()
+      const store = getStore()
+      const instance = store.whatsappInstances.find(
+        (i: WhatsAppInstanceData) => i.id === matches[1],
+      )
+      if (instance) {
+        instance.running = matches[2] !== 'stop'
+        instance.pid = matches[2] !== 'stop' ? 4521 : undefined
+      }
+      return { status: 'ok', pid: 4521, instance_id: matches[1] }
+    },
+  },
+
+  // Get status
+  {
+    method: 'GET',
+    pattern: /^\/admin\/whatsapp\/instances\/([^/]+)\/status$/,
+    handler: ({ matches }) => {
+      initWhatsAppData()
+      const instance = getStore().whatsappInstances.find(
+        (i: WhatsAppInstanceData) => i.id === matches[1],
+      )
+      return {
+        status: {
+          running: instance?.running ?? false,
+          enabled: instance?.enabled ?? false,
+          pid: instance?.pid ?? null,
+        },
+      }
+    },
+  },
+
+  // Get logs
+  {
+    method: 'GET',
+    pattern: /^\/admin\/whatsapp\/instances\/([^/]+)\/logs$/,
+    handler: () => ({ logs: demoLogs }),
+  },
+]


### PR DESCRIPTION
## Summary

- Added `admin/src/api/demo/whatsapp.ts` — mock data for WhatsApp bot instances in demo mode (2 sample bots: "AI Секретарь" running + "Техподдержка" stopped)
- Added `WhatsAppInstanceData` interface and `whatsappInstances` array to `store.ts`
- Registered `whatsappRoutes` and `initWhatsAppData()` in `demo/index.ts`
- Handles all 8 API endpoints: list, get, create, update, delete, start/stop/restart, status, logs

Without this mock data, the WhatsApp view was broken in the demo build — API calls returned generic `{ status: 'ok' }` instead of the expected data structure, causing the view to not render properly.

Relates to #183

## Test plan

- [ ] `cd admin && npm run build -- --mode demo` — builds without errors
- [ ] Open demo build → sidebar shows WhatsApp in Channels group
- [ ] WhatsApp view lists 2 bot instances
- [ ] Click instance → settings/AI/access/logs tabs work
- [ ] Start/stop buttons toggle instance status

## NEWS

📱 WhatsApp теперь виден в демо-режиме! Два демо-бота — "AI Секретарь" и "Техподдержка" — показывают все настройки: AI, доступ, логи и управление.

🤖 Generated with [Claude Code](https://claude.ai/code)