### PR TITLE
feat: deployment profiles (DEPLOYMENT_MODE)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -17,6 +17,9 @@
 # Legacy "gemini" value is auto-migrated to cloud provider on startup
 LLM_BACKEND=vllm
 
+# Deployment mode: "full" (all features), "cloud" (no GPU/hardware), "local" (explicit full)
+DEPLOYMENT_MODE=full
+
 # vLLM Model (for GPU mode)
 # Options: Qwen/Qwen2.5-7B-Instruct-AWQ, meta-llama/Meta-Llama-3.1-8B-Instruct
 VLLM_MODEL=Qwen/Qwen2.5-7B-Instruct-AWQ

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ TWILIO_ACCOUNT_SID=your_twilio_account_sid
 TWILIO_AUTH_TOKEN=your_twilio_auth_token
 TWILIO_PHONE_NUMBER=+1234567890
 
+# Deployment mode: "full" (all features), "cloud" (no GPU/hardware), "local" (explicit full)
+DEPLOYMENT_MODE=full
+
 # Server settings
 TTS_SERVER_PORT=5002
 ORCHESTRATOR_PORT=8000

--- a/admin/src/components/AccordionNav.vue
+++ b/admin/src/components/AccordionNav.vue
@@ -34,9 +34,10 @@ const authStore = useAuthStore()
 
 const ROLE_LEVEL: Record<UserRole, number> = { guest: 0, web: 1, user: 1, admin: 2 }
 
