### PR TITLE
fix: relay text/thinking from Claude Code assistant messages

### DIFF
--- a/app/routers/claude_code.py
+++ b/app/routers/claude_code.py
@@ -232,8 +232,22 @@ async def _parse_and_relay(ws: WebSocket, line: str) -> Optional[dict[str, Any]]
                     },
                 )
             elif part.get("type") == "text" and part.get("text"):
-                # For non-streaming fallback
-                pass
+                # Non-streaming fallback: emit as text_delta
+                await _send(
+                    ws,
+                    {
+                        "type": "text_delta",
+                        "text": part["text"],
+                    },
+                )
+            elif part.get("type") == "thinking" and part.get("thinking"):
+                await _send(
+                    ws,
+                    {
+                        "type": "thinking_delta",
+                        "text": part["thinking"],
+                    },
+                )
 
     elif msg_type == "user":
         # User message with tool_result


### PR DESCRIPTION
## Summary
- Fixed Claude Code WS not returning text responses
- The CLI outputs full `assistant` message events (not streaming deltas)
- Parser was ignoring text content blocks (`pass`) — now emits `text_delta`
- Also handles `thinking` blocks in assistant messages → `thinking_delta`

## Test plan
- [x] WS test: "say hello" → receives text_delta + done
- [x] WS test: "read file" → receives tool_use + tool_result + text_delta + done

🤖 Generated with [Claude Code](https://claude.ai/claude-code)