### PR TITLE
fix: refresh branch tree after sending/receiving messages

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -365,6 +365,7 @@ const sendMessageMutation = useMutation({
     chatApi.sendMessage(sessionId, content),
   onSuccess: () => {
     refetchSession()
+    refetchBranches()
     refetchSessions()
     scrollToBottom()
   },
@@ -697,6 +698,7 @@ function sendMessage() {
       }
 
       refetchSession().then(() => scrollToBottom())
+      refetchBranches()
       refetchSessions()
       scrollToBottom()
       nextTick(() => messageInputRef.value?.focus())


### PR DESCRIPTION
## Summary
- Added `refetchBranches()` to stream completion handler — branch tree now updates live when a message is sent and the response arrives
- Added `refetchBranches()` to `sendMessageMutation` (non-streaming fallback) for consistency

## What was broken
Branch tree panel only updated after edit, regenerate, delete, or branch switch — but NOT after the main send-message-and-stream-response flow. Users had to refresh the page to see new messages in the tree.

## Test plan
- [ ] Send a message → verify branch tree updates immediately after response
- [ ] Verify existing mutations (edit, regenerate, delete, switch) still update tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)