### PR TITLE
fix: Claude Code CLI starts from /root

### DIFF
--- a/app/routers/claude_code.py
+++ b/app/routers/claude_code.py
@@ -89,7 +89,7 @@ async def _run_claude(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         env=env,
-        cwd="/opt/ai-secretary",
+        cwd="/root",
     )
 
     _active_processes[user_id] = process


### PR DESCRIPTION
## Summary
- Changed working directory for Claude Code subprocess from `/opt/ai-secretary` to `/root` (same as SSH login)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)