### PR TITLE
fix: add get_active_messages to AsyncChatManager (share 500 error)

### DIFF
--- a/db/integration.py
+++ b/db/integration.py
@@ -204,6 +204,12 @@ class AsyncChatManager:
             repo = ChatRepository(session)
             return await repo.get_branch_path(session_id, message_id)
 
+    async def get_active_messages(self, session_id: str) -> List[dict]:
+        """Get active (visible) messages for a session."""
+        async with AsyncSessionLocal() as session:
+            repo = ChatRepository(session)
+            return await repo.get_active_messages(session_id)
+
     async def add_message(
         self,
         session_id: str,


### PR DESCRIPTION
## Summary
- Added missing `get_active_messages()` method to `AsyncChatManager` in `db/integration.py`
- The share endpoint (`POST /sessions/{id}/shares`) was calling this method to snapshot the branch tip, but it only existed on `ChatRepository` — causing 500 Internal Server Error

## Test plan
- [ ] Share a chat with another user → should succeed (no 500 error)
- [ ] Verify the shared user can see the correct branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)