### PR TITLE
fix(admin): branch tree drag-to-scroll for deep conversations

### DIFF
--- a/admin/src/components/BranchTree.vue
+++ b/admin/src/components/BranchTree.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { GitBranch, Plus, X } from 'lucide-vue-next'
 import type { BranchNode } from '@/api/chat'
@@ -25,11 +26,68 @@ function handleClick(messageId: string) {
 function handleScrollTo(messageId: string) {
   emit('scroll-to', messageId)
 }
+
+// ── Drag-to-scroll ──
+const scrollContainer = ref<HTMLElement | null>(null)
+let isDragging = false
+let startX = 0
+let startY = 0
+let scrollLeft = 0
+let scrollTop = 0
+let hasMoved = false
+
+function onPointerDown(e: PointerEvent) {
+  const el = scrollContainer.value
+  if (!el) return
+  // Don't hijack clicks on buttons/interactive elements
+  if ((e.target as HTMLElement).closest('button')) return
+  isDragging = true
+  hasMoved = false
+  startX = e.clientX
+  startY = e.clientY
+  scrollLeft = el.scrollLeft
+  scrollTop = el.scrollTop
+  el.setPointerCapture(e.pointerId)
+  el.style.cursor = 'grabbing'
+  el.style.userSelect = 'none'
+}
+
+function onPointerMove(e: PointerEvent) {
+  if (!isDragging) return
+  const dx = e.clientX - startX
+  const dy = e.clientY - startY
+  if (Math.abs(dx) > 3 || Math.abs(dy) > 3) hasMoved = true
+  const el = scrollContainer.value!
+  el.scrollLeft = scrollLeft - dx
+  el.scrollTop = scrollTop - dy
+}
+
+function onPointerUp(e: PointerEvent) {
+  if (!isDragging) return
+  isDragging = false
+  const el = scrollContainer.value!
+  el.releasePointerCapture(e.pointerId)
+  el.style.cursor = ''
+  el.style.userSelect = ''
+  // If we dragged, prevent the click from triggering node switch
+  if (hasMoved) {
+    el.addEventListener('click', suppressClick, { capture: true, once: true })
+  }
+}
+
+function suppressClick(e: Event) {
+  e.stopPropagation()
+  e.preventDefault()
+}
+
+onUnmounted(() => {
+  scrollContainer.value?.removeEventListener('click', suppressClick, { capture: true })
+})
 </script>
 
 <template>
-  <div class="border-l border-border bg-card/50 overflow-y-auto overflow-x-hidden flex-shrink-0">
-    <div class="p-3 border-b border-border flex items-center justify-between">
+  <div class="border-l border-border bg-card/50 flex flex-col flex-shrink-0">
+    <div class="p-3 border-b border-border flex items-center justify-between flex-shrink-0">
       <h3 class="text-xs font-semibold text-muted-foreground uppercase flex items-center gap-1.5">
         <GitBranch class="w-3.5 h-3.5" />
         {{ t('chatView.branchTree') }}
@@ -51,15 +109,25 @@ function handleScrollTo(messageId: string) {
       </div>
     </div>
 
-    <div v-if="branches.length > 0" class="p-2">
-      <BranchTreeNode
-        v-for="root in branches"
-        :key="root.id"
-        :node="root"
-        :depth="0"
-        @click-node="handleClick"
-        @scroll-to="handleScrollTo"
-      />
+    <div
+      v-if="branches.length > 0"
+      ref="scrollContainer"
+      class="p-2 flex-1 overflow-auto cursor-grab"
+      @pointerdown="onPointerDown"
+      @pointermove="onPointerMove"
+      @pointerup="onPointerUp"
+      @pointercancel="onPointerUp"
+    >
+      <div class="w-max min-w-full">
+        <BranchTreeNode
+          v-for="root in branches"
+          :key="root.id"
+          :node="root"
+          :depth="0"
+          @click-node="handleClick"
+          @scroll-to="handleScrollTo"
+        />
+      </div>
     </div>
     <div v-else class="p-4 text-center text-xs text-muted-foreground">
       {{ t('chatView.noBranches') }}


### PR DESCRIPTION
## Summary
- Replace `overflow-x-hidden` with `overflow: auto` on branch tree panel
- Add pointer-based drag-to-scroll (grab cursor, pan in any direction)
- Deep nested branches no longer clipped — full tree accessible via drag or scrollbar
- Click vs drag detection prevents accidental branch switches while panning

## Test plan
- [ ] Open a chat with deep branch nesting (5+ levels)
- [ ] Branch tree panel shows grab cursor
- [ ] Mouse drag pans the tree horizontally and vertically
- [ ] Single click on a node still switches/scrolls to branch
- [ ] Buttons (new branch, close) still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)