### PR TITLE
fix: branch tree access control + per-branch sharing (#266)

### DIFF
--- a/alembic/versions/20260220_0001_add_share_branch_message_id.py
+++ b/alembic/versions/20260220_0001_add_share_branch_message_id.py
@@ -1,0 +1,30 @@
+"""Add branch_message_id to chat_session_shares for per-branch sharing
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-02-20
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0004"
+down_revision: Union[str, None] = "0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chat_session_shares",
+        sa.Column("branch_message_id", sa.String(50), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("chat_session_shares", "branch_message_id")

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -950,10 +950,35 @@ async def admin_summarize_branch(
 # ============== Branch Endpoints ==============
 
 
+async def _get_branch_visible_ids(session_id: str, user: User) -> tuple[dict, Optional[set[str]]]:
+    """Check session access and compute visible message IDs for branch endpoints.
+
+    Returns (session_data, visible_ids). visible_ids is None for owner/admin (full tree).
+    """
+    owner_id = None if user.role == "admin" else user.id
+    session_data = await async_chat_manager.get_session(session_id, owner_id=owner_id)
+    if not session_data:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    visible_ids: Optional[set[str]] = None
+    if user.role != "admin":
+        session_owner = session_data.get("owner_id")
+        if session_owner not in (user.id, None):
+            # Shared user — restrict to shared branch
+            share = await async_chat_share_manager.get_user_share(session_id, user.id)
+            if share and share.get("branch_message_id"):
+                visible_ids = await async_chat_manager.compute_branch_visible_ids(
+                    session_id, share["branch_message_id"]
+                )
+
+    return session_data, visible_ids
+
+
 @router.get("/sessions/{session_id}/branches")
 async def admin_get_branch_tree(session_id: str, user: User = Depends(get_current_user)):
     """Получить дерево веток чата"""
-    branches = await async_chat_manager.get_branch_tree(session_id)
+    _, visible_ids = await _get_branch_visible_ids(session_id, user)
+    branches = await async_chat_manager.get_branch_tree(session_id, visible_ids=visible_ids)
     return {"branches": branches}
 
 
@@ -964,6 +989,12 @@ async def admin_switch_branch(
     user: User = Depends(get_current_user),
 ):
     """Переключить активную ветку"""
+    _, visible_ids = await _get_branch_visible_ids(session_id, user)
+
+    # For shared users, verify the target message is within the visible branch
+    if visible_ids is not None and request.message_id not in visible_ids:
+        raise HTTPException(status_code=403, detail="Message not in shared branch")
+
     success = await async_chat_manager.switch_branch(session_id, request.message_id)
     if not success:
         raise HTTPException(status_code=404, detail="Message not found")
@@ -1026,8 +1057,16 @@ async def admin_share_session(
     if request.user_id == user.id:
         raise HTTPException(status_code=400, detail="Cannot share with yourself")
 
+    # Snapshot current branch tip (last active message)
+    active_messages = await async_chat_manager.get_active_messages(session_id)
+    branch_message_id = active_messages[-1]["id"] if active_messages else None
+
     share = await async_chat_share_manager.add_share(
-        session_id, request.user_id, request.permission, shared_by=user.id
+        session_id,
+        request.user_id,
+        request.permission,
+        shared_by=user.id,
+        branch_message_id=branch_message_id,
     )
     return {"share": share}
 

--- a/db/integration.py
+++ b/db/integration.py
@@ -247,11 +247,19 @@ class AsyncChatManager:
             repo = ChatRepository(session)
             return await repo.delete_message(session_id, message_id)
 
-    async def get_branch_tree(self, session_id: str) -> List[dict]:
-        """Get full branch tree structure for a session."""
+    async def get_branch_tree(
+        self, session_id: str, visible_ids: Optional[set[str]] = None
+    ) -> List[dict]:
+        """Get branch tree structure for a session."""
         async with AsyncSessionLocal() as session:
             repo = ChatRepository(session)
-            return await repo.get_branch_tree(session_id)
+            return await repo.get_branch_tree(session_id, visible_ids=visible_ids)
+
+    async def compute_branch_visible_ids(self, session_id: str, branch_message_id: str) -> set[str]:
+        """Compute visible message IDs for a shared branch."""
+        async with AsyncSessionLocal() as session:
+            repo = ChatRepository(session)
+            return await repo.compute_branch_visible_ids(session_id, branch_message_id)
 
     async def get_sibling_info(self, session_id: str) -> dict:
         """Get sibling info for messages with alternatives."""
@@ -1332,11 +1340,21 @@ class AsyncChatShareManager:
         user_id: int,
         permission: str = "read",
         shared_by: Optional[int] = None,
+        branch_message_id: Optional[str] = None,
     ) -> dict:
         """Add or update a share."""
         async with AsyncSessionLocal() as session:
             repo = ChatShareRepository(session)
-            return await repo.add_share(session_id, user_id, permission, shared_by)
+            return await repo.add_share(
+                session_id, user_id, permission, shared_by, branch_message_id
+            )
+
+    async def get_user_share(self, session_id: str, user_id: int) -> Optional[dict]:
+        """Get full share record for a user (with branch_message_id)."""
+        async with AsyncSessionLocal() as session:
+            repo = ChatShareRepository(session)
+            share = await repo.get_share(session_id, user_id)
+            return share.to_dict() if share else None
 
     async def remove_share(self, session_id: str, user_id: int) -> bool:
         """Remove a share."""

--- a/db/models.py
+++ b/db/models.py
@@ -269,6 +269,7 @@ class ChatSessionShare(Base):
         Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
     )
     shared_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    branch_message_id: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
 
     __table_args__ = (
         Index("ix_chat_session_shares_session_user", "session_id", "user_id", unique=True),
@@ -282,6 +283,7 @@ class ChatSessionShare(Base):
             "permission": self.permission,
             "shared_by": self.shared_by,
             "shared_at": self.shared_at.isoformat() if self.shared_at else None,
+            "branch_message_id": self.branch_message_id,
         }
 
 

--- a/db/repositories/chat.py
+++ b/db/repositories/chat.py
@@ -446,8 +446,13 @@ class ChatRepository(BaseRepository[ChatSession]):
         messages = result.scalars().all()
         return [m.to_dict() for m in messages]
 
-    async def get_branch_tree(self, session_id: str) -> List[dict]:
-        """Get full branch tree structure for a session."""
+    async def get_branch_tree(
+        self, session_id: str, visible_ids: Optional[set[str]] = None
+    ) -> List[dict]:
+        """Get branch tree structure for a session.
+
+        If visible_ids is provided, only messages in the set are included.
+        """
         result = await self.session.execute(
             select(ChatMessage)
             .where(ChatMessage.session_id == session_id)
@@ -461,6 +466,8 @@ class ChatRepository(BaseRepository[ChatSession]):
         # Build lookup maps
         children_map: Dict[Optional[str], List[ChatMessage]] = {}
         for m in all_messages:
+            if visible_ids is not None and m.id not in visible_ids:
+                continue
             children_map.setdefault(m.parent_id, []).append(m)
 
         def build_node(msg: ChatMessage) -> dict:
@@ -473,9 +480,50 @@ class ChatRepository(BaseRepository[ChatSession]):
                 "children": [build_node(c) for c in kids],
             }
 
-        # Root nodes are messages with no parent
+        # Root nodes are messages with no parent (or whose parent is filtered out)
         roots = children_map.get(None, [])
         return [build_node(r) for r in roots]
+
+    async def compute_branch_visible_ids(self, session_id: str, branch_message_id: str) -> set[str]:
+        """Compute visible message IDs for a shared branch.
+
+        Returns the set of ancestors (linear path to root) + the tip message
+        + all descendants of the tip (with sub-branches).
+        """
+        result = await self.session.execute(
+            select(ChatMessage.id, ChatMessage.parent_id).where(
+                ChatMessage.session_id == session_id
+            )
+        )
+        rows = result.all()
+
+        parent_map: Dict[str, Optional[str]] = {}
+        children_map: Dict[str, List[str]] = {}
+        for msg_id, parent_id in rows:
+            parent_map[msg_id] = parent_id
+            if parent_id:
+                children_map.setdefault(parent_id, []).append(msg_id)
+
+        if branch_message_id not in parent_map:
+            return set()
+
+        visible: set[str] = set()
+
+        # Walk ancestors from tip to root
+        current: Optional[str] = branch_message_id
+        while current:
+            visible.add(current)
+            current = parent_map.get(current)
+
+        # BFS descendants from tip
+        queue = [branch_message_id]
+        while queue:
+            mid = queue.pop()
+            for child_id in children_map.get(mid, []):
+                visible.add(child_id)
+                queue.append(child_id)
+
+        return visible
 
     async def get_sibling_info(self, session_id: str) -> Dict[str, dict]:
         """Get sibling info for messages that have alternatives.

--- a/db/repositories/chat_share.py
+++ b/db/repositories/chat_share.py
@@ -52,6 +52,7 @@ class ChatShareRepository(BaseRepository[ChatSessionShare]):
         user_id: int,
         permission: str = "read",
         shared_by: Optional[int] = None,
+        branch_message_id: Optional[str] = None,
     ) -> dict:
         """Add or update a share (upsert)."""
         existing = await self.get_share(session_id, user_id)
