### PR TITLE
fix: chat input bottom position layout

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -1511,9 +1511,9 @@ watch(sessions, (newSessions) => {
       <!-- Input Area -->
       <div
         v-if="currentSession"
-        :class="['p-4 bg-card', inputPosition === 'bottom' ? 'border-t border-border order-last' : 'border-b border-border']"
+        :class="['p-4 bg-card', inputPosition === 'bottom' ? 'border-t border-border order-last pb-16' : 'border-b border-border']"
       >
-        <div class="flex gap-3 items-end">
+        <div :class="['flex gap-3', inputPosition === 'bottom' ? 'items-stretch' : 'items-end']">
           <textarea
             ref="messageInputRef"
             v-model="inputMessage"


### PR DESCRIPTION
## Summary

- Add `pb-16` padding to bottom input position to prevent widget overlay from covering mic/send buttons
- Use `items-stretch` so mic and send buttons match textarea height for a visually uniform input strip

## NEWS

🎨 Улучшили расположение поля ввода в чате — теперь в нижнем положении кнопки микрофона и отправки идеально выровнены с полем ввода, ничего не перекрывается.

🤖 Generated with [Claude Code](https://claude.com/claude-code)