-function isVisibleForRole(item: { minRole?: UserRole; excludeRoles?: UserRole[] }): boolean {
+function isVisibleForRole(item: { minRole?: UserRole; excludeRoles?: UserRole[]; localOnly?: boolean }): boolean {
   const userRole = authStore.user?.role || 'guest'
   if (item.excludeRoles?.includes(userRole)) return false
+  if (item.localOnly && authStore.isCloudMode) return false
   if (!item.minRole) return true
   return ROLE_LEVEL[userRole] >= ROLE_LEVEL[item.minRole]
 }
@@ -48,9 +49,9 @@ const allNavGroups = computed(() => [
     nameKey: 'nav.group.monitoring',
     icon: Activity,
     items: [
-      { path: '/', nameKey: 'nav.dashboard', icon: LayoutDashboard, excludeRoles: ['web'] as UserRole[] },
-      { path: '/monitoring', nameKey: 'nav.monitoring', icon: Activity, minRole: 'user' as UserRole },
-      { path: '/services', nameKey: 'nav.services', icon: Server, minRole: 'user' as UserRole, excludeRoles: ['web'] as UserRole[] },
+      { path: '/', nameKey: 'nav.dashboard', icon: LayoutDashboard, excludeRoles: ['web'] as UserRole[], localOnly: true },
+      { path: '/monitoring', nameKey: 'nav.monitoring', icon: Activity, minRole: 'user' as UserRole, localOnly: true },
+      { path: '/services', nameKey: 'nav.services', icon: Server, minRole: 'user' as UserRole, excludeRoles: ['web'] as UserRole[], localOnly: true },
       { path: '/audit', nameKey: 'nav.audit', icon: FileText, minRole: 'user' as UserRole },
     ]
   },
@@ -60,9 +61,9 @@ const allNavGroups = computed(() => [
     icon: Brain,
     items: [
       { path: '/llm', nameKey: 'nav.llm', icon: Brain, minRole: 'user' as UserRole },
-      { path: '/tts', nameKey: 'nav.tts', icon: Mic, minRole: 'user' as UserRole, excludeRoles: ['web'] as UserRole[] },
-      { path: '/models', nameKey: 'nav.models', icon: AudioLines, minRole: 'admin' as UserRole },
-      { path: '/finetune', nameKey: 'nav.finetune', icon: Sparkles },
+      { path: '/tts', nameKey: 'nav.tts', icon: Mic, minRole: 'user' as UserRole, excludeRoles: ['web'] as UserRole[], localOnly: true },
+      { path: '/models', nameKey: 'nav.models', icon: AudioLines, minRole: 'admin' as UserRole, localOnly: true },
+      { path: '/finetune', nameKey: 'nav.finetune', icon: Sparkles, localOnly: true },
     ]
   },
   {
@@ -74,7 +75,7 @@ const allNavGroups = computed(() => [
       { path: '/telegram', nameKey: 'nav.telegram', icon: Send, minRole: 'user' as UserRole },
       { path: '/whatsapp', nameKey: 'nav.whatsapp', icon: MessageCircle, minRole: 'user' as UserRole },
       { path: '/widget', nameKey: 'nav.widget', icon: Code2, minRole: 'user' as UserRole },
-      { path: '/gsm', nameKey: 'nav.gsm', icon: Phone, minRole: 'admin' as UserRole },
+      { path: '/gsm', nameKey: 'nav.gsm', icon: Phone, minRole: 'admin' as UserRole, localOnly: true },
     ]
   },
   {

--- a/admin/src/router.ts
+++ b/admin/src/router.ts
@@ -34,7 +34,7 @@ const router = createRouter({
       path: '/',
       name: 'dashboard',
       component: DashboardView,
-      meta: { title: 'Dashboard', icon: 'LayoutDashboard', excludeRoles: ['web'] }
+      meta: { title: 'Dashboard', icon: 'LayoutDashboard', excludeRoles: ['web'], localOnly: true }
     },
     {
       path: '/chat',
@@ -46,7 +46,7 @@ const router = createRouter({
       path: '/services',
       name: 'services',
       component: ServicesView,
-      meta: { title: 'Services', icon: 'Server', minRole: 'user', excludeRoles: ['web'] }
+      meta: { title: 'Services', icon: 'Server', minRole: 'user', excludeRoles: ['web'], localOnly: true }
     },
     {
       path: '/llm',
@@ -58,7 +58,7 @@ const router = createRouter({
       path: '/tts',
       name: 'tts',
       component: TtsView,
-      meta: { title: 'TTS', icon: 'Mic', minRole: 'user', excludeRoles: ['web'] }
+      meta: { title: 'TTS', icon: 'Mic', minRole: 'user', excludeRoles: ['web'], localOnly: true }
     },
     {
       path: '/faq',
@@ -70,19 +70,19 @@ const router = createRouter({
       path: '/finetune',
       name: 'finetune',
       component: FinetuneView,
-      meta: { title: 'Fine-tune', icon: 'Sparkles' }
+      meta: { title: 'Fine-tune', icon: 'Sparkles', localOnly: true }
     },
     {
       path: '/monitoring',
       name: 'monitoring',
       component: MonitoringView,
-      meta: { title: 'Monitoring', icon: 'Activity', minRole: 'user' }
+      meta: { title: 'Monitoring', icon: 'Activity', minRole: 'user', localOnly: true }
     },
     {
       path: '/models',
       name: 'models',
       component: ModelsView,
-      meta: { title: 'Models', icon: 'HardDrive', minRole: 'admin' }
+      meta: { title: 'Models', icon: 'HardDrive', minRole: 'admin', localOnly: true }
     },
     {
       path: '/widget',
@@ -106,7 +106,7 @@ const router = createRouter({
       path: '/gsm',
       name: 'gsm',
       component: GSMView,
-      meta: { title: 'GSM Telephony', icon: 'Phone', minRole: 'admin' }
+      meta: { title: 'GSM Telephony', icon: 'Phone', minRole: 'admin', localOnly: true }
     },
     {
       path: '/audit',
@@ -179,6 +179,12 @@ router.beforeEach((to, from, next) => {
   // Check excludeRoles (e.g. 'web' excluded from dashboard, services)
   const excludeRoles = to.meta.excludeRoles as string[] | undefined
   if (excludeRoles?.includes(userRole)) {
+    next({ name: 'chat' })
+    return
+  }
+
+  // Check deployment mode (localOnly routes hidden in cloud mode)
+  if (to.meta.localOnly && authStore.isCloudMode) {
     next({ name: 'chat' })
     return
   }

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,6 +1,8 @@
 # app/routers/auth.py
 """Authentication router - login, user info, auth status, profile management."""
 
+import os
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.rate_limiter import RATE_LIMIT_AUTH, limiter
@@ -42,7 +44,13 @@ async def admin_login(request: Request, login_request: LoginRequest):
 @router.get("/me")
 async def admin_get_current_user(user: User = Depends(get_current_user)):
     """Get current authenticated user info."""
-    return {"id": user.id, "username": user.username, "role": user.role}
+    deployment_mode = os.getenv("DEPLOYMENT_MODE", "full").lower()
+    return {
+        "id": user.id,
+        "username": user.username,
+        "role": user.role,
+        "deployment_mode": deployment_mode,
+    }
 
 
 @router.get("/profile")


### PR DESCRIPTION
## Summary

- Add `DEPLOYMENT_MODE` env var (`full`/`cloud`/`local`) that controls which services and routers are loaded — orthogonal to user roles
- Backend: conditional router registration and service initialization in `orchestrator.py` — hardware routers (services, monitor, gsm, stt, tts) and GPU services skipped in cloud mode
- Frontend: `isCloudMode` computed in auth store, `localOnly` flag on 7 routes/nav items (Dashboard, Services, TTS, Monitoring, Models, Finetune, GSM), router guard redirects to `/chat`
- Health endpoint includes `deployment_mode` and adjusts healthy logic (TTS not required in cloud)
- New `GET /admin/deployment-mode` endpoint; `/auth/me` returns `deployment_mode`

Relates to #101

## Test plan

- [ ] Default behavior (`DEPLOYMENT_MODE` unset or `full`): all services load, all tabs visible — no regressions
- [ ] `DEPLOYMENT_MODE=cloud`: health shows `"deployment_mode": "cloud"`, TTS services `false`, hardware tabs hidden in admin panel
- [ ] Navigate to `/monitoring` in cloud mode → redirects to `/chat`
- [ ] Chat works with cloud LLM in cloud mode
- [ ] Telegram/WhatsApp bots work in cloud mode
- [ ] `ruff check .` and `npm run build` pass

## NEWS

☁️ Теперь систему можно развернуть в облаке без GPU!
Новая переменная `DEPLOYMENT_MODE=cloud` автоматически отключает все GPU-сервисы и убирает лишние вкладки из админки.
Идеально для облачного сервера — только чат, боты и облачные LLM, без тяжёлых зависимостей.

🤖 Generated with [Claude Code](https://claude.com/claude-code)