### PR TITLE
fix: run news broadcast scheduler only on primary bot

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -97,9 +97,15 @@ async def main() -> None:
         if allowed:
             logger.info(f"Allowed users: {allowed}")
 
-    # Start news broadcast scheduler (checks every 60 minutes)
-    scheduler_task = asyncio.create_task(news_broadcast_scheduler(bot, interval_minutes=60))
-    logger.info("News broadcast scheduler started")
+    # Start news broadcast scheduler only for the primary bot (standalone mode).
+    # Multi-instance bots (BOT_INSTANCE_ID set) are client bots and should not
+    # broadcast project news — otherwise each bot sends duplicates.
+    scheduler_task = None
+    if not instance_id:
+        scheduler_task = asyncio.create_task(news_broadcast_scheduler(bot, interval_minutes=60))
+        logger.info("News broadcast scheduler started")
+    else:
+        logger.info("Skipping news scheduler (multi-instance bot)")
 
     try:
         await dp.start_polling(
@@ -107,11 +113,12 @@ async def main() -> None:
             allowed_updates=["message", "callback_query", "pre_checkout_query"],
         )
     finally:
-        scheduler_task.cancel()
-        try:
-            await scheduler_task
-        except asyncio.CancelledError:
-            pass
+        if scheduler_task:
+            scheduler_task.cancel()
+            try:
+                await scheduler_task
+            except asyncio.CancelledError:
+                pass
         router = get_llm_router()
         await router.close()
         await db.close()


### PR DESCRIPTION
## Summary

- `news_broadcast_scheduler` was started for **every** bot instance (ShaerWare + StalkerElectric)
- Each bot independently found the same NEWS and broadcast it → subscribers got 2x messages
- Now the scheduler only runs in standalone mode (no `BOT_INSTANCE_ID`), i.e. only the primary ShaerWare bot

## NEWS

🔔 **Новости теперь приходят ровно 1 раз**

Исправлен баг, из-за которого подписчики получали дублирующие уведомления от разных ботов.
Теперь рассылку ведёт только один основной бот.

## Test plan

- [ ] Restart service, check logs: primary bot should log "News broadcast scheduler started", secondary should log "Skipping news scheduler (multi-instance bot)"
- [ ] Merge a PR with NEWS section → verify only 1 message arrives per subscriber

🤖 Generated with [Claude Code](https://claude.com/claude-code)