### PR TITLE
feat: visual indicators for chat sharing state

### DIFF
--- a/admin/src/api/chat.ts
+++ b/admin/src/api/chat.ts
@@ -65,6 +65,7 @@ export interface ChatSessionSummary {
   updated: string
   is_shared_with_me?: boolean
   share_permission?: string
+  share_count?: number
 }
 
 export interface ChatShare {

--- a/admin/src/api/demo/chat.ts
+++ b/admin/src/api/demo/chat.ts
@@ -96,6 +96,7 @@ function sessionToSummary(s: ChatSessionData) {
     updated: s.updated,
     is_shared_with_me: false,
     share_permission: 'owner',
+    share_count: (demoShares[s.id] || []).length,
   }
 }
 

--- a/admin/src/plugins/i18n.ts
+++ b/admin/src/plugins/i18n.ts
@@ -314,6 +314,7 @@ const messages = {
       chatForked: 'Чат скопирован',
       readOnlyHint: 'Только для чтения',
       sharedWithYou: 'Доступ открыт',
+      sharedByYou: 'Вы поделились ({count})',
       shareDialog: {
         title: 'Поделиться чатом',
         searchUsers: 'Поиск пользователей...',
@@ -1305,6 +1306,7 @@ const messages = {
       chatForked: 'Chat forked',
       readOnlyHint: 'Read-only',
       sharedWithYou: 'Shared with you',
+      sharedByYou: 'Shared by you ({count})',
       shareDialog: {
         title: 'Share chat',
         searchUsers: 'Search users...',
@@ -2295,6 +2297,7 @@ const messages = {
       chatForked: 'Чат көшірілді',
       readOnlyHint: 'Тек оқу',
       sharedWithYou: 'Сізбен бөлісілген',
+      sharedByYou: 'Сіз бөлістіңіз ({count})',
       shareDialog: {
         title: 'Чатпен бөлісу',
         searchUsers: 'Пайдаланушыларды іздеу...',

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -1204,8 +1204,10 @@ watch(sessions, (newSessions) => {
             @click="selectSession(session.id)"
           >
             <div v-if="session.pinned" class="absolute top-1 left-1 w-2 h-2 rounded-full bg-primary" />
-            <div class="w-8 h-8 rounded-full border border-border bg-transparent flex items-center justify-center text-xs font-medium text-muted-foreground shrink-0">
+            <div class="w-8 h-8 rounded-full border border-border bg-transparent flex items-center justify-center text-xs font-medium text-muted-foreground shrink-0 relative">
               {{ session.title.trim().slice(0, 2).toUpperCase() }}
+              <span v-if="session.is_shared_with_me" class="absolute bottom-0 right-0 w-2.5 h-2.5 rounded-full bg-blue-400 border-2 border-card" :title="t('chatView.sharedWithYou')" />
+              <span v-else-if="(session.share_count ?? 0) > 0" class="absolute bottom-0 right-0 w-2.5 h-2.5 rounded-full bg-green-400 border-2 border-card" :title="t('chatView.sharedByYou', { count: session.share_count })" />
             </div>
           </button>
         </div>
@@ -1301,6 +1303,7 @@ watch(sessions, (newSessions) => {
                 >
                   <Pin v-if="session.pinned" class="w-3 h-3 text-primary shrink-0" />
                   <Users v-if="session.is_shared_with_me" class="w-3 h-3 text-blue-400 shrink-0" :title="t('chatView.sharedWithYou')" />
+                  <Share2 v-else-if="(session.share_count ?? 0) > 0" class="w-3 h-3 text-green-400 shrink-0" :title="t('chatView.sharedByYou', { count: session.share_count })" />
                   {{ session.title }}
                 </p>
               </template>
@@ -1467,14 +1470,19 @@ watch(sessions, (newSessions) => {
             </div>
           </div>
           <!-- Share button (owner/admin only) -->
-          <button
-            v-if="isSessionOwner && !isSharedWithMe"
-            class="p-2 rounded-lg hover:bg-secondary transition-colors"
-            :title="t('chatView.shareChat')"
-            @click="showShareDialog = true"
-          >
-            <Share2 class="w-4 h-4" />
-          </button>
+          <div v-if="isSessionOwner && !isSharedWithMe" class="relative">
+            <button
+              class="p-2 rounded-lg hover:bg-secondary transition-colors"
+              :title="t('chatView.shareChat')"
+              @click="showShareDialog = true"
+            >
+              <Share2 class="w-4 h-4" />
+              <span
+                v-if="(currentSession?.share_count ?? 0) > 0"
+                class="absolute -top-1 -right-1 w-4 h-4 text-[10px] font-bold rounded-full bg-green-500 text-white flex items-center justify-center border border-background"
+              >{{ currentSession!.share_count }}</span>
+            </button>
+          </div>
           <!-- Fork button (read-only shared sessions) -->
           <button
             v-if="isReadOnly"

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -372,7 +372,7 @@ async def admin_list_chat_sessions(
     if owner_id is not None:
         shared_perms = await async_chat_share_manager.get_shared_sessions_with_permissions(user.id)
 
-    def _enrich(sessions_list: list[dict]) -> list[dict]:
+    def _enrich(sessions_list: list[dict], share_counts: dict[str, int]) -> list[dict]:
         for s in sessions_list:
             sid = s.get("id", "")
             s_owner = s.get("owner_id")
@@ -382,17 +382,22 @@ async def admin_list_chat_sessions(
             else:
                 s["is_shared_with_me"] = False
                 s["share_permission"] = "owner"
+            s["share_count"] = share_counts.get(sid, 0)
         return sessions_list
 
     if group_by == "source":
         grouped = await async_chat_manager.list_sessions_grouped(owner_id=owner_id)
+        all_ids = [s["id"] for sl in grouped.values() for s in sl]
+        share_counts = await async_chat_share_manager.get_share_counts(all_ids) if all_ids else {}
         for source_key in grouped:
-            _enrich(grouped[source_key])
+            _enrich(grouped[source_key], share_counts)
         return {"sessions": grouped, "grouped": True}
     sessions = await async_chat_manager.list_sessions(
         owner_id=owner_id, source=source, exclude_source=exclude_source
     )
-    _enrich(sessions)
+    all_ids = [s["id"] for s in sessions]
+    share_counts = await async_chat_share_manager.get_share_counts(all_ids) if all_ids else {}
+    _enrich(sessions, share_counts)
     return {"sessions": sessions}
 
 

--- a/db/integration.py
+++ b/db/integration.py
@@ -1356,6 +1356,12 @@ class AsyncChatShareManager:
             repo = ChatShareRepository(session)
             return await repo.get_user_permission(session_id, user_id)
 
+    async def get_share_counts(self, session_ids: list[str]) -> dict[str, int]:
+        """Get share counts for multiple sessions in a single query."""
+        async with AsyncSessionLocal() as session:
+            repo = ChatShareRepository(session)
+            return await repo.get_share_counts(session_ids)
+
     async def get_shared_sessions_with_permissions(self, user_id: int) -> Dict[str, str]:
         """Get dict of session_id -> permission for all sessions shared with user."""
         async with AsyncSessionLocal() as session:

--- a/db/repositories/chat_share.py
+++ b/db/repositories/chat_share.py
@@ -5,7 +5,7 @@ Repository for managing chat session sharing between users.
 from datetime import datetime
 from typing import List, Optional
 
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.models import ChatSessionShare, User
@@ -124,6 +124,17 @@ class ChatShareRepository(BaseRepository[ChatSessionShare]):
         )
         await self.session.commit()
         return int(result.rowcount)  # type: ignore[attr-defined]
+
+    async def get_share_counts(self, session_ids: list[str]) -> dict[str, int]:
+        """Get share counts for multiple sessions in a single query."""
+        if not session_ids:
+            return {}
+        result = await self.session.execute(
+            select(ChatSessionShare.session_id, func.count())
+            .where(ChatSessionShare.session_id.in_(session_ids))
+            .group_by(ChatSessionShare.session_id)
+        )
+        return {row[0]: row[1] for row in result.all()}
 
     async def get_shared_sessions_with_permissions(self, user_id: int) -> dict[str, str]:
         """Get dict of session_id -> permission for all sessions shared with user."""


### PR DESCRIPTION
## Summary
- Add `share_count` to `list_sessions` API via batch `GROUP BY` query (single DB round-trip)
- Collapsed sidebar: colored dots on avatar (blue = shared with me, green = I shared)
- Expanded sidebar: `Share2` icon in green for my shared chats
- Green badge counter on Share button in chat header (same style as RAG collections badge)
- i18n `sharedByYou` key in ru/en/kk
- Demo mode: `share_count` in session summary

## Test plan
- [ ] Open chat with shared sessions — verify blue/green dots in collapsed sidebar
- [ ] Expand sidebar — verify Share2 icon appears for sessions shared by you
- [ ] Open a shared chat — verify green badge with count on Share button in header
- [ ] Check demo mode shows share_count after sharing in dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)