### PR TITLE
feat: remove chat from channels nav group

### DIFF
--- a/admin/src/components/AccordionNav.vue
+++ b/admin/src/components/AccordionNav.vue
@@ -74,7 +74,6 @@ const allNavGroups = computed(() => [
     nameKey: 'nav.group.channels',
     icon: MessageCircle,
     items: [
-      { path: '/chat', nameKey: 'nav.chat', icon: MessageCircle },
       { path: '/telegram', nameKey: 'nav.telegram', icon: Send, minRole: 'user' as UserRole },
       { path: '/whatsapp', nameKey: 'nav.whatsapp', icon: WhatsApp, minRole: 'user' as UserRole },
       { path: '/widget', nameKey: 'nav.widget', icon: Code2, minRole: 'user' as UserRole },


### PR DESCRIPTION
## Summary
- Removed /chat item from Channels accordion group (now accessible via sidebar shortcut button)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)