### PR TITLE
fix: extract unsorted lead names from metadata

### DIFF
--- a/app/services/amocrm_service.py
+++ b/app/services/amocrm_service.py
@@ -381,10 +381,23 @@ async def get_unsorted_leads(
         contacts = embedded.get("contacts", [])
         category = item.get("category", "")
         source_name = item.get("source_name", "")
-        contact_name = contacts[0]["name"] if contacts else ""
+        metadata = item.get("metadata", {})
+
+        # Build display name from metadata (contacts are stubs without names)
+        name = ""
+        if category == "mail":
+            name = metadata.get("subject") or metadata.get("from", {}).get("email", "")
+        elif category == "chats":
+            client = metadata.get("client", {})
+            name = (
+                (client.get("name") if client else None)
+                or metadata.get("source_name", "")
+                or source_name
+            )
+        if not name:
+            name = source_name or category or "Неразобранное"
 
         lead_id = stub_leads[0]["id"] if stub_leads else item.get("uid")
-        name = contact_name or source_name or category or "Неразобранное"
 
         lead: dict[str, Any] = {
             "id": lead_id,


### PR DESCRIPTION
## Summary
- Contacts in unsorted items are stubs (only `id` + `_links`, no `name`)
- Now extracts proper names: `metadata.subject` for mail, `metadata.client.name` / phone for chats
- Tested: 250 leads load with proper names like "Отчет за неделю...", "77753238598", "Шаттық"

## Test plan
- [ ] Kanban "Неразобранное" column shows proper lead names
- [ ] Mail items show email subjects
- [ ] Chat items show client names or phone numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)