### PR TITLE
fix: use session prompt as RAG injection base

### DIFF
--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -436,8 +436,9 @@ async def admin_send_chat_message(
     user_msg = await async_chat_manager.add_message(session_id, "user", msg_request.content)
 
     # Получаем историю для LLM
-    default_prompt = None
-    if hasattr(llm_service, "get_system_prompt"):
+    # Session prompt takes priority; fallback to LLM service default
+    default_prompt = session.get("system_prompt")
+    if not default_prompt and hasattr(llm_service, "get_system_prompt"):
         default_prompt = llm_service.get_system_prompt()
 
     # RAG: inject relevant wiki context based on rag_mode
@@ -588,7 +589,8 @@ async def admin_stream_chat_message(
     user_msg = await async_chat_manager.add_message(session_id, "user", msg_request.content)
 
     # Получаем историю для LLM
-    default_prompt = custom_prompt
+    # Priority: widget prompt > session prompt > LLM service default
+    default_prompt = custom_prompt or session.get("system_prompt")
     if not default_prompt and hasattr(active_llm, "get_system_prompt"):
         default_prompt = active_llm.get_system_prompt()
 
@@ -686,8 +688,8 @@ async def admin_edit_chat_message(
     if not llm_service:
         return {"message": edited_msg}
 
-    default_prompt = None
-    if hasattr(llm_service, "get_system_prompt"):
+    default_prompt = session.get("system_prompt")
+    if not default_prompt and hasattr(llm_service, "get_system_prompt"):
         default_prompt = llm_service.get_system_prompt()
 
     # RAG: inject relevant wiki context based on rag_mode
@@ -779,8 +781,8 @@ async def admin_regenerate_chat_response(
         parent_id = message_id
 
     # Generate new response
-    default_prompt = None
-    if hasattr(llm_service, "get_system_prompt"):
+    default_prompt = session.get("system_prompt")
+    if not default_prompt and hasattr(llm_service, "get_system_prompt"):
         default_prompt = llm_service.get_system_prompt()
 
     # RAG: inject relevant wiki context based on rag_mode

--- a/db/repositories/chat.py
+++ b/db/repositories/chat.py
@@ -624,8 +624,8 @@ class ChatRepository(BaseRepository[ChatSession]):
 
         messages = []
 
-        # Add system prompt
-        prompt = session.system_prompt or system_prompt
+        # Add system prompt (passed system_prompt already includes session prompt + RAG)
+        prompt = system_prompt or session.system_prompt
         if prompt:
             messages.append({"role": "system", "content": prompt})
 


### PR DESCRIPTION
## Summary
- **Root cause**: RAG context was injected into the LLM service default prompt, but `get_messages_for_llm()` prioritized `session.system_prompt` — so the RAG-enriched prompt was silently discarded
- Now the router starts with `session.system_prompt` as the base for RAG injection
- `get_messages_for_llm()` now prioritizes the passed (RAG-enriched) prompt over session's raw prompt
- Affects all 4 chat endpoints: send, stream, edit, regenerate

## Test plan
- [x] Tested: "Что такое фонарь?" in STALKER ELECTRIC chat — correctly returns amoCRM deal data (ID #24385707, status, amount)
- [ ] Verify chats without RAG still use session system_prompt correctly
- [ ] Verify widget chats still use widget system_prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)