### PR TITLE
feat: per-bot sales funnel toggle + fix RAG collection saving

### DIFF
--- a/app/routers/telegram.py
+++ b/app/routers/telegram.py
@@ -69,6 +69,11 @@ class BotInstanceCreateRequest(BaseModel):
     stars_enabled: bool = False
     payment_products: Optional[list] = None
     payment_success_message: Optional[str] = None
+    # Sales funnel
+    sales_funnel_enabled: bool = True
+    # RAG
+    rag_mode: str = "all"
+    knowledge_collection_ids: Optional[List[int]] = None
     # YooMoney OAuth2
     yoomoney_client_id: Optional[str] = None
     yoomoney_client_secret: Optional[str] = None
@@ -99,6 +104,11 @@ class BotInstanceUpdateRequest(BaseModel):
     stars_enabled: Optional[bool] = None
     payment_products: Optional[list] = None
     payment_success_message: Optional[str] = None
+    # Sales funnel
+    sales_funnel_enabled: Optional[bool] = None
+    # RAG
+    rag_mode: Optional[str] = None
+    knowledge_collection_ids: Optional[List[int]] = None
     # YooMoney OAuth2
     yoomoney_client_id: Optional[str] = None
     yoomoney_client_secret: Optional[str] = None

--- a/db/models.py
+++ b/db/models.py
@@ -498,6 +498,9 @@ class BotInstance(Base):
     )
     knowledge_collection_ids: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
+    # Sales funnel
+    sales_funnel_enabled: Mapped[bool] = mapped_column(Boolean, default=True, server_default="1")
+
     # Rate limiting
     rate_limit_count: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     rate_limit_hours: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
@@ -622,6 +625,8 @@ class BotInstance(Base):
             "knowledge_collection_ids": json.loads(self.knowledge_collection_ids)
             if self.knowledge_collection_ids
             else None,
+            # Sales funnel
+            "sales_funnel_enabled": self.sales_funnel_enabled,
             # Rate limiting
             "rate_limit_count": self.rate_limit_count,
             "rate_limit_hours": self.rate_limit_hours,

