### PR TITLE
fix: auto-save context files on every change

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -73,6 +73,7 @@ const showSettings = ref(false)
 const settingsTab = ref<'session' | 'files'>('session')
 const customPrompt = ref('')
 const contextFiles = ref<{ name: string; content: string }[]>([])
+const contextFilesSessionId = ref<string | null>(null) // tracks which session files belong to
 const editingFileIndex = ref<number | null>(null)
 const editingFileName = ref('')
 const editingFileContent = ref('')
@@ -295,7 +296,11 @@ const currentLlmLabel = computed(() => {
 watch(currentSession, (session) => {
   if (session) {
     customPrompt.value = session.system_prompt || ''
-    contextFiles.value = session.context_files ? [...session.context_files] : []
+    // Only reset context files when switching to a different session (not on refetch)
+    if (session.id !== contextFilesSessionId.value) {
+      contextFiles.value = session.context_files ? [...session.context_files] : []
+      contextFilesSessionId.value = session.id
+    }
     // Load per-session RAG settings
     selectedRagMode.value = session.rag_mode || ''
     selectedCollectionIds.value = session.knowledge_collection_ids || []
@@ -439,10 +444,20 @@ const deleteMessageMutation = useMutation({
 const saveContextFilesMutation = useMutation({
   mutationFn: ({ sessionId, files }: { sessionId: string; files: { name: string; content: string }[] }) =>
     chatApi.updateSession(sessionId, { context_files: files }),
-  onSuccess: () => {
+  onSuccess: (_data, variables) => {
+    // Sync local state with what was saved to avoid watcher overwrite
+    contextFilesSessionId.value = variables.sessionId
     refetchSession()
   },
 })
+
+function autoSaveContextFiles() {
+  if (!currentSessionId.value) return
+  saveContextFilesMutation.mutate({
+    sessionId: currentSessionId.value,
+    files: contextFiles.value,
+  })
+}
 
 const summarizeBranchMutation = useMutation({
   mutationFn: ({ sessionId, messageId }: { sessionId: string; messageId: string }) =>
@@ -857,11 +872,15 @@ function triggerContextFileUpload() {
 function handleContextFileUpload(event: Event) {
   const input = event.target as HTMLInputElement
   if (!input.files) return
-  Array.from(input.files).forEach(file => {
+  const files = Array.from(input.files)
+  let loaded = 0
+  files.forEach(file => {
     const reader = new FileReader()
     reader.onload = (e) => {
       const content = e.target?.result as string
       contextFiles.value.push({ name: file.name, content })
+      loaded++
+      if (loaded === files.length) autoSaveContextFiles()
     }
     reader.readAsText(file)
   })
@@ -891,6 +910,7 @@ function saveContextFileEdit() {
   editingFileIndex.value = null
   editingFileName.value = ''
   editingFileContent.value = ''
+  autoSaveContextFiles()
 }
 
 function cancelContextFileEdit() {
@@ -911,14 +931,11 @@ function removeContextFile(index: number) {
   if (editingFileIndex.value === index) {
     editingFileIndex.value = null
   }
+  autoSaveContextFiles()
 }
 
 function saveContextFiles() {
-  if (!currentSessionId.value) return
-  saveContextFilesMutation.mutate({
-    sessionId: currentSessionId.value,
-    files: contextFiles.value,
-  })
+  autoSaveContextFiles()
 }
 
 function copyToClipboard(text: string) {


### PR DESCRIPTION
## Summary
- Context files now auto-save to backend on every modification (upload, delete, edit)
- Watcher only resets `contextFiles` when switching to a different session, not on refetch — prevents deleted files from reappearing
- Added `autoSaveContextFiles()` helper called from `handleContextFileUpload`, `removeContextFile`, and `saveContextFileEdit`

## What was broken
1. Deleting a context file only removed it from local state — any `refetchSession()` (triggered by sending a message, switching branches, etc.) overwrote local state from DB, bringing back "deleted" files
2. Uploading a file only added it to local state — same refetch issue lost the addition
3. Editing a file's content was not persisted until manual Save button click

## Test plan
- [ ] Upload a context file → verify it persists after page refresh
- [ ] Delete a context file → verify it stays deleted after page refresh  
- [ ] Edit a context file name/content → verify changes persist after refresh
- [ ] Switch between sessions → verify each session has its own independent files
- [ ] Send a message after modifying files → verify files don't revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)