### PR TITLE
feat: persistent Claude Code sessions + new session/stop buttons

### DIFF
--- a/admin/src/composables/useClaudeCode.ts
+++ b/admin/src/composables/useClaudeCode.ts
@@ -1,4 +1,4 @@
-import { ref, onUnmounted } from 'vue'
+import { ref } from 'vue'
 import {
   createClaudeCodeWs,
   type CcWsEvent,
@@ -21,248 +21,256 @@ export interface CcToolBlock {
   collapsed: boolean
 }
 
-export function useClaudeCode() {
-  // State
-  const isActive = ref(false)
-  const isConnected = ref(false)
-  const isProcessing = ref(false)
-  const cliSessionId = ref<string | null>(null)
-  const dbSessionId = ref<string | null>(null)
-  const streamingText = ref('')
-  const thinkingText = ref('')
-  const currentToolBlocks = ref<CcToolBlock[]>([])
-  const messages = ref<CcMessage[]>([])
-  const currentModel = ref<string | null>(null)
-  const error = ref<string | null>(null)
+// ---- Global singleton state (persists across route changes) ----
+const isActive = ref(false)
+const isConnected = ref(false)
+const isProcessing = ref(false)
+const cliSessionId = ref<string | null>(null)
+const dbSessionId = ref<string | null>(null)
+const streamingText = ref('')
+const thinkingText = ref('')
+const currentToolBlocks = ref<CcToolBlock[]>([])
+const messages = ref<CcMessage[]>([])
+const currentModel = ref<string | null>(null)
+const error = ref<string | null>(null)
 
-  // WebSocket connection
-  let ws: ReturnType<typeof createClaudeCodeWs> | null = null
+let ws: ReturnType<typeof createClaudeCodeWs> | null = null
+const isDemo = import.meta.env.VITE_DEMO_MODE === 'true'
 
-  const isDemo = import.meta.env.VITE_DEMO_MODE === 'true'
+function handleEvent(event: CcWsEvent) {
+  error.value = null
 
-  function handleEvent(event: CcWsEvent) {
-    error.value = null
+  switch (event.type) {
+    case 'session_created':
+      dbSessionId.value = event.session.id
+      break
 
-    switch (event.type) {
-      case 'session_created':
-        dbSessionId.value = event.session.id
-        break
-
-      case 'session_init':
-        cliSessionId.value = event.session_id
-        if (event.model) currentModel.value = event.model
-        isProcessing.value = true
-        streamingText.value = ''
-        thinkingText.value = ''
-        currentToolBlocks.value = []
-        break
-
-      case 'text_delta':
-        streamingText.value += event.text
-        break
-
-      case 'thinking_delta':
-        thinkingText.value += event.text
-        break
-
-      case 'tool_use_start':
-        currentToolBlocks.value.push({
-          tool_use_id: event.tool_use_id,
-          name: event.name,
-          collapsed: true,
-        })
-        break
-
-      case 'tool_use_input': {
-        const block = currentToolBlocks.value.find(b => b.tool_use_id === event.tool_use_id)
-        if (block) {
-          block.input = typeof event.input === 'string'
-            ? event.input
-            : JSON.stringify(event.input, null, 2)
-        }
-        break
-      }
-
-      case 'tool_use_input_delta': {
-        // Append to last tool block's input
-        const lastBlock = currentToolBlocks.value[currentToolBlocks.value.length - 1]
-        if (lastBlock) {
-          lastBlock.input = (lastBlock.input || '') + event.partial_json
-        }
-        break
-      }
-
-      case 'tool_result': {
-        const block = currentToolBlocks.value.find(b => b.tool_use_id === event.tool_use_id)
-        if (block) {
-          block.result = event.content
-          block.is_error = event.is_error
-        }
-        break
-      }
-
-      case 'done': {
-        // Flush current streaming into a message
-        _flushMessage()
-        if (event.session_id) cliSessionId.value = event.session_id
-        isProcessing.value = false
-        break
-      }
-
-      case 'error':
-        error.value = event.error
-        isProcessing.value = false
-        // Flush any partial content
-        if (streamingText.value || currentToolBlocks.value.length) {
-          _flushMessage()
-        }
-        break
-
-      case 'aborted':
-        isProcessing.value = false
-        if (streamingText.value || currentToolBlocks.value.length) {
-          _flushMessage()
-        }
-        break
-    }
-  }
-
-  function _flushMessage() {
-    if (!streamingText.value && !thinkingText.value && currentToolBlocks.value.length === 0) return
-    messages.value.push({
-      role: 'assistant',
-      content: streamingText.value,
-      thinking: thinkingText.value || undefined,
-      toolBlocks: currentToolBlocks.value.length > 0
-        ? [...currentToolBlocks.value]
-        : undefined,
-      timestamp: new Date().toISOString(),
-    })
-    streamingText.value = ''
-    thinkingText.value = ''
-    currentToolBlocks.value = []
-  }
-
-  function connect() {
-    if (isDemo) {
-      isConnected.value = true
-      return
-    }
-    if (ws) return
-    ws = createClaudeCodeWs(handleEvent)
-    ws.ws.onopen = () => {
-      isConnected.value = true
-      error.value = null
-    }
-    const origClose = ws.ws.onclose
-    ws.ws.onclose = (e) => {
-      isConnected.value = false
-      if (origClose) (origClose as (ev: CloseEvent) => void)(e)
-      ws = null
-    }
-  }
-
-  function disconnect() {
-    if (ws) {
-      ws.close()
-      ws = null
-    }
-    isConnected.value = false
-    isProcessing.value = false
-  }
-
-  function toggle() {
-    if (isActive.value) {
-      isActive.value = false
-      disconnect()
-      // Reset state
-      messages.value = []
+    case 'session_init':
+      cliSessionId.value = event.session_id
+      if (event.model) currentModel.value = event.model
+      isProcessing.value = true
       streamingText.value = ''
       thinkingText.value = ''
       currentToolBlocks.value = []
-      cliSessionId.value = null
-      dbSessionId.value = null
-      currentModel.value = null
-      error.value = null
-    } else {
-      isActive.value = true
-      connect()
-    }
-  }
+      break
 
-  function sendMessage(prompt: string) {
-    if (!prompt.trim()) return
+    case 'text_delta':
+      streamingText.value += event.text
+      break
 
-    // Add user message
-    messages.value.push({
-      role: 'user',
-      content: prompt,
-      timestamp: new Date().toISOString(),
-    })
+    case 'thinking_delta':
+      thinkingText.value += event.text
+      break
 
-    isProcessing.value = true
-    streamingText.value = ''
-    thinkingText.value = ''
-    currentToolBlocks.value = []
-    error.value = null
-
-    if (isDemo) {
-      _demoSimulate()
-      return
-    }
-
-    if (!ws) {
-      error.value = 'Not connected'
-      isProcessing.value = false
-      return
-    }
-
-    if (cliSessionId.value) {
-      // Continue existing session
-      ws.send({
-        action: 'message',
-        prompt,
-        session_id: dbSessionId.value || undefined,
-        cli_session_id: cliSessionId.value,
+    case 'tool_use_start':
+      currentToolBlocks.value.push({
+        tool_use_id: event.tool_use_id,
+        name: event.name,
+        collapsed: true,
       })
-    } else {
-      // Start new session
-      ws.send({ action: 'start', prompt })
-    }
-  }
+      break
 
-  function abort() {
-    if (isDemo) {
-      isProcessing.value = false
-      _flushMessage()
-      return
+    case 'tool_use_input': {
+      const block = currentToolBlocks.value.find(b => b.tool_use_id === event.tool_use_id)
+      if (block) {
+        block.input = typeof event.input === 'string'
+          ? event.input
+          : JSON.stringify(event.input, null, 2)
+      }
+      break
     }
-    if (ws) {
+
+    case 'tool_use_input_delta': {
+      const lastBlock = currentToolBlocks.value[currentToolBlocks.value.length - 1]
+      if (lastBlock) {
+        lastBlock.input = (lastBlock.input || '') + event.partial_json
+      }
+      break
+    }
+
+    case 'tool_result': {
+      const block = currentToolBlocks.value.find(b => b.tool_use_id === event.tool_use_id)
+      if (block) {
+        block.result = event.content
+        block.is_error = event.is_error
+      }
+      break
+    }
+
+    case 'done': {
+      _flushMessage()
+      if (event.session_id) cliSessionId.value = event.session_id
+      isProcessing.value = false
+      break
+    }
+
+    case 'error':
+      error.value = event.error
+      isProcessing.value = false
+      if (streamingText.value || currentToolBlocks.value.length) {
+        _flushMessage()
+      }
+      break
+
+    case 'aborted':
+      isProcessing.value = false
+      if (streamingText.value || currentToolBlocks.value.length) {
+        _flushMessage()
+      }
+      break
+  }
+}
+
+function _flushMessage() {
+  if (!streamingText.value && !thinkingText.value && currentToolBlocks.value.length === 0) return
+  messages.value.push({
+    role: 'assistant',
+    content: streamingText.value,
+    thinking: thinkingText.value || undefined,
+    toolBlocks: currentToolBlocks.value.length > 0
+      ? [...currentToolBlocks.value]
+      : undefined,
+    timestamp: new Date().toISOString(),
+  })
+  streamingText.value = ''
+  thinkingText.value = ''
+  currentToolBlocks.value = []
+}
+
+function connect() {
+  if (isDemo) {
+    isConnected.value = true
+    return
+  }
+  if (ws) return
+  ws = createClaudeCodeWs(handleEvent)
+  ws.ws.onopen = () => {
+    isConnected.value = true
+    error.value = null
+  }
+  const origClose = ws.ws.onclose
+  ws.ws.onclose = (e) => {
+    isConnected.value = false
+    if (origClose) (origClose as (ev: CloseEvent) => void)(e)
+    ws = null
+  }
+}
+
+function disconnect() {
+  if (ws) {
+    ws.close()
+    ws = null
+  }
+  isConnected.value = false
+  isProcessing.value = false
+}
+
+function _resetState() {
+  messages.value = []
+  streamingText.value = ''
+  thinkingText.value = ''
+  currentToolBlocks.value = []
+  cliSessionId.value = null
+  dbSessionId.value = null
+  currentModel.value = null
+  error.value = null
+}
+
+/** Activate / deactivate Claude Code mode */
+function toggle() {
+  if (isActive.value) {
+    // Deactivate: abort if running, disconnect, reset
+    if (isProcessing.value && ws) {
       ws.send({ action: 'abort' })
     }
-  }
-
-  // Demo simulation
-  function _demoSimulate() {
-    const steps = [
-      { delay: 200, fn: () => handleEvent({ type: 'session_init', session_id: 'demo-session-1', model: 'claude-opus-4-6', tools: ['Bash', 'Read', 'Write'], mcp_servers: [] }) },
-      { delay: 400, fn: () => handleEvent({ type: 'thinking_delta', text: 'Let me analyze this request...' }) },
-      { delay: 800, fn: () => handleEvent({ type: 'text_delta', text: 'I\'ll help you with that. ' }) },
-      { delay: 1000, fn: () => handleEvent({ type: 'text_delta', text: 'Let me check the relevant files.' }) },
-      { delay: 1200, fn: () => handleEvent({ type: 'tool_use_start', tool_use_id: 'tool-1', name: 'Read' }) },
-      { delay: 1400, fn: () => handleEvent({ type: 'tool_use_input', tool_use_id: 'tool-1', name: 'Read', input: { file_path: '/opt/ai-secretary/orchestrator.py' } }) },
-      { delay: 1800, fn: () => handleEvent({ type: 'tool_result', tool_use_id: 'tool-1', content: 'File contents displayed (156 lines)', is_error: false }) },
-      { delay: 2200, fn: () => handleEvent({ type: 'text_delta', text: '\n\nI\'ve reviewed the file. Everything looks good!' }) },
-      { delay: 2600, fn: () => handleEvent({ type: 'done', session_id: 'demo-session-1', cost_usd: null, duration_ms: 2400, result: '' }) },
-    ]
-
-    steps.forEach(({ delay, fn }) => setTimeout(fn, delay))
-  }
-
-  onUnmounted(() => {
+    isActive.value = false
     disconnect()
+    _resetState()
+  } else {
+    isActive.value = true
+    connect()
+  }
+}
+
+/** Stop current session and start fresh (keeps CC mode active) */
+function newSession() {
+  if (isProcessing.value && ws) {
+    ws.send({ action: 'abort' })
+  }
+  _resetState()
+  // Reconnect if WS dropped
+  if (!ws && !isDemo) {
+    connect()
+  }
+}
+
+function sendMessage(prompt: string) {
+  if (!prompt.trim()) return
+
+  messages.value.push({
+    role: 'user',
+    content: prompt,
+    timestamp: new Date().toISOString(),
   })
 
+  isProcessing.value = true
+  streamingText.value = ''
+  thinkingText.value = ''
+  currentToolBlocks.value = []
+  error.value = null
+
+  if (isDemo) {
+    _demoSimulate()
+    return
+  }
+
+  if (!ws) {
+    error.value = 'Not connected'
+    isProcessing.value = false
+    return
+  }
+
+  if (cliSessionId.value) {
+    ws.send({
+      action: 'message',
+      prompt,
+      session_id: dbSessionId.value || undefined,
+      cli_session_id: cliSessionId.value,
+    })
+  } else {
+    ws.send({ action: 'start', prompt })
+  }
+}
+
+function abort() {
+  if (isDemo) {
+    isProcessing.value = false
+    _flushMessage()
+    return
+  }
+  if (ws) {
+    ws.send({ action: 'abort' })
+  }
+}
+
+function _demoSimulate() {
+  const steps = [
+    { delay: 200, fn: () => handleEvent({ type: 'session_init', session_id: 'demo-session-1', model: 'claude-opus-4-6', tools: ['Bash', 'Read', 'Write'], mcp_servers: [] }) },
+    { delay: 400, fn: () => handleEvent({ type: 'thinking_delta', text: 'Let me analyze this request...' }) },
+    { delay: 800, fn: () => handleEvent({ type: 'text_delta', text: 'I\'ll help you with that. ' }) },
+    { delay: 1000, fn: () => handleEvent({ type: 'text_delta', text: 'Let me check the relevant files.' }) },
+    { delay: 1200, fn: () => handleEvent({ type: 'tool_use_start', tool_use_id: 'tool-1', name: 'Read' }) },
+    { delay: 1400, fn: () => handleEvent({ type: 'tool_use_input', tool_use_id: 'tool-1', name: 'Read', input: { file_path: '/opt/ai-secretary/orchestrator.py' } }) },
+    { delay: 1800, fn: () => handleEvent({ type: 'tool_result', tool_use_id: 'tool-1', content: 'File contents displayed (156 lines)', is_error: false }) },
+    { delay: 2200, fn: () => handleEvent({ type: 'text_delta', text: '\n\nI\'ve reviewed the file. Everything looks good!' }) },
+    { delay: 2600, fn: () => handleEvent({ type: 'done', session_id: 'demo-session-1', cost_usd: null, duration_ms: 2400, result: '' }) },
+  ]
+
+  steps.forEach(({ delay, fn }) => setTimeout(fn, delay))
+}
+
+// ---- Public composable (returns same global refs every time) ----
+export function useClaudeCode() {
   return {
     isActive,
     isConnected,
@@ -276,6 +284,7 @@ export function useClaudeCode() {
     currentModel,
     error,
     toggle,
+    newSession,
     connect,
     disconnect,
     sendMessage,

--- a/admin/src/plugins/i18n.ts
+++ b/admin/src/plugins/i18n.ts
@@ -333,6 +333,7 @@ const messages = {
         abort: 'Прервать выполнение',
         welcome: 'Введите запрос для Claude Code CLI',
         thinking: 'Размышление',
+        newSession: 'Новая сессия Claude Code',
       },
     },
     // Auth
@@ -1334,6 +1335,7 @@ const messages = {
         abort: 'Abort execution',
         welcome: 'Enter a prompt for Claude Code CLI',
         thinking: 'Thinking',
+        newSession: 'New Claude Code session',
       },
     },
     // Auth
@@ -2334,6 +2336,7 @@ const messages = {
         abort: 'Орындауды тоқтату',
         welcome: 'Claude Code CLI үшін сұрау енгізіңіз',
         thinking: 'Ойлану',
+        newSession: 'Жаңа Claude Code сессиясы',
       },
     },
     // Auth

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -1638,21 +1638,22 @@ watch(sessions, (newSessions) => {
           >
             <Settings2 class="w-4 h-4" />
           </button>
-          <!-- New branch from scratch -->
+          <!-- New branch / New CC session -->
           <button
             v-if="!isReadOnly"
-            :disabled="newBranchMutation.isPending.value"
+            :disabled="!cc.isActive.value && newBranchMutation.isPending.value"
             class="p-2 rounded-lg hover:bg-secondary transition-colors"
-            :title="t('chatView.newBranch')"
-            @click="startNewBranch"
+            :title="cc.isActive.value ? t('chatView.claudeCode.newSession') : t('chatView.newBranch')"
+            @click="cc.isActive.value ? cc.newSession() : startNewBranch()"
           >
             <Plus class="w-4 h-4" />
           </button>
+          <!-- Delete chat / Stop CC mode -->
           <button
-            v-if="isSessionOwner"
+            v-if="cc.isActive.value || isSessionOwner"
             class="p-2 rounded-lg text-red-500 hover:bg-red-500/20 transition-colors"
-            title="Delete chat"
-            @click="deleteCurrentSession"
+            :title="cc.isActive.value ? t('chatView.claudeCode.disable') : 'Delete chat'"
+            @click="cc.isActive.value ? cc.toggle() : deleteCurrentSession()"
           >
             <Trash2 class="w-4 h-4" />
           </button>


### PR DESCRIPTION
## Summary
- `useClaudeCode` is now a global singleton — WS and state persist across route changes
- **+** in CC mode: aborts current task, clears messages, starts new session (stays in CC mode)
- **Delete** in CC mode: stops session entirely, switches back to normal chat
- Session keeps running when navigating to other admin tabs

## Test plan
- [ ] Activate CC, send prompt, navigate to LLM tab, come back — session still active with messages
- [ ] In CC mode, click + — messages cleared, can send new prompt
- [ ] In CC mode, click Delete — CC deactivates, back to normal chat
- [ ] Normal mode — + and Delete work as before (new branch / delete chat)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)