### PR TITLE
ui: collapse sidebars by default

### DIFF
--- a/admin/src/composables/useSidebarCollapse.ts
+++ b/admin/src/composables/useSidebarCollapse.ts
@@ -1,7 +1,8 @@
 import { ref, watch } from 'vue'
 
 export function useSidebarCollapse(storageKey: string) {
-  const collapsed = ref(localStorage.getItem(storageKey) === 'true')
+  const stored = localStorage.getItem(storageKey)
+  const collapsed = ref(stored === null ? true : stored === 'true')
   watch(collapsed, (val) => localStorage.setItem(storageKey, String(val)))
   const toggle = () => { collapsed.value = !collapsed.value }
   return { collapsed, toggle }

--- a/admin/src/stores/settings.ts
+++ b/admin/src/stores/settings.ts
@@ -3,7 +3,7 @@ import { ref, watch } from 'vue'
 
 export const useSettingsStore = defineStore('settings', () => {
   // UI Settings (persisted to localStorage)
-  const sidebarCollapsed = ref(false)
+  const sidebarCollapsed = ref(true)
   const autoRefreshInterval = ref(5000) // ms
   const theme = ref<'dark' | 'light'>('dark')
 
@@ -12,7 +12,7 @@ export const useSettingsStore = defineStore('settings', () => {
   if (savedSettings) {
     try {
       const parsed = JSON.parse(savedSettings)
-      sidebarCollapsed.value = parsed.sidebarCollapsed ?? false
+      sidebarCollapsed.value = parsed.sidebarCollapsed ?? true
       autoRefreshInterval.value = parsed.autoRefreshInterval ?? 5000
       theme.value = parsed.theme ?? 'dark'
     } catch {


### PR DESCRIPTION
## Summary
- Main nav sidebar defaults to collapsed (settings store)
- Chat list sidebar defaults to collapsed (useSidebarCollapse composable)
- Existing users with saved localStorage preferences are not affected

## Test plan
- [ ] Clear localStorage, reload — both sidebars collapsed
- [ ] Expand sidebars, reload — stays expanded (saved preference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)