### PR TITLE
Fix click on BranchTree nodes (#267)

### DIFF
--- a/admin/src/components/BranchTree.vue
+++ b/admin/src/components/BranchTree.vue
@@ -40,7 +40,7 @@ function onPointerDown(e: PointerEvent) {
   const el = scrollContainer.value
   if (!el) return
   // Don't hijack clicks on buttons/interactive elements
-  if ((e.target as HTMLElement).closest('button')) return
+  if ((e.target as HTMLElement).closest('[data-branch-node], button')) return
   isDragging = true
   hasMoved = false
   startX = e.clientX
@@ -56,7 +56,7 @@ function onPointerMove(e: PointerEvent) {
   if (!isDragging) return
   const dx = e.clientX - startX
   const dy = e.clientY - startY
-  if (Math.abs(dx) > 3 || Math.abs(dy) > 3) hasMoved = true
+  if (Math.abs(dx) > 6 || Math.abs(dy) > 6) hasMoved = true
   const el = scrollContainer.value!
   el.scrollLeft = scrollLeft - dx
   el.scrollTop = scrollTop - dy

--- a/admin/src/components/BranchTreeNode.vue
+++ b/admin/src/components/BranchTreeNode.vue
@@ -56,6 +56,7 @@ function onChildScrollTo(messageId: string) {
           : 'opacity-50 hover:opacity-75 hover:bg-secondary/50',
       ]"
       :style="{ paddingLeft: `${visualDepth * 14 + (isAssistant ? 18 : 4)}px` }"
+      data-branch-node
       :title="node.content_preview"
       @click="onClick"
     >


### PR DESCRIPTION
## Summary
- Drag-to-scroll guard in `BranchTree.vue` only checked for `<button>` elements, but tree nodes are `<div @click>` — clicks on nodes activated drag mode instead of triggering navigation
- Added `data-branch-node` attribute to clickable node divs in `BranchTreeNode.vue` and expanded the guard selector to `[data-branch-node], button`
- Raised `hasMoved` threshold from 3px to 6px to prevent false drag detection on normal clicks

## Test plan
- [ ] Click on tree node (inactive) → switches branch
- [ ] Click on tree node (active) → scrolls to message
- [ ] Collapse/expand chevron still works
- [ ] Drag-to-scroll on empty space still works
- [ ] After real drag, click is still suppressed (no accidental switch)

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)