### PR TITLE
fix: enable Wiki RAG context injection in chat

### DIFF
--- a/cloud_llm_service.py
+++ b/cloud_llm_service.py
@@ -646,6 +646,10 @@ class CloudLLMService:
             self.faq = {}
         logger.info(f"🔄 FAQ перезагружен: {len(self.faq)} записей")
 
+    def get_system_prompt(self) -> str:
+        """Return the system prompt configured for this provider."""
+        return self.system_prompt or ""
+
     def is_available(self) -> bool:
         """Check if provider is available."""
         return self.provider.is_available()


### PR DESCRIPTION
## Summary
- Wiki RAG was indexed (589 sections from 32 wiki pages) but never injected into chat conversations
- Root cause: `CloudLLMService` lacked `get_system_prompt()` method, and RAG condition required `default_prompt` to be truthy (always `None` for bridge LLM)
- Added `get_system_prompt()` to `CloudLLMService`, removed overly strict RAG condition, added default system prompt fallback
- RAG now works in all 4 chat endpoints: stream, non-stream, edit, regenerate

## Test plan
- [x] Tested chat with RAG query "Как настроить telegram бота?" — correct response from wiki docs
- [x] Tested "Какие роли пользователей?" — accurate answer from documentation
- [x] No tool-use XML in responses (fixed by default system prompt)
- [x] Service healthy after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)