### PR TITLE
fix: zen mode button placement in 3 locations

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -10,7 +10,8 @@ import {
   User,
   Languages,
   PanelLeftClose,
-  MessageCircle
+  MessageCircle,
+  Maximize2
 } from 'lucide-vue-next'
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -240,6 +241,16 @@ const localeTitle: Record<string, string> = { ru: 'Переключить язы
               <h1 class="text-lg md:text-xl font-semibold truncate">{{ currentTitle }}</h1>
             </div>
             <div class="flex items-center gap-2 md:gap-4">
+              <!-- Zen mode (chat page only) -->
+              <button
+                v-if="route.name === 'chat'"
+                class="p-2 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors"
+                :title="t('chatView.zenMode')"
+                @click="chatFullscreenStore.enter()"
+              >
+                <Maximize2 class="w-4 h-4" />
+              </button>
+
               <!-- Language Toggle -->
               <button
                 class="flex items-center gap-1 px-2 py-1.5 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors text-sm font-medium"

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -1334,6 +1334,13 @@ watch(sessions, (newSessions) => {
             <PanelLeftClose class="w-4 h-4" />
           </button>
           <button
+            class="p-2 rounded-lg hover:bg-secondary transition-colors text-muted-foreground"
+            :title="t('chatView.zenMode')"
+            @click="fullscreenStore.enter()"
+          >
+            <Maximize2 class="w-4 h-4" />
+          </button>
+          <button
             :class="[
               'p-2 rounded-lg transition-colors',
               selectionMode ? 'bg-primary text-primary-foreground' : 'hover:bg-secondary'
@@ -1950,15 +1957,6 @@ watch(sessions, (newSessions) => {
               </label>
             </div>
           </div>
-          <!-- Zen (fullscreen) mode toggle -->
-          <button
-            v-if="!cc.isActive.value"
-            class="p-2 rounded-lg hover:bg-secondary transition-colors"
-            :title="t('chatView.zenMode')"
-            @click="fullscreenStore.enter()"
-          >
-            <Maximize2 class="w-4 h-4" />
-          </button>
           <!-- New branch / New CC session -->
           <button
             v-if="!isReadOnly"
@@ -1977,6 +1975,14 @@ watch(sessions, (newSessions) => {
             @click="cc.isActive.value ? cc.toggle() : deleteCurrentSession()"
           >
             <Trash2 class="w-4 h-4" />
+          </button>
+          <!-- Zen (fullscreen) mode toggle -->
+          <button
+            class="p-2 rounded-lg hover:bg-secondary transition-colors"
+            :title="t('chatView.zenMode')"
+            @click="fullscreenStore.enter()"
+          >
+            <Maximize2 class="w-4 h-4" />
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Move zen mode button to last position in chat header toolbar (after delete)
- Add zen mode button to chat sidebar header (between collapse and new chat)
- Add zen mode button to App header bar (visible only on chat page)

## Test plan
- [ ] Verify Maximize2 button appears in App header when on chat page
- [ ] Verify Maximize2 button appears in chat sidebar header
- [ ] Verify Maximize2 button is last in chat header toolbar
- [ ] All three buttons enter fullscreen mode when clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)