### PR TITLE
docs: mark Kanban Stage 3 as complete

### DIFF
--- a/docs/TASK_KANBAN_ROADMAP.md
+++ b/docs/TASK_KANBAN_ROADMAP.md
@@ -1,6 +1,6 @@
 # TASK: Kanban + Roadmap — вкладка «Tasks» в Admin Panel
 
-## Статус: Stage 1 (Backend) ✅ PR #299 | Stage 2 (Kanban Board) ✅ PR #300 | Stage 3 (Roadmap) — PENDING
+## Статус: Stage 1 (Backend) ✅ PR #299 | Stage 2 (Kanban Board) ✅ PR #300 | Stage 3 (Roadmap) ✅ PR #302
 ## Приоритет: HIGH
 ## Оценка: 6/10 сложности | ~4–6 дней
 


### PR DESCRIPTION
## Summary

- Mark Stage 3 (Gantt Roadmap) as complete in `docs/TASK_KANBAN_ROADMAP.md` — PR #302

All 3 stages of #284 are now done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)