### PR TITLE
feat: per-session RAG collection settings

### DIFF
--- a/admin/src/api/chat.ts
+++ b/admin/src/api/chat.ts
@@ -40,6 +40,8 @@ export interface ChatSession {
   context_files?: { name: string; content: string }[]
   source?: 'admin' | 'telegram' | 'widget' | 'whatsapp' | null
   source_id?: string
+  rag_mode?: string | null
+  knowledge_collection_ids?: number[] | null
   created: string
   updated: string
   sibling_info?: Record<string, SiblingInfo>
@@ -91,7 +93,7 @@ export const chatApi = {
       source_id: sourceId,
     }),
 
-  updateSession: (sessionId: string, data: { title?: string; system_prompt?: string; pinned?: boolean; context_files?: { name: string; content: string }[] }) =>
+  updateSession: (sessionId: string, data: { title?: string; system_prompt?: string; pinned?: boolean; context_files?: { name: string; content: string }[]; rag_mode?: string; knowledge_collection_ids?: number[] }) =>
     api.put<{ session: ChatSession }>(`/admin/chat/sessions/${sessionId}`, data),
 
   deleteSession: (sessionId: string) =>

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -144,11 +144,9 @@ const audioChunks = ref<Blob[]>([])
 // LLM selection state
 const selectedLlmBackend = ref<string>(localStorage.getItem('chat-llm-backend') || '')
 
-// RAG selection state
-const selectedRagMode = ref<string>(localStorage.getItem('chat-rag-mode') || '')
-const selectedCollectionIds = ref<number[]>(
-  localStorage.getItem('chat-rag-collections') ? JSON.parse(localStorage.getItem('chat-rag-collections')!) : []
-)
+// RAG selection state (per-session, loaded from session data)
+const selectedRagMode = ref<string>('')
+const selectedCollectionIds = ref<number[]>([])
 
 // Save voice mode preference
 watch(voiceMode, (val) => {
@@ -160,17 +158,21 @@ watch(selectedLlmBackend, (val) => {
   localStorage.setItem('chat-llm-backend', val)
 })
 
-// Save RAG selection
-watch(selectedRagMode, (val) => {
-  localStorage.setItem('chat-rag-mode', val)
-})
-watch(selectedCollectionIds, (val) => {
-  if (val.length) {
-    localStorage.setItem('chat-rag-collections', JSON.stringify(val))
-  } else {
-    localStorage.removeItem('chat-rag-collections')
-  }
-}, { deep: true })
+// Save RAG selection to session (per-chat)
+let ragSaveTimer: ReturnType<typeof setTimeout> | null = null
+function saveRagToSession() {
+  if (!currentSessionId.value) return
+  if (ragSaveTimer) clearTimeout(ragSaveTimer)
+  ragSaveTimer = setTimeout(() => {
+    if (!currentSessionId.value) return
+    chatApi.updateSession(currentSessionId.value, {
+      rag_mode: selectedRagMode.value || 'none',
+      knowledge_collection_ids: selectedRagMode.value === 'selected' ? selectedCollectionIds.value : [],
+    })
+  }, 500)
+}
+watch(selectedRagMode, saveRagToSession)
+watch(selectedCollectionIds, saveRagToSession, { deep: true })
 
 // Queries
 const { data: sessionsData, refetch: refetchSessions } = useQuery({
@@ -276,6 +278,9 @@ watch(currentSession, (session) => {
   if (session) {
     customPrompt.value = session.system_prompt || ''
     contextFiles.value = session.context_files ? [...session.context_files] : []
+    // Load per-session RAG settings
+    selectedRagMode.value = session.rag_mode || ''
+    selectedCollectionIds.value = session.knowledge_collection_ids || []
   }
   attachedFiles.value = []
 })

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -276,6 +276,7 @@ class UpdateSessionRequest(BaseModel):
     pinned: Optional[bool] = None
     rag_mode: Optional[str] = None
     knowledge_collection_id: Optional[int] = None
+    knowledge_collection_ids: Optional[list[int]] = None
     context_files: Optional[list] = None  # [{"name": str, "content": str}]
 
 
@@ -394,6 +395,7 @@ async def admin_update_chat_session(
         pinned=request.pinned,
         rag_mode=request.rag_mode,
         knowledge_collection_id=request.knowledge_collection_id,
+        knowledge_collection_ids=request.knowledge_collection_ids,
         context_files=request.context_files,
     )
     if not session:

--- a/db/repositories/chat.py
+++ b/db/repositories/chat.py
@@ -145,6 +145,7 @@ class ChatRepository(BaseRepository[ChatSession]):
         pinned: Optional[bool] = None,
         rag_mode: Optional[str] = None,
         knowledge_collection_id: Optional[int] = None,
+        knowledge_collection_ids: Optional[list[int]] = None,
         context_files: Optional[list] = None,
     ) -> Optional[dict]:
         """Update session title, system prompt, pinned status, RAG config, or context files."""
@@ -170,6 +171,12 @@ class ChatRepository(BaseRepository[ChatSession]):
             # Allow unsetting with 0 or -1
             session.knowledge_collection_id = (
                 knowledge_collection_id if knowledge_collection_id > 0 else None
+            )
+        if knowledge_collection_ids is not None:
+            import json as _json
+
+            session.knowledge_collection_ids = (
+                _json.dumps(knowledge_collection_ids) if knowledge_collection_ids else None
             )
         if context_files is not None:
             import json


### PR DESCRIPTION
## Summary
- RAG mode and collection IDs are now stored **per chat session** in the database instead of a single global localStorage value
- Switching between chats loads that session's RAG configuration
- Changes auto-saved to session via API with 500ms debounce
- Backend: added `knowledge_collection_ids` to `UpdateSessionRequest` and `update_session()`

## Test plan
- [ ] Open STALKER ELECTRIC chat — verify amoCRM collection is selected
- [ ] Switch to another chat — verify RAG settings reset (not inherited from STALKER)
- [ ] Change RAG settings in one chat, switch away and back — verify settings persisted
- [ ] Create new chat — verify RAG settings start empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)