### PR TITLE
docs: update demo structure to path-based routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,8 +340,8 @@ Systemd services:
 
 Static sites:
     /var/www/admin-ai-sekretar24/   ← admin panel (rsync from admin/dist/)
-    /var/www/ai-sekretar24/         ← admin demo (demo build, role=admin)
-    /var/www/demo-ai-sekretar24/    ← web demo (demo-web build, role=web)
+    /var/www/ai-sekretar24/         ← landing page (static)
+    /var/www/demo-ai-sekretar24/    ← demo builds (full/ + cloud/ subdirs)
 ```
 
 **Local-only files** (not in git, backed up by deploy.sh): `.env`, `apply_patches.py`, `deploy.sh`, `webhook_server.py`, `admin/.env.production.local`
@@ -382,27 +382,32 @@ bash deploy.sh                               # deploy to production
 Fully offline demo builds of the admin panel — no backend needed, mock data only.
 
 ```bash
-bash /root/deploy-demo.sh       # pull → build --mode demo → deploy to /var/www/ai-sekretar24/
-bash /root/deploy-demo-web.sh   # pull → build --mode demo-web → deploy to /var/www/demo-ai-sekretar24/
+bash /root/deploy-demo.sh       # pull → build both demos → deploy to /var/www/demo-ai-sekretar24/
 ```
 
-**Admin demo** (ai-sekretar24.ru) — full admin panel:
-- **URL**: https://ai-sekretar24.ru (login: admin/admin)
-- **Build**: `npm run build -- --mode demo` (loads `.env.demo`: `VITE_DEMO_ROLE=admin`, `VITE_DEMO_DEPLOYMENT_MODE=full`)
-- **Auto-deploy**: GitHub webhook → `demo-webhook.service` (port 9876) → `/root/deploy-demo.sh` on push to main
+Both demos live on `demo.ai-sekretar24.ru` with path-based routing. Single script `deploy-demo.sh` builds and deploys both.
 
-**Web demo** (demo.ai-sekretar24.ru) — customer-facing view (web role):
-- **URL**: https://demo.ai-sekretar24.ru (login: admin/admin or demo/demo)
+**Full demo** (`/full/`) — admin role, all features:
+- **URL**: https://demo.ai-sekretar24.ru/full/ (auto-login as admin)
+- **Build**: `npm run build -- --mode demo` (loads `.env.demo`: `VITE_DEMO_ROLE=admin`, `VITE_DEMO_DEPLOYMENT_MODE=full`)
+- **All tabs visible**
+
+**Cloud demo** (`/cloud/`) — web role, customer-facing:
+- **URL**: https://demo.ai-sekretar24.ru/cloud/ (auto-login as web)
 - **Build**: `npm run build -- --mode demo-web` (loads `.env.demo-web`: `VITE_DEMO_ROLE=web`, `VITE_DEMO_DEPLOYMENT_MODE=cloud`)
 - **Hidden tabs**: Dashboard, Services, TTS, Monitoring, Models, GSM
-- **Visible tabs**: Chat, Telegram, WhatsApp, Widget, FAQ, LLM, Fine-tune (Cloud AI), CRM
+
+**Auto-deploy**: GitHub webhook → `demo-webhook.service` (port 9876) → `/root/deploy-demo.sh` on push to main
+
+**Landing page**: https://ai-sekretar24.ru — static site in `/var/www/ai-sekretar24/` (not a demo)
 
 **Shared architecture:**
 - **How it works**: monkey-patches `window.fetch` in `demo/index.ts` to intercept all API calls with mock data
 - **SSE**: polling (3s interval) instead of real EventSource
 - **Mock data**: 22 files in `admin/src/api/demo/`, in-memory store for session-persistent mutations
 - **Role config**: `VITE_DEMO_ROLE` and `VITE_DEMO_DEPLOYMENT_MODE` env vars control role in JWT and deployment mode mock
-- **Nginx**: hash history, no server-side routing needed
+- **Auto-login**: inline `<script>` in `index.html` injects JWT with correct role before Vue app loads
+- **Nginx**: path-based routing (`/full/`, `/cloud/`), root `/` redirects to `/full/`
 
 ## Parallel Development (Two Claude Code Instances)
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 **Self-hosted AI-секретарь с клонированием голоса, локальным и облачным LLM, Telegram/WhatsApp ботами и Vue 3 админ-панелью**
 
 [![Сайт проекта](https://img.shields.io/badge/Сайт_проекта-ai--sekretar24.ru-4285F4?style=for-the-badge&logo=google-chrome&logoColor=white)](https://ai-sekretar24.ru/)
-[![Демо](https://img.shields.io/badge/Демо_(Web)-demo.ai--sekretar24.ru-00C853?style=for-the-badge&logo=google-chrome&logoColor=white)](https://demo.ai-sekretar24.ru)
+[![Демо](https://img.shields.io/badge/Демо-demo.ai--sekretar24.ru-00C853?style=for-the-badge&logo=google-chrome&logoColor=white)](https://demo.ai-sekretar24.ru/full/)
 [![Telegram](https://img.shields.io/badge/Telegram_бот-@shaerware__digital__bot-26A5E4?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/shaerware_digital_bot)
 
-[Сайт проекта](https://ai-sekretar24.ru/) | [Демо (Web)](https://demo.ai-sekretar24.ru) | [Telegram бот](https://t.me/shaerware_digital_bot) | [Wiki](https://github.com/ShaerWare/AI_Secretary_System/wiki) | [Issues](https://github.com/ShaerWare/AI_Secretary_System/issues)
+[Сайт проекта](https://ai-sekretar24.ru/) | [Демо (Full)](https://demo.ai-sekretar24.ru/full/) | [Демо (Cloud)](https://demo.ai-sekretar24.ru/cloud/) | [Telegram бот](https://t.me/shaerware_digital_bot) | [Wiki](https://github.com/ShaerWare/AI_Secretary_System/wiki) | [Issues](https://github.com/ShaerWare/AI_Secretary_System/issues)
 
 ---
 
@@ -1223,7 +1223,8 @@ Copyright (c) 2026 ShaerWare
 ## Support
 
 - **Сайт проекта:** https://ai-sekretar24.ru/
-- **Демо (Web-роль):** https://demo.ai-sekretar24.ru
+- **Демо (полный):** https://demo.ai-sekretar24.ru/full/
+- **Демо (облачный):** https://demo.ai-sekretar24.ru/cloud/
 - **Telegram бот:** https://t.me/shaerware_digital_bot
 - **Issues:** https://github.com/ShaerWare/AI_Secretary_System/issues
 - **Wiki:** https://github.com/ShaerWare/AI_Secretary_System/wiki

--- a/SYSTEM_DOCS.md
+++ b/SYSTEM_DOCS.md
@@ -388,8 +388,9 @@ Vue 3 PWA с 20 вкладками:
 - Deployment mode: `VITE_DEMO_DEPLOYMENT_MODE=full` или `cloud`
 
 ```bash