--- a/db/repositories/bot_instance.py
+++ b/db/repositories/bot_instance.py
@@ -2,6 +2,7 @@
 Bot instance repository for managing Telegram bot instances.
 """
 
+import json
 import logging
 import re
 from datetime import datetime
@@ -129,6 +130,10 @@ class BotInstanceRepository(BaseRepository[BotInstance]):
             yookassa_provider_token=kwargs.get("yookassa_provider_token"),
             stars_enabled=kwargs.get("stars_enabled", False),
             payment_success_message=kwargs.get("payment_success_message"),
+            # Sales funnel
+            sales_funnel_enabled=kwargs.get("sales_funnel_enabled", True),
+            # RAG
+            rag_mode=kwargs.get("rag_mode", "all"),
             # Timestamps
             created=datetime.utcnow(),
             updated=datetime.utcnow(),
@@ -148,6 +153,9 @@ class BotInstanceRepository(BaseRepository[BotInstance]):
             instance.set_action_buttons(DEFAULT_ACTION_BUTTONS)
         if "payment_products" in kwargs:
             instance.set_payment_products(kwargs["payment_products"])
+        if "knowledge_collection_ids" in kwargs:
+            ids = kwargs["knowledge_collection_ids"]
+            instance.knowledge_collection_ids = json.dumps(ids) if ids else None
 
         self.session.add(instance)
         await self.session.commit()
@@ -184,6 +192,10 @@ class BotInstanceRepository(BaseRepository[BotInstance]):
             "yookassa_provider_token",
             "stars_enabled",
             "payment_success_message",
+            # Sales funnel
+            "sales_funnel_enabled",
+            # RAG
+            "rag_mode",
             # YooMoney
             "yoomoney_client_id",
             "yoomoney_client_secret",
@@ -206,6 +218,9 @@ class BotInstanceRepository(BaseRepository[BotInstance]):
             instance.set_action_buttons(kwargs["action_buttons"])
         if "payment_products" in kwargs:
             instance.set_payment_products(kwargs["payment_products"])
+        if "knowledge_collection_ids" in kwargs:
+            ids = kwargs["knowledge_collection_ids"]
+            instance.knowledge_collection_ids = json.dumps(ids) if ids else None
 
         instance.updated = datetime.utcnow()
         await self.session.commit()

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -36,6 +36,8 @@ async def main() -> None:
     # Check for multi-instance mode
     instance_id = get_bot_instance_id()
 
+    skip_sales = False
+
     if instance_id:
         # Multi-instance mode: try pre-fetched config file first, then API
         logger.info(f"Multi-instance mode: loading config for {instance_id}")
@@ -51,7 +53,13 @@ async def main() -> None:
         if bot_config:
             set_bot_config(bot_config)
             bot_token = bot_config.bot_token
-            set_action_buttons(bot_config.action_buttons or DEFAULT_ACTION_BUTTONS)
+            if bot_config.sales_funnel_enabled:
+                set_action_buttons(bot_config.action_buttons or DEFAULT_ACTION_BUTTONS)
+            else:
+                skip_sales = True
+                # Use bot's own action_buttons (may contain URL buttons)
+                set_action_buttons(bot_config.action_buttons or [])
+                logger.info("Sales funnel disabled for this bot instance")
             logger.info(f"Loaded config for bot: {bot_config.name}")
             logger.info(f"LLM backend: {bot_config.llm_backend}")
             logger.info(f"Action buttons: {len(get_action_buttons())} configured")
@@ -74,7 +82,7 @@ async def main() -> None:
     logger.info("Sales DB initialized")
 
     # Register routers (pass action_buttons for keyboard building)
-    dp.include_router(get_main_router())
+    dp.include_router(get_main_router(skip_sales=skip_sales))
 
     logger.info("Starting Telegram bot (polling)…")
 

--- a/telegram_bot/config.py
+++ b/telegram_bot/config.py
@@ -134,6 +134,7 @@ class BotConfig:
     payment_currency: str = "RUB"
     yoomoney_token: str | None = None
     auto_start: bool = False
+    sales_funnel_enabled: bool = True
 
     # Merged settings from TelegramSettings for convenience
     stream_edit_interval: float = 1.5
@@ -190,6 +191,7 @@ def load_config_from_file(instance_id: str) -> BotConfig | None:
             payment_currency=instance.get("payment_currency", "RUB"),
             yoomoney_token=instance.get("yoomoney_access_token"),
             auto_start=instance.get("auto_start", False),
+            sales_funnel_enabled=instance.get("sales_funnel_enabled", True),
             admin_ids=set(),
         )
     except Exception as e:
@@ -261,5 +263,6 @@ async def load_config_from_api(instance_id: str, max_retries: int = 5) -> BotCon
         payment_currency=instance.get("payment_currency", "RUB"),
         yoomoney_token=instance.get("yoomoney_access_token"),
         auto_start=instance.get("auto_start", False),
+        sales_funnel_enabled=instance.get("sales_funnel_enabled", True),
         admin_ids=admin_ids,
     )

--- a/telegram_bot/handlers/__init__.py
+++ b/telegram_bot/handlers/__init__.py
@@ -1,7 +1,17 @@
 """Telegram bot handlers."""
 
-from aiogram import Router
+import json
+import logging
+import os
+from pathlib import Path
 
+from aiogram import Router
+from aiogram.filters import CommandStart
+from aiogram.fsm.context import FSMContext
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, Message, ReplyKeyboardRemove
+
+from ..services.session_store import get_session_store
+from ..state import get_action_buttons
 from .callbacks import router as callbacks_router
 from .commands import router as commands_router
 from .files import router as files_router
@@ -11,11 +21,82 @@ from .sales import get_sales_router
 from .tz import router as tz_router
 
 
-def get_main_router() -> Router:
+logger = logging.getLogger(__name__)
+
+
+def _get_welcome_message() -> str:
+    """Read welcome_message from bot config file (fallback to generic)."""
+    config_file = os.environ.get("BOT_CONFIG_FILE")
+    if config_file:
+        try:
+            data = json.loads(Path(config_file).read_text())
+            msg = data.get("welcome_message")
+            if msg:
+                return msg
+        except Exception:
+            pass
+    return "Здравствуйте! Я AI-ассистент. Напишите мне ваш вопрос."
+
+
+def _build_url_keyboard() -> InlineKeyboardMarkup | None:
+    """Build inline keyboard from action_buttons that have a 'url' field."""
+    buttons = get_action_buttons()
+    rows = []
+    for btn in sorted(buttons, key=lambda b: b.get("order", 99)):
+        if not btn.get("enabled", True):
+            continue
+        url = btn.get("url")
+        if not url:
+            continue
+        icon = btn.get("icon", "")
+        label = btn.get("label", url)
+        text = f"{icon} {label}" if icon else label
+        rows.append([InlineKeyboardButton(text=text, url=url)])
+    return InlineKeyboardMarkup(inline_keyboard=rows) if rows else None
+
+
+def _make_simple_start_router() -> Router:
+    """Create a minimal /start router (no sales funnel)."""
+    router = Router()
+
+    @router.message(CommandStart())
+    async def cmd_start_simple(message: Message, state: FSMContext) -> None:
+        """Handle /start — show welcome message and go straight to AI chat."""
+        if not message.from_user:
+            return
+
+        # Ensure AI-chat session exists
+        store = get_session_store()
+        store.get_or_create(message.from_user.id)
+
+        # Clear any leftover FSM state
+        await state.clear()
+
+        welcome = _get_welcome_message()
+        first_name = message.from_user.first_name
+        if first_name:
+            welcome = f"{welcome}\n\n{first_name}, напишите ваш вопрос 👇"
+
+        # Remove reply keyboard, show inline URL buttons if configured
+        url_kb = _build_url_keyboard()
+        await message.answer(
+            welcome,
+            reply_markup=url_kb or ReplyKeyboardRemove(),
+        )
+
+    return router
+
+
+def get_main_router(skip_sales: bool = False) -> Router:
     """Create and configure the main router with all sub-routers."""
     main_router = Router()
-    # Sales funnel first — handles /start, sales: callbacks, FSM text input
-    main_router.include_router(get_sales_router())
+    if skip_sales:
+        # Simple /start handler, no sales funnel
+        main_router.include_router(_make_simple_start_router())
+        logger.info("Sales funnel disabled — using simple /start handler")
+    else:
+        # Sales funnel first — handles /start, sales: callbacks, FSM text input
+        main_router.include_router(get_sales_router())
     # TZ (technical specification) quiz
     main_router.include_router(tz_router)
     # News handler


### PR DESCRIPTION
## Summary
- Add `sales_funnel_enabled` per-bot flag to disable sales funnel entirely (simple /start → AI chat)
- Support URL-type action buttons as inline keyboard for bots without sales funnel
- Fix RAG `rag_mode` / `knowledge_collection_ids` not saving via admin API (fields were missing from request models and repository)
- Configure stalkerelectricbot: sales funnel off, single URL button to stalkerelectric.kz, RAG limited to amoCRM collection

## Changes
- `db/models.py` — add `sales_funnel_enabled` column to BotInstance + `to_dict()`
- `telegram_bot/config.py` — add field to BotConfig dataclass + both config loaders
- `telegram_bot/handlers/__init__.py` — `get_main_router(skip_sales)`, simple /start handler with URL inline keyboard
- `telegram_bot/bot.py` — wire `skip_sales` flag based on config
- `app/routers/telegram.py` — add `sales_funnel_enabled`, `rag_mode`, `knowledge_collection_ids` to Create/Update request models
- `db/repositories/bot_instance.py` — add fields to `simple_fields` + JSON handling for `knowledge_collection_ids`

## Test plan
- [x] Service restarts healthy
- [x] stalkerelectricbot logs: "Sales funnel disabled", 1 action button, polling OK
- [x] tz-generator unaffected (full sales funnel, 6 buttons)
- [ ] Send /start to stalkerelectricbot — welcome message + URL button, no sales quiz
- [ ] Send text — goes to AI chat with amoCRM RAG context
- [ ] Admin panel: change knowledge collections for a bot → settings persist after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)