### PR TITLE
fix: add instruction prefix for RAG context injection

### DIFF
--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -206,7 +206,13 @@ def _inject_rag_context(
 
     if wiki_context:
         base = base_prompt or _DEFAULT_RAG_PROMPT
-        return f"{base}\n\n{wiki_context}"
+        rag_instruction = (
+            "\n\n--- КОНТЕКСТ ИЗ БАЗЫ ЗНАНИЙ (обязательно к использованию) ---\n"
+            "Ниже приведена релевантная информация из базы знаний. "
+            "ОБЯЗАТЕЛЬНО используй эти данные при ответе. "
+            "Если информация ниже отвечает на вопрос пользователя — ответь на основе неё.\n"
+        )
+        return f"{base}{rag_instruction}\n{wiki_context}"
 
     return base_prompt
 


### PR DESCRIPTION
## Summary
- RAG context from knowledge base was being ignored by LLM when appended to large system prompts
- Added explicit instruction header before RAG context (`ОБЯЗАТЕЛЬНО используй эти данные`) to force the model to prioritize knowledge base data
- Only changes how context is injected — does not modify any system prompts set by users

## Test plan
- [ ] Send a question to a chat with amoCRM collection enabled — verify the answer uses RAG data
- [ ] Verify normal chats without RAG still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)