### PR TITLE
feat: restrict Claude Code to shaerware & ivan

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -1589,9 +1589,9 @@ watch(sessions, (newSessions) => {
             <ArrowDownToLine v-if="inputPosition === 'top'" class="w-4 h-4" />
             <ArrowUpToLine v-else class="w-4 h-4" />
           </button>
-          <!-- Claude Code toggle (admin only) -->
+          <!-- Claude Code toggle (restricted users) -->
           <button
-            v-if="authStore.isAdmin"
+            v-if="['shaerware', 'ivan'].includes(authStore.user?.username ?? '')"
             :class="[
               'p-2 rounded-lg transition-colors',
               cc.isActive.value ? 'bg-green-600 text-white' : 'hover:bg-secondary'

--- a/app/routers/claude_code.py
+++ b/app/routers/claude_code.py
@@ -29,6 +29,7 @@ router = APIRouter(prefix="/admin/claude-code", tags=["claude-code"])
 logger = logging.getLogger(__name__)
 
 CLAUDE_CLI = "/root/.local/bin/claude"
+_ALLOWED_USERS = {"shaerware", "ivan"}
 
 # One active WS per user
 _active_connections: dict[int, WebSocket] = {}
@@ -41,8 +42,8 @@ def _ws_auth(token: str) -> TokenPayload:
     payload = decode_token(token)
     if payload is None:
         raise ValueError("Invalid or expired token")
-    if payload.role != "admin":
-        raise ValueError("Admin access required")
+    if payload.sub not in _ALLOWED_USERS:
+        raise ValueError("Access denied")
     return payload
 
 


### PR DESCRIPTION
## Summary
- Backend: WebSocket auth checks username whitelist (`shaerware`, `ivan`) instead of admin role
- Frontend: Terminal button visible only for allowed usernames

## Test plan
- [ ] Login as shaerware — Terminal button visible, WS connects
- [ ] Login as ivan — Terminal button visible, WS connects
- [ ] Login as other admin — Terminal button hidden, WS rejected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)