### PR TITLE
fix: remove duplicate news broadcast

### DIFF
--- a/telegram_bot/handlers/news.py
+++ b/telegram_bot/handlers/news.py
@@ -16,11 +16,8 @@ from ..config import get_telegram_settings
 from ..sales.database import get_sales_db
 from ..sales.keyboards import submenu_reply_kb
 from ..services.github_news import (
-    check_and_broadcast_commit_news,
     check_and_broadcast_news,
     fetch_merged_prs,
-    fetch_recent_commits,
-    generate_commit_news_post,
     generate_news_post,
 )
 
@@ -121,39 +118,14 @@ async def cmd_news(message: Message, state: FSMContext) -> None:
                 except Exception as e:
                     logger.error(f"Failed to parse news for PR #{pr['number']}: {e}")
 
-        # ── Commit-based news ──────────────────────────────────
-        commit_posts: dict[str, str] = {}  # sha -> post_text
-        all_commits: list[dict] = []
-        for repo in repos:
-            try:
-                commits = await fetch_recent_commits(repo, days=60, limit=10)
-                all_commits.extend(commits)
-            except Exception as e:
-                logger.error(f"Failed to fetch commits from {repo}: {e}")
-
-        if all_commits:
-            commit_shas = [c["sha"] for c in all_commits]
-            cached_commit_posts = await db.get_all_cached_commit_news(commit_shas)
-            commit_posts.update(cached_commit_posts)
-
-            uncached_commits = [c for c in all_commits if c["sha"] not in cached_commit_posts]
-            for commit in uncached_commits:
-                try:
-                    post_text = await generate_commit_news_post(commit)
-                    if post_text:
-                        await db.save_commit_news_cache(
-                            commit["sha"], commit["repo"], commit["message"], post_text
-                        )
-                        commit_posts[commit["sha"]] = post_text
-                except Exception as e:
-                    logger.error(f"Failed to parse commit news for {commit['sha'][:8]}: {e}")
+        # NOTE: commit-based news removed — PR body is canonical NEWS source
+        # (having both caused duplicate messages to subscribers)
 
         # Delete loading message
         await loading_msg.delete()
 
         # Send posts for each PR (in order)
         sent_count = 0
-        has_commit_posts = bool(commit_posts)
         for i, pr in enumerate(prs):
             pr_number = pr["number"]
 
@@ -161,23 +133,8 @@ async def cmd_news(message: Message, state: FSMContext) -> None:
                 continue  # Skip if generation failed
 
             post_text = cached_posts[pr_number]
-            is_last_pr = i == len(prs) - 1
-            # Only attach upsell kb on very last message if no commit posts follow
-            show_upsell = is_last_pr and not has_commit_posts
+            is_last = i == len(prs) - 1
 
-            try:
-                await message.answer(
-                    post_text,
-                    reply_markup=news_upsell_kb() if show_upsell else None,
-                )
-                sent_count += 1
-            except Exception as e:
-                logger.error(f"Failed to send news post: {e}")
-
-        # Send commit-based news posts
-        commit_items = list(commit_posts.items())
-        for i, (sha, post_text) in enumerate(commit_items):
-            is_last = i == len(commit_items) - 1
             try:
                 await message.answer(
                     post_text,
@@ -185,7 +142,7 @@ async def cmd_news(message: Message, state: FSMContext) -> None:
                 )
                 sent_count += 1
             except Exception as e:
-                logger.error(f"Failed to send commit news post: {e}")
+                logger.error(f"Failed to send news post: {e}")
 
         # Log completion
         await db.log_event(
@@ -194,7 +151,6 @@ async def cmd_news(message: Message, state: FSMContext) -> None:
             {
                 "count": sent_count,
                 "generated": len(uncached_prs),
-                "commit_posts": len(commit_posts),
             },
         )
 
@@ -389,7 +345,7 @@ async def cmd_broadcast(message: Message, state: FSMContext) -> None:
     try:
         skip_initial = not force_mode
         await check_and_broadcast_news(message.bot, skip_initial=skip_initial)
-        await check_and_broadcast_commit_news(message.bot, skip_initial=skip_initial)
+        # NOTE: commit-based broadcasting removed — PR body is canonical NEWS source
 
         # Get stats
         subscribers_count = await db.get_subscribers_count()

--- a/telegram_bot/services/github_news.py
+++ b/telegram_bot/services/github_news.py
@@ -535,10 +535,9 @@ async def news_broadcast_scheduler(bot: "Bot", interval_minutes: int = 30) -> No
         except Exception as e:
             logger.error(f"Scheduler error (PR news): {e}")
 
-        try:
-            await check_and_broadcast_commit_news(bot)
-        except Exception as e:
-            logger.error(f"Scheduler error (commit news): {e}")
+        # NOTE: commit-based broadcasting removed — all changes go through PRs
+        # (main is protected), and PR body is the canonical source of ## NEWS.
+        # Having both caused duplicate messages (same NEWS in commit + PR body).
 
         # Wait for next check
         await asyncio.sleep(interval_minutes * 60)


### PR DESCRIPTION
## Summary

- Telegram bot sent each news item **twice** — once from PR body, once from commit message (both contain `## NEWS`)
- Removed commit-based broadcasting from scheduler, `/broadcast` command, and `/news` command
- PR body is now the single canonical source of `## NEWS`

## NEWS

🔧 **Исправлена двойная рассылка новостей**

Бот больше не присылает одну и ту же новость дважды.
Раньше новость находилась и в коммите, и в PR — теперь источник один.

## Test plan

- [ ] Merge this PR and verify only 1 Telegram message is sent (not 2)
- [ ] Run `/news` command in bot — verify no duplicate posts
- [ ] Run `/broadcast` as admin — verify single delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)