### PR TITLE
feat(admin): sidebar buttons, role permissions, cloud mode UI

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -7,7 +7,8 @@ import {
   Search,
   LogOut,
   User,
-  Languages
+  Languages,
+  PanelLeftClose
 } from 'lucide-vue-next'
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -113,12 +114,19 @@ const localeTitle: Record<string, string> = { ru: 'Переключить язы
         >
           <!-- Logo -->
           <div class="flex items-center justify-between h-16 px-4 border-b border-border">
-            <div class="flex items-center gap-3 cursor-pointer" @click="isMobile ? (mobileMenuOpen = false) : (sidebarOpen = !sidebarOpen)">
+            <div :class="['flex items-center gap-3', !sidebarOpen && !isMobile ? 'cursor-pointer' : '']" @click="!sidebarOpen && !isMobile && (sidebarOpen = true)">
               <div class="w-8 h-8 rounded-lg bg-primary/20 flex items-center justify-center">
                 <Settings class="w-5 h-5 text-primary" />
               </div>
               <span v-if="sidebarOpen || isMobile" class="font-semibold text-lg">AI Secretary</span>
             </div>
+            <button
+              v-if="!isMobile && sidebarOpen"
+              class="p-2 rounded-lg border border-border text-muted-foreground hover:bg-secondary/50 transition-colors"
+              @click="sidebarOpen = false"
+            >
+              <PanelLeftClose class="w-4 h-4" />
+            </button>
             <button
               v-if="isMobile"
               class="p-1 rounded-lg hover:bg-secondary/50 text-muted-foreground"

--- a/admin/src/components/AccordionNav.vue
+++ b/admin/src/components/AccordionNav.vue
@@ -49,10 +49,10 @@ const allNavGroups = computed(() => [
     nameKey: 'nav.group.monitoring',
     icon: Activity,
     items: [
-      { path: '/', nameKey: 'nav.dashboard', icon: LayoutDashboard, excludeRoles: ['web'] as UserRole[], localOnly: true },
-      { path: '/monitoring', nameKey: 'nav.monitoring', icon: Activity, minRole: 'user' as UserRole, excludeRoles: ['web'] as UserRole[], localOnly: true },
-      { path: '/services', nameKey: 'nav.services', icon: Server, minRole: 'user' as UserRole, excludeRoles: ['web'] as UserRole[], localOnly: true },
-      { path: '/audit', nameKey: 'nav.audit', icon: FileText, minRole: 'user' as UserRole, excludeRoles: ['web'] as UserRole[] },
+      { path: '/', nameKey: 'nav.dashboard', icon: LayoutDashboard, excludeRoles: ['web', 'user'] as UserRole[], localOnly: true },
+      { path: '/monitoring', nameKey: 'nav.monitoring', icon: Activity, minRole: 'admin' as UserRole, localOnly: true },
+      { path: '/services', nameKey: 'nav.services', icon: Server, minRole: 'admin' as UserRole, localOnly: true },
+      { path: '/audit', nameKey: 'nav.audit', icon: FileText, minRole: 'admin' as UserRole },
     ]
   },
   {
@@ -63,7 +63,7 @@ const allNavGroups = computed(() => [
       { path: '/llm', nameKey: 'nav.llm', icon: Brain, minRole: 'user' as UserRole },
       { path: '/tts', nameKey: 'nav.tts', icon: Mic, minRole: 'user' as UserRole, excludeRoles: ['web'] as UserRole[], localOnly: true },
       { path: '/models', nameKey: 'nav.models', icon: AudioLines, minRole: 'admin' as UserRole, localOnly: true },
-      { path: '/finetune', nameKey: 'nav.finetune', icon: Sparkles },
+      { path: '/finetune', nameKey: 'nav.finetune', icon: Sparkles, minRole: 'user' as UserRole },
     ]
   },
   {

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -1130,7 +1130,7 @@ watch(sessions, (newSessions) => {
       <template v-if="sidebarCollapsed">
         <!-- Collapsed header: expand + new chat -->
         <div class="hidden md:flex flex-col items-center gap-1 p-2 border-b border-border">
-          <button class="p-2 rounded-lg text-muted-foreground hover:bg-secondary/50" :title="t('chatView.expandSidebar')" @click="toggleSidebarCollapse">
+          <button class="p-2 rounded-lg border border-border text-muted-foreground hover:bg-secondary/50 transition-colors" :title="t('chatView.expandSidebar')" @click="toggleSidebarCollapse">
             <PanelLeftOpen class="w-4 h-4" />
           </button>
           <button
@@ -1175,7 +1175,7 @@ watch(sessions, (newSessions) => {
         </h2>
         <div class="flex items-center gap-1">
           <button
-            class="hidden md:inline-flex p-2 rounded-lg text-muted-foreground hover:bg-secondary transition-colors"
+            class="hidden md:inline-flex p-2 rounded-lg border border-border text-muted-foreground hover:bg-secondary/50 transition-colors"
             :title="t('chatView.collapseSidebar')"
             @click="toggleSidebarCollapse"
           >

--- a/admin/src/views/FinetuneView.vue
+++ b/admin/src/views/FinetuneView.vue
@@ -48,7 +48,7 @@ const activeTab = ref<'llm' | 'tts'>('llm')
 
 // LLM sub-mode: local LoRA vs cloud AI knowledge
 // Web role users only see Cloud AI
-const llmMode = ref<'local' | 'cloud'>(authStore.isWeb ? 'cloud' : 'local')
+const llmMode = ref<'local' | 'cloud'>(authStore.isWeb || authStore.isCloudMode ? 'cloud' : 'local')
 
 // ============== Cloud AI (Wiki RAG) State ==============
 const searchQuery = ref('')
@@ -564,7 +564,7 @@ onUnmounted(() => {
         LLM Training
       </button>
       <button
-        v-if="!authStore.isWeb"
+        v-if="!authStore.isWeb && !authStore.isCloudMode"
         :class="[
           'flex items-center gap-2 px-4 py-2 rounded-lg transition-colors',
           activeTab === 'tts' ? 'bg-primary text-primary-foreground' : 'bg-secondary hover:bg-secondary/80'
@@ -578,8 +578,8 @@ onUnmounted(() => {
 
     <!-- ============== LLM TAB ============== -->
     <template v-if="activeTab === 'llm'">
-      <!-- Local / Cloud AI Toggle (hidden for web role — they only see Cloud AI) -->
-      <div v-if="!authStore.isWeb" class="bg-card rounded-lg border border-border p-4">
+      <!-- Local / Cloud AI Toggle (hidden for web/cloud — they only see Cloud AI) -->
+      <div v-if="!authStore.isWeb && !authStore.isCloudMode" class="bg-card rounded-lg border border-border p-4">
         <div class="grid grid-cols-2 gap-2 p-1 bg-secondary rounded-lg max-w-md">
           <button
             :class="[
@@ -605,7 +605,7 @@ onUnmounted(() => {
       </div>
 
       <!-- ====== LOCAL (LoRA) MODE ====== -->
-      <template v-if="llmMode === 'local'">
+      <template v-if="llmMode === 'local' && !authStore.isCloudMode">
       <!-- Project Dataset Generator -->
       <div class="bg-card rounded-lg border border-border">
         <div class="p-4 border-b border-border">
@@ -1024,7 +1024,7 @@ v-if="!adapter.active" :disabled="deleteAdapterMutation.isPending.value" class="
       </template>
 
       <!-- ====== CLOUD AI MODE ====== -->
-      <template v-if="llmMode === 'cloud'">
+      <template v-if="llmMode === 'cloud' || authStore.isCloudMode">
         <!-- Wiki RAG Status -->
         <div class="bg-card rounded-lg border border-border">
           <div class="p-4 border-b border-border flex items-center justify-between">


### PR DESCRIPTION
## Summary
- Sidebar toggle buttons with outline style (main sidebar + chat sidebar)
- Collapsed main sidebar: click logo to expand, no button shown
- Monitoring group hidden for `user` role (admin only)
- Finetune page: hide local LoRA/TTS training in cloud mode, show only Wiki RAG
- DB migration: added missing `knowledge_collection_ids` and `base_dir` columns

## Test plan
- [ ] Main sidebar: outline toggle button visible when expanded, hidden when collapsed
- [ ] Collapsed sidebar: clicking logo expands it
- [ ] Chat sidebar: collapse/expand buttons have outline border style
- [ ] User role: no Monitoring group in menu
- [ ] User role: Finetune page shows only Wiki RAG (no Dataset, no LoRA, no TTS tab)
- [ ] Admin role: all features still accessible
- [ ] Widgets, chats, Telegram bot all functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)