-npm run build -- --mode demo      # Admin demo (role=admin, full mode)
-npm run build -- --mode demo-web  # Web demo (role=web, cloud mode)
+npm run build -- --mode demo      # Full demo (role=admin, full mode) → /full/
+npm run build -- --mode demo-web  # Cloud demo (role=web, cloud mode) → /cloud/
+# Both deployed by: bash /root/deploy-demo.sh
 ```
 
 ## API (21 роутер, ~371 endpoint)

--- a/wiki-pages/Home.md
+++ b/wiki-pages/Home.md
@@ -6,7 +6,9 @@
 
 | Ресурс | Ссылка |
 |--------|--------|
-| **Админ-панель** (демо) | [ai-sekretar24.ru](https://ai-sekretar24.ru/) |
+| **Демо** (полный режим) | [demo.ai-sekretar24.ru/full/](https://demo.ai-sekretar24.ru/full/) |
+| **Демо** (облачный режим) | [demo.ai-sekretar24.ru/cloud/](https://demo.ai-sekretar24.ru/cloud/) |
+| **Сайт проекта** | [ai-sekretar24.ru](https://ai-sekretar24.ru/) |
 | **Чат-бот техподдержки** | [@shaerware_digital_bot](https://t.me/shaerware_digital_bot) |
 
 ## Возможности системы


### PR DESCRIPTION
## Summary
- Updated all docs to reflect new demo structure: both demos on `demo.ai-sekretar24.ru` with `/full/` and `/cloud/` subdirectories
- Removed all references to deleted `deploy-demo-web.sh`
- `ai-sekretar24.ru` documented as landing page, not demo
- Updated demo URLs in README badges and Support section
- Updated wiki Home.md with both demo links

## Files changed
- `CLAUDE.md` — server architecture, demo sites section
- `README.md` — badges, nav links, support section
- `SYSTEM_DOCS.md` — build commands
- `wiki-pages/Home.md` — demo links table

## Test plan
- [ ] Verify README badges link to correct URLs
- [ ] Verify wiki Home page shows both demo links

🤖 Generated with [Claude Code](https://claude.com/claude-code)