@@ -59,6 +60,7 @@ class ChatShareRepository(BaseRepository[ChatSessionShare]):
             existing.permission = permission
             existing.shared_by = shared_by
             existing.shared_at = datetime.utcnow()
+            existing.branch_message_id = branch_message_id
             await self.session.commit()
             await self.session.refresh(existing)
             return existing.to_dict()
@@ -69,6 +71,7 @@ class ChatShareRepository(BaseRepository[ChatSessionShare]):
             permission=permission,
             shared_by=shared_by,
             shared_at=datetime.utcnow(),
+            branch_message_id=branch_message_id,
         )
         self.session.add(share)
         await self.session.commit()


### PR DESCRIPTION
## Summary

- **Branch endpoints had zero access control** — `GET /branches` and `POST /branches/switch` accepted any authenticated user for any session
- Now session access is verified via `owner_id` pattern (same as `GET /sessions/{id}`)
- **Per-branch sharing**: when creating a share, `branch_message_id` (the last active message) is stored as a snapshot
- Shared users see only the shared branch: ancestors of the tip (linear path to root) + all descendants of the tip (including future sub-branches)
- `POST /branches/switch` validates that the target message is within the visible set for shared users

## Changes

| File | What |
|------|------|
| `alembic/versions/20260220_0001_...` | Migration: add `branch_message_id` column to `chat_session_shares` |
| `db/models.py` | `ChatSessionShare.branch_message_id` field + `to_dict()` |
| `db/repositories/chat.py` | `compute_branch_visible_ids()` + `visible_ids` filter in `get_branch_tree()` |
| `db/repositories/chat_share.py` | `branch_message_id` param in `add_share()` |
| `db/integration.py` | Proxy new methods + `get_user_share()` wrapper |
| `app/routers/chat.py` | Access checks in `GET/POST /branches`, tip snapshot in `POST /shares` |

## Test plan

- [ ] Owner sees full branch tree (unchanged behavior)
- [ ] Admin sees full branch tree (unchanged behavior)  
- [ ] Shared user sees only the shared branch (ancestors + descendants of tip)
- [ ] `POST /branches/switch` within visible set — OK
- [ ] `POST /branches/switch` outside visible set — 403
- [ ] Unauthenticated/unauthorized user → `GET /branches` → 404
- [ ] `alembic upgrade head` applies cleanly

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)