### PR TITLE
fix: build proper lead objects from unsorted API

### DIFF
--- a/admin/src/api/amocrm.ts
+++ b/admin/src/api/amocrm.ts
@@ -164,7 +164,7 @@ export const amocrmApi = {
 
   getUnsortedLeads: (page = 1, limit = 250) => {
     const params = new URLSearchParams({ page: String(page), limit: String(limit) })
-    return api.get<{ _embedded: { leads: AmoCRMLead[] }; total: number }>(`/admin/crm/leads/unsorted?${params}`)
+    return api.get<{ _embedded: { leads: AmoCRMLead[] }; total: number; has_next: boolean }>(`/admin/crm/leads/unsorted?${params}`)
   },
 
   createLead: (data: {

--- a/admin/src/api/demo/amocrm.ts
+++ b/admin/src/api/demo/amocrm.ts
@@ -202,7 +202,7 @@ export const amocrmRoutes: DemoRoute[] = [
   {
     method: 'GET',
     pattern: /^\/admin\/crm\/leads\/unsorted/,
-    handler: () => ({ _embedded: { leads: [] }, total: 0 }),
+    handler: () => ({ _embedded: { leads: [] }, has_next: false }),
   },
   // GET /admin/crm/leads/by-pipeline/:id
   {

--- a/admin/src/components/CrmKanban.vue
+++ b/admin/src/components/CrmKanban.vue
@@ -269,7 +269,7 @@ const { data: unsortedData, refetch: refetchUnsorted } = useQuery({
   enabled: computed(() => !!selectedPipeline.value),
 })
 
-const unsortedTotal = computed(() => unsortedData.value?.total || 0)
+const unsortedHasNext = computed(() => unsortedData.value?.has_next || false)
 
 const allLeads = computed<AmoCRMLead[]>(() =>
   leadsData.value?._embedded?.leads || []
@@ -299,9 +299,12 @@ function rebuildColumns() {
       grouped[lead.status_id].push(lead)
     }
   }
-  // Merge unsorted leads into "Неразобранное" column
-  if (unsortedStatusId.value && grouped[unsortedStatusId.value]) {
-    grouped[unsortedStatusId.value].push(...unsortedLeads.value)
+  // Merge unsorted leads into "Неразобранное" column (assign status_id)
+  const usId = unsortedStatusId.value
+  if (usId && grouped[usId]) {
+    for (const lead of unsortedLeads.value) {
+      grouped[usId].push({ ...lead, status_id: usId })
+    }
   }
   columnLeads.value = grouped
   displayLimits.value = newLimits
@@ -495,7 +498,7 @@ onUnmounted(() => {
               />
               <span class="font-medium text-sm truncate">{{ status.name }}</span>
               <span class="text-xs text-muted-foreground ml-auto">
-                {{ status.id === unsortedStatusId && unsortedTotal > totalCount(status.id) ? unsortedTotal : totalCount(status.id) }}
+                {{ totalCount(status.id) }}{{ status.id === unsortedStatusId && unsortedHasNext ? '+' : '' }}
               </span>
               <button
                 class="p-0.5 rounded hover:bg-secondary text-muted-foreground"

--- a/app/services/amocrm_service.py
+++ b/app/services/amocrm_service.py
@@ -354,35 +354,55 @@ async def get_unsorted_leads(
 ) -> dict:
     """Get unsorted (incoming) leads for one page.
 
-    Returns flattened lead objects from unsorted items with _is_unsorted=True marker,
-    plus total count from response metadata.
+    amoCRM unsorted API returns wrapper items whose embedded leads are stubs
+    (only id + _links).  We build proper lead-like objects from the wrapper
+    metadata (source_name, category, contacts) so the frontend can render them.
+
+    Returns ``{_embedded: {leads: [...]}, has_next: bool}``.
     """
-    all_leads: list[dict] = []
+    empty: dict[str, Any] = {"_embedded": {"leads": []}, "has_next": False}
     params: dict[str, Any] = {"limit": limit, "page": page}
     try:
         data = await _api_request(subdomain, access_token, "GET", "leads/unsorted", params=params)
     except AmoCRMAPIError as e:
         if e.status_code == 204:
-            return {"_embedded": {"leads": []}, "total": 0}
+            return empty
         raise
     if not data or "_embedded" not in data:
-        return {"_embedded": {"leads": []}, "total": 0}
+        return empty
 
-    total_from_api = data.get("_total_items", 0)
+    has_next = bool(data.get("_links", {}).get("next"))
     unsorted_items = data["_embedded"].get("unsorted", [])
+    all_leads: list[dict] = []
+
     for item in unsorted_items:
         embedded = item.get("_embedded", {})
-        leads = embedded.get("leads", [])
+        stub_leads = embedded.get("leads", [])
         contacts = embedded.get("contacts", [])
-        for lead in leads:
-            lead["_is_unsorted"] = True
-            lead["_unsorted_uid"] = item.get("uid")
-            lead["_unsorted_created_at"] = item.get("created_at")
-            if contacts and "_embedded" not in lead:
-                lead["_embedded"] = {"contacts": contacts}
-            all_leads.append(lead)
+        category = item.get("category", "")
+        source_name = item.get("source_name", "")
+        contact_name = contacts[0]["name"] if contacts else ""
 
-    return {"_embedded": {"leads": all_leads}, "total": total_from_api or len(all_leads)}
+        lead_id = stub_leads[0]["id"] if stub_leads else item.get("uid")
+        name = contact_name or source_name or category or "Неразобранное"
+
+        lead: dict[str, Any] = {
+            "id": lead_id,
+            "name": name,
+            "price": 0,
+            "pipeline_id": item.get("pipeline_id"),
+            "status_id": None,
+            "created_at": item.get("created_at"),
+            "_is_unsorted": True,
+            "_unsorted_uid": item.get("uid"),
+            "_unsorted_category": category,
+            "_unsorted_source": source_name,
+        }
+        if contacts:
+            lead["_embedded"] = {"contacts": contacts}
+        all_leads.append(lead)
+
+    return {"_embedded": {"leads": all_leads}, "has_next": has_next}
 
 
 async def get_events(


### PR DESCRIPTION
## Summary
- amoCRM `/leads/unsorted` returns stub leads (only `id` + `_links`) — no name, price, or pipeline_id
- Backend now builds proper lead objects from unsorted item metadata: `source_name`, `_embedded.contacts[0].name`, `category`
- Uses `has_next` (from `_links.next`) instead of unreliable `_total_items` for pagination
- Frontend assigns `status_id` when merging unsorted leads into the kanban column
- Column header shows `250+` when more unsorted leads exist

## Test plan
- [ ] Open kanban board, verify "Неразобранное" column shows leads with proper names
- [ ] Column counter shows `250+` if there are more unsorted leads
- [ ] Demo mode works (returns empty unsorted list with `has_next: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)