### PR TITLE
fix: add zen mode button to collapsed chat sidebar

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -1284,6 +1284,13 @@ watch(sessions, (newSessions) => {
             <PanelLeftOpen class="w-4 h-4" />
           </button>
           <button
+            class="p-2 rounded-lg text-muted-foreground hover:bg-secondary/50 transition-colors"
+            :title="t('chatView.zenMode')"
+            @click="fullscreenStore.enter()"
+          >
+            <Maximize2 class="w-4 h-4" />
+          </button>
+          <button
             :disabled="createSessionMutation.isPending.value"
             class="p-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
             :title="t('chatView.newChat')"


### PR DESCRIPTION
## Summary
- Add Maximize2 (zen mode) button to collapsed sidebar column, between expand and new-chat buttons

## Test plan
- [ ] Collapse chat sidebar, verify zen button appears between expand and plus icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)