### PR TITLE
fix: session update crash, logout cache, CRM web role

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { RouterView, useRoute, useRouter } from 'vue-router'
+import { useQueryClient } from '@tanstack/vue-query'
 import {
   Settings,
   Menu,
@@ -68,8 +69,11 @@ const currentTitle = computed(() => {
 
 const isLoginPage = computed(() => route.name === 'login')
 
+const queryClient = useQueryClient()
+
 function handleLogout() {
   authStore.logout()
+  queryClient.clear()
   router.push('/login')
 }
 

--- a/admin/src/router.ts
+++ b/admin/src/router.ts
@@ -130,7 +130,7 @@ const router = createRouter({
       path: '/crm',
       name: 'crm',
       component: CrmView,
-      meta: { title: 'CRM', icon: 'Users', minRole: 'user' }
+      meta: { title: 'CRM', icon: 'Users', minRole: 'user', excludeRoles: ['web'] }
     },
     {
       path: '/sales',

--- a/db/integration.py
+++ b/db/integration.py
@@ -160,6 +160,7 @@ class AsyncChatManager:
         pinned: Optional[bool] = None,
         rag_mode: Optional[str] = None,
         knowledge_collection_id: Optional[int] = None,
+        knowledge_collection_ids: Optional[list[int]] = None,
         context_files: Optional[list] = None,
     ) -> Optional[dict]:
         """Update session title, system prompt, pinned status, RAG config, or context files."""
@@ -172,6 +173,7 @@ class AsyncChatManager:
                 pinned=pinned,
                 rag_mode=rag_mode,
                 knowledge_collection_id=knowledge_collection_id,
+                knowledge_collection_ids=knowledge_collection_ids,
                 context_files=context_files,
             )
 


### PR DESCRIPTION
## Summary
- **db/integration.py**: Add missing `knowledge_collection_ids` parameter to `AsyncChatManager.update_session()` — fixes `TypeError` causing 500 on all session updates with multi-collection RAG settings (broken since PR #258)
- **admin/src/App.vue**: Clear TanStack Query cache on logout so switching accounts shows correct user data immediately instead of stale cached sessions from previous account
- **admin/src/router.ts**: Hide CRM tab from `web` role via `excludeRoles: ['web']`

## Test plan
- [ ] Update a chat session with RAG collection settings — should return 200 (was 500)
- [ ] Log out and log in as a different user — chat list should refresh immediately
- [ ] Log in as `web` role — CRM tab should not be visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)