### PR TITLE
fix: include base_dir in collection dict for RAG index loading

### DIFF
--- a/db/repositories/knowledge_collection.py
+++ b/db/repositories/knowledge_collection.py
@@ -59,6 +59,7 @@ class KnowledgeCollectionRepository(BaseRepository[KnowledgeCollection]):
                 "slug": col.slug,
                 "description": col.description,
                 "enabled": col.enabled,
+                "base_dir": col.base_dir,
                 "document_count": doc_count,
                 "created": col.created.isoformat() if col.created else None,
                 "updated": col.updated.isoformat() if col.updated else None,


### PR DESCRIPTION
## Summary
- `get_all_collections()` was missing `base_dir` in the returned dict
- This caused `_load_collection_indexes()` to use default `wiki-pages` dir for all collections
- amoCRM collection (base_dir=`data/crm-dataset`) loaded 0 sections instead of 1158

## Root cause
`db/repositories/knowledge_collection.py:get_all_collections()` built the dict manually and omitted `base_dir`. The orchestrator's `_load_collection_indexes()` then fell back to `Path(col.get("base_dir", "wiki-pages"))` which resolved to `wiki-pages` — wrong directory for amoCRM data.

## Test plan
- [ ] Restart orchestrator, check logs: `collection 5: 1158 секций из 4 файлов`
- [ ] Send message in chat with amoCRM collection → RAG context injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)