### PR TITLE
feat: replace FAQ page with Wiki pages viewer

### DIFF
--- a/admin/src/api/demo/index.ts
+++ b/admin/src/api/demo/index.ts
@@ -6,6 +6,7 @@ import { monitorRoutes } from './monitor'
 import { llmRoutes, initLlmData } from './llm'
 import { ttsRoutes, createMinimalWav } from './tts'
 import { faqRoutes, initFaqData } from './faq'
+import { wikiRoutes } from './wiki'
 import { chatRoutes, initChatData } from './chat'
 import { telegramRoutes, initTelegramData } from './telegram'
 import { widgetRoutes, initWidgetData } from './widget'
@@ -32,6 +33,7 @@ const allRoutes: DemoRoute[] = [
   ...whatsappRoutes,
   ...widgetRoutes,
   ...chatRoutes,
+  ...wikiRoutes,
   ...faqRoutes,
   ...llmRoutes,
   ...ttsRoutes,

--- a/admin/src/api/demo/wiki.ts
+++ b/admin/src/api/demo/wiki.ts
@@ -1,0 +1,301 @@
+import type { DemoRoute } from './types'
+
+interface WikiDoc {
+  id: number
+  filename: string
+  title: string
+  source_type: string
+  file_size_bytes: number
+  section_count: number
+  collection_id: number | null
+  owner_id: number | null
+  created: string
+  updated: string
+}
+
+const mockDocs: WikiDoc[] = [
+  {
+    id: 1,
+    filename: '01-architecture.md',
+    title: 'Архитектура системы',
+    source_type: 'wiki',
+    file_size_bytes: 4200,
+    section_count: 8,
+    collection_id: null,
+    owner_id: null,
+    created: '2025-12-01T10:00:00Z',
+    updated: '2026-01-15T14:30:00Z',
+  },
+  {
+    id: 2,
+    filename: '02-deployment.md',
+    title: 'Руководство по деплою',
+    source_type: 'wiki',
+    file_size_bytes: 3100,
+    section_count: 6,
+    collection_id: null,
+    owner_id: null,
+    created: '2025-12-05T09:00:00Z',
+    updated: '2026-01-20T11:00:00Z',
+  },
+  {
+    id: 3,
+    filename: '03-llm-config.md',
+    title: 'Настройка LLM',
+    source_type: 'wiki',
+    file_size_bytes: 2800,
+    section_count: 5,
+    collection_id: null,
+    owner_id: null,
+    created: '2025-12-10T08:00:00Z',
+    updated: '2026-02-01T16:00:00Z',
+  },
+  {
+    id: 4,
+    filename: '04-telegram-bot.md',
+    title: 'Telegram бот',
+    source_type: 'wiki',
+    file_size_bytes: 3500,
+    section_count: 7,
+    collection_id: null,
+    owner_id: null,
+    created: '2025-12-15T12:00:00Z',
+    updated: '2026-02-10T09:00:00Z',
+  },
+  {
+    id: 5,
+    filename: '05-faq-system.md',
+    title: 'Система FAQ и быстрых ответов',
+    source_type: 'wiki',
+    file_size_bytes: 1900,
+    section_count: 4,
+    collection_id: null,
+    owner_id: null,
+    created: '2026-01-05T10:00:00Z',
+    updated: '2026-02-15T13:00:00Z',
+  },
+]
+
+const mockContents: Record<number, string> = {
+  1: `# Архитектура системы
+
+## Обзор
+
+AI-секретарь — это модульная система для автоматизации коммуникаций с клиентами. Система состоит из нескольких ключевых компонентов.
+
+## Основные компоненты
+
+- **Оркестратор** — FastAPI-сервер, координирующий все модули
+- **LLM-сервис** — обработка естественного языка (Claude / локальная модель)
+- **TTS-сервис** — синтез речи (XTTS v2)
+- **Wiki-RAG** — поиск по базе знаний (BM25)
+- **Telegram-бот** — интеграция с Telegram
+- **Чат-виджет** — встраиваемый виджет для сайта
+
+## Потоки данных
+
+\`\`\`
+Пользователь → Канал (Telegram/Widget/GSM)
+  → Оркестратор
+    → FAQ-матчинг (быстрый ответ)
+    → Wiki-RAG (поиск контекста)
+    → LLM (генерация ответа)
+  → Ответ пользователю
+\`\`\`
+
+## База данных
+
+Используется SQLite с асинхронным доступом через \`aiosqlite\`. Основные таблицы:
+
+| Таблица | Описание |
+|---------|----------|
+| users | Пользователи системы |
+| chat_sessions | Сессии чата |
+| messages | Сообщения |
+| knowledge_documents | Документы базы знаний |
+| faq_entries | Быстрые ответы |
+
+## Конфигурация
+
+Все настройки хранятся в \`.env\` файле и доступны через admin-панель.
+`,
+  2: `# Руководство по деплою
+
+## Требования
+
+- Python 3.12+
+- Node.js 20+
+- SQLite 3
+- systemd (для production)
+
+## Быстрый старт
+
+\`\`\`bash
+git clone https://github.com/user/ai-secretary.git
+cd ai-secretary
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+\`\`\`
+
+## Production деплой
+
+### Systemd сервис
+
+\`\`\`ini
+[Unit]
+Description=AI Secretary
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/ai-secretary
+EnvironmentFile=/opt/ai-secretary/.env
+ExecStart=/opt/ai-secretary/venv/bin/python -m uvicorn app.main:app --port 8002
+
+[Install]
+WantedBy=multi-user.target
+\`\`\`
+
+### Nginx
+
+Nginx используется как reverse proxy для API и для раздачи статики admin-панели.
+
+## Обновление
+
+\`\`\`bash
+cd /opt/ai-secretary && bash deploy.sh
+\`\`\`
+
+Скрипт \`deploy.sh\` выполняет полный цикл: backup → git pull → build → restart → health check.
+`,
+  3: `# Настройка LLM
+
+## Поддерживаемые бэкенды
+
+1. **Cloud (Claude)** — через Claude API или Claude Code bridge
+2. **Локальная модель** — llama.cpp / vLLM на GPU
+
+## Cloud режим
+
+\`\`\`env
+LLM_BACKEND=cloud:claude-bridge-stalkerelectric
+DEPLOYMENT_MODE=cloud
+\`\`\`
+
+В cloud-режиме используется Claude через bridge-сервис. Не требует GPU.
+
+## Промпт-система
+
+Промпт собирается из нескольких частей:
+
+1. **Системный промпт** — базовые инструкции
+2. **Wiki-контекст** — релевантные фрагменты из базы знаний
+3. **История чата** — последние сообщения
+4. **Пользовательский запрос**
+
+> Порядок сборки промпта критичен для качества ответов.
+
+## Параметры генерации
+
+| Параметр | Значение | Описание |
+|----------|----------|----------|
+| temperature | 0.7 | Креативность ответа |
+| max_tokens | 2048 | Максимальная длина |
+| top_p | 0.9 | Nucleus sampling |
+`,
+  4: `# Telegram бот
+
+## Настройка
+
+1. Создайте бота через [@BotFather](https://t.me/BotFather)
+2. Получите токен
+3. Укажите токен в настройках admin-панели
+
+## Мультибот
+
+Система поддерживает несколько Telegram-ботов одновременно. Каждый бот может:
+
+- Иметь свой **системный промпт**
+- Использовать свою **коллекцию** базы знаний
+- Работать с отдельными настройками LLM
+
+## Команды
+
+- \`/start\` — начало работы
+- \`/help\` — справка
+- \`/reset\` — сброс контекста
+
+## Webhook vs Polling
+
+В production рекомендуется использовать **webhook** для надёжности. Polling подходит для разработки.
+
+\`\`\`python
+# Webhook URL формат
+https://your-domain.com/webhooks/telegram/{bot_id}
+\`\`\`
+
+## Inline-кнопки
+
+Бот поддерживает inline-клавиатуры для интерактивных сценариев (запись, выбор услуги, оплата).
+`,
+  5: `# Система FAQ и быстрых ответов
+
+## Принцип работы
+
+FAQ-система обрабатывает входящие сообщения **до** отправки в LLM. Если найдено совпадение, ответ возвращается мгновенно.
+
+## Матчинг
+
+Используется **нечёткое сравнение** (fuzzy matching):
+
+- Регистронезависимый поиск
+- Частичное совпадение подстроки
+- Приоритет точного совпадения
+
+## Шаблонные переменные
+
+В ответах FAQ можно использовать переменные:
+
+- \`{current_time}\` — текущее время
+- \`{current_date}\` — текущая дата
+- \`{day_of_week}\` — день недели
+
+## Управление
+
+FAQ управляется через API (\`/admin/faq\`). Записи хранятся в SQLite и кэшируются в памяти для быстрого доступа.
+
+> **Совет:** Добавляйте в FAQ часто задаваемые вопросы, чтобы снизить нагрузку на LLM и ускорить ответы.
+`,
+}
+
+export const wikiRoutes: DemoRoute[] = [
+  {
+    method: 'GET',
+    pattern: /^\/admin\/wiki-rag\/documents$/,
+    handler: ({ searchParams }) => {
+      const collectionId = searchParams.get('collection_id')
+      let docs = mockDocs
+      if (collectionId) {
+        docs = docs.filter(d => d.collection_id === Number(collectionId))
+      }
+      return { documents: docs, synced: docs.length }
+    },
+  },
+  {
+    method: 'GET',
+    pattern: /^\/admin\/wiki-rag\/documents\/(\d+)$/,
+    handler: ({ matches }) => {
+      const id = Number(matches[1])
+      const doc = mockDocs.find(d => d.id === id)
+      if (!doc) {
+        throw new Error('Document not found')
+      }
+      return {
+        document: doc,
+        content_preview: mockContents[id] || '# No content\n\nContent not available.',
+      }
+    },
+  },
+]

--- a/admin/src/components/AccordionNav.vue
+++ b/admin/src/components/AccordionNav.vue
@@ -17,7 +17,7 @@ import {
   Send,
   Code2,
   Phone,
-  MessageSquare,
+  BookOpen,
   ShoppingCart,
   Users,
   Settings,
@@ -86,7 +86,6 @@ const allNavGroups = computed(() => [
     nameKey: 'nav.group.business',
     icon: ShoppingCart,
     items: [
-      { path: '/faq', nameKey: 'nav.faq', icon: MessageSquare },
       { path: '/sales', nameKey: 'nav.sales', icon: ShoppingCart, minRole: 'user' as UserRole },
       { path: '/crm', nameKey: 'nav.crm', icon: Users, minRole: 'user' as UserRole },
       { path: '/kanban', nameKey: 'nav.kanban', icon: ClipboardList, minRole: 'user' as UserRole },
@@ -97,6 +96,7 @@ const allNavGroups = computed(() => [
     nameKey: 'nav.group.system',
     icon: Settings,
     items: [
+      { path: '/wiki', nameKey: 'nav.wiki', icon: BookOpen },
       { path: '/settings', nameKey: 'common.settings', icon: Settings, minRole: 'user' as UserRole },
       { path: '/about', nameKey: 'nav.about', icon: Info },
     ]

--- a/admin/src/plugins/i18n.ts
+++ b/admin/src/plugins/i18n.ts
@@ -10,6 +10,7 @@ const messages = {
       llm: 'LLM',
       tts: 'Голос',
       faq: 'FAQ',
+      wiki: 'Wiki',
       finetune: 'Обучение',
       monitoring: 'Мониторинг',
       models: 'Модели',
@@ -152,7 +153,17 @@ const messages = {
       createPreset: 'Создать пресет',
       speed: 'Скорость'
     },
-    // FAQ
+    // Wiki
+    wiki: {
+      title: 'Wiki проекта',
+      search: 'Поиск по страницам...',
+      noPages: 'Страницы не найдены',
+      sections: 'разделов',
+      back: 'К списку',
+      loading: 'Загрузка...',
+      selectPage: 'Выберите страницу для чтения'
+    },
+    // FAQ (kept for backend)
     faq: {
       title: 'Редактор FAQ',
       addEntry: 'Добавить запись',
@@ -1070,6 +1081,7 @@ const messages = {
       llm: 'LLM',
       tts: 'TTS',
       faq: 'FAQ',
+      wiki: 'Wiki',
       finetune: 'Fine-tune',
       monitoring: 'Monitoring',
       models: 'Models',
@@ -1212,7 +1224,17 @@ const messages = {
       createPreset: 'Create Preset',
       speed: 'Speed'
     },
-    // FAQ
+    // Wiki
+    wiki: {
+      title: 'Project Wiki',
+      search: 'Search pages...',
+      noPages: 'No pages found',
+      sections: 'sections',
+      back: 'Back to list',
+      loading: 'Loading...',
+      selectPage: 'Select a page to read'
+    },
+    // FAQ (kept for backend)
     faq: {
       title: 'FAQ Editor',
       addEntry: 'Add Entry',
@@ -2130,6 +2152,7 @@ const messages = {
       llm: 'LLM',
       tts: 'Дауыс',
       faq: 'FAQ',
+      wiki: 'Wiki',
       finetune: 'Оқыту',
       monitoring: 'Мониторинг',
       models: 'Модельдер',
@@ -2271,7 +2294,17 @@ const messages = {
       createPreset: 'Пресет жасау',
       speed: 'Жылдамдық'
     },
-    // FAQ
+    // Wiki
+    wiki: {
+      title: 'Жоба Wiki',
+      search: 'Беттерді іздеу...',
+      noPages: 'Беттер табылмады',
+      sections: 'бөлімдер',
+      back: 'Тізімге',
+      loading: 'Жүктелуде...',
+      selectPage: 'Оқу үшін бетті таңдаңыз'
+    },
+    // FAQ (kept for backend)
     faq: {
       title: 'FAQ редакторы',
       addEntry: 'Жазба қосу',

--- a/admin/src/router.ts
+++ b/admin/src/router.ts
@@ -62,10 +62,10 @@ const router = createRouter({
       meta: { title: 'TTS', icon: 'Mic', minRole: 'user', excludeRoles: ['web'], localOnly: true }
     },
     {
-      path: '/faq',
-      name: 'faq',
+      path: '/wiki',
+      name: 'wiki',
       component: FaqView,
-      meta: { title: 'FAQ', icon: 'MessageSquare' }
+      meta: { title: 'Wiki', icon: 'BookOpen' }
     },
     {
       path: '/finetune',

--- a/admin/src/views/FaqView.vue
+++ b/admin/src/views/FaqView.vue
@@ -1,333 +1,177 @@
 <script setup lang="ts">
-import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
-import { faqApi } from '@/api'
-import {
-  MessageSquare,
-  Plus,
-  Pencil,
-  Trash2,
-  RotateCw,
-  Search,
-  TestTube2,
-  X,
-  Info
-} from 'lucide-vue-next'
-import { ref, computed } from 'vue'
+import { useQuery } from '@tanstack/vue-query'
+import { wikiRagApi, type KnowledgeDocument } from '@/api/wikiRag'
+import { BookOpen, Search, ArrowLeft, FileText, Loader2 } from 'lucide-vue-next'
+import { ref, computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 
-const queryClient = useQueryClient()
+const { t } = useI18n()
 
 // State
 const searchQuery = ref('')
-const showAddModal = ref(false)
-const editingEntry = ref<{ trigger: string; response: string } | null>(null)
-const testText = ref('')
-const testResult = ref<{ match: boolean; response: string | null } | null>(null)
+const selectedDocId = ref<number | null>(null)
+const isMobileDetail = ref(false)
 
-const formTrigger = ref('')
-const formResponse = ref('')
-
-// Queries
-const { data: faqData, isLoading, refetch } = useQuery({
-  queryKey: ['faq'],
-  queryFn: () => faqApi.getAll(),
+// Fetch document list
+const { data: docsData, isLoading: isLoadingList } = useQuery({
+  queryKey: ['wiki-documents'],
+  queryFn: () => wikiRagApi.getDocuments(),
 })
 
-// Mutations
-const addMutation = useMutation({
-  mutationFn: ({ trigger, response }: { trigger: string; response: string }) =>
-    faqApi.add(trigger, response),
-  onSuccess: () => {
-    queryClient.invalidateQueries({ queryKey: ['faq'] })
-    closeModal()
-  },
+// Fetch selected document content
+const { data: docDetail, isLoading: isLoadingDoc } = useQuery({
+  queryKey: computed(() => ['wiki-document', selectedDocId.value]),
+  queryFn: () => wikiRagApi.getDocument(selectedDocId.value!),
+  enabled: computed(() => selectedDocId.value != null),
 })
 
-const updateMutation = useMutation({
-  mutationFn: ({ oldTrigger, trigger, response }: { oldTrigger: string; trigger: string; response: string }) =>
-    faqApi.update(oldTrigger, trigger, response),
-  onSuccess: () => {
-    queryClient.invalidateQueries({ queryKey: ['faq'] })
-    closeModal()
-  },
-})
-
-const deleteMutation = useMutation({
-  mutationFn: (trigger: string) => faqApi.delete(trigger),
-  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['faq'] }),
-})
-
-const reloadMutation = useMutation({
-  mutationFn: () => faqApi.reload(),
-  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['faq'] }),
-})
-
-const testMutation = useMutation({
-  mutationFn: (text: string) => faqApi.test(text),
-  onSuccess: (data) => {
-    testResult.value = data
-  },
-})
-
-// Computed
-const faqEntries = computed(() => {
-  if (!faqData.value?.faq) return []
-
-  let entries = Object.entries(faqData.value.faq).map(([trigger, response]) => ({
-    trigger,
-    response,
-  }))
-
+// Filtered list
+const documents = computed(() => {
+  if (!docsData.value?.documents) return []
+  let docs = docsData.value.documents
   if (searchQuery.value) {
-    const query = searchQuery.value.toLowerCase()
-    entries = entries.filter(
-      e => e.trigger.toLowerCase().includes(query) ||
-           e.response.toLowerCase().includes(query)
-    )
+    const q = searchQuery.value.toLowerCase()
+    docs = docs.filter(d => d.title.toLowerCase().includes(q) || d.filename.toLowerCase().includes(q))
   }
-
-  return entries.sort((a, b) => a.trigger.localeCompare(b.trigger))
+  return docs.sort((a, b) => a.title.localeCompare(b.title))
 })
 
-// Methods
-function openAddModal() {
-  editingEntry.value = null
-  formTrigger.value = ''
-  formResponse.value = ''
-  showAddModal.value = true
+// Rendered markdown
+const renderedContent = computed(() => {
+  const raw = docDetail.value?.content_preview
+  if (!raw) return ''
+  return DOMPurify.sanitize(marked.parse(raw) as string)
+})
+
+const selectedDoc = computed(() => {
+  if (!selectedDocId.value || !docsData.value?.documents) return null
+  return docsData.value.documents.find(d => d.id === selectedDocId.value) ?? null
+})
+
+function selectDoc(doc: KnowledgeDocument) {
+  selectedDocId.value = doc.id
+  isMobileDetail.value = true
 }
 
-function openEditModal(entry: { trigger: string; response: string }) {
-  editingEntry.value = entry
-  formTrigger.value = entry.trigger
-  formResponse.value = entry.response
-  showAddModal.value = true
+function goBack() {
+  isMobileDetail.value = false
 }
 
-function closeModal() {
-  showAddModal.value = false
-  editingEntry.value = null
-  formTrigger.value = ''
-  formResponse.value = ''
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  return `${(bytes / 1024).toFixed(1)} KB`
 }
 
-function saveEntry() {
-  if (!formTrigger.value || !formResponse.value) return
-
-  if (editingEntry.value) {
-    updateMutation.mutate({
-      oldTrigger: editingEntry.value.trigger,
-      trigger: formTrigger.value,
-      response: formResponse.value,
-    })
-  } else {
-    addMutation.mutate({
-      trigger: formTrigger.value,
-      response: formResponse.value,
-    })
-  }
-}
-
-function runTest() {
-  if (testText.value) {
-    testMutation.mutate(testText.value)
-  }
-}
+// Reset detail when doc changes
+watch(selectedDocId, () => {
+  // just triggers refetch via queryKey
+})
 </script>
 
 <template>
-  <div class="space-y-6">
-    <!-- Toolbar -->
-    <div class="flex items-center gap-4 flex-wrap">
-      <button
-        class="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
-        @click="openAddModal"
+  <div class="h-full flex flex-col">
+    <!-- Header -->
+    <div class="flex items-center gap-3 mb-4">
+      <BookOpen class="w-6 h-6 text-primary" />
+      <h1 class="text-xl font-bold">{{ t('wiki.title') }}</h1>
+      <span v-if="docsData?.documents" class="text-sm text-muted-foreground">
+        ({{ documents.length }})
+      </span>
+    </div>
+
+    <!-- Main layout -->
+    <div class="flex-1 min-h-0 flex gap-4">
+      <!-- List panel -->
+      <div
+        :class="[
+          'flex flex-col border border-border rounded-lg bg-card overflow-hidden',
+          selectedDocId ? 'hidden md:flex md:w-72 lg:w-80 shrink-0' : 'flex-1'
+        ]"
       >
-        <Plus class="w-4 h-4" />
-        Add Entry
-      </button>
-      <button
-        :disabled="reloadMutation.isPending.value"
-        class="flex items-center gap-2 px-4 py-2 bg-secondary rounded-lg hover:bg-secondary/80 disabled:opacity-50 transition-colors"
-        @click="reloadMutation.mutate()"
-      >
-        <RotateCw class="w-4 h-4" />
-        Reload
-      </button>
-
-      <div class="flex-1" />
-
-      <div class="relative">
-        <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-        <input
-          v-model="searchQuery"
-          type="text"
-          placeholder="Search..."
-          class="pl-10 pr-4 py-2 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary w-64"
-        />
-      </div>
-    </div>
-
-    <!-- Template Variables Info -->
-    <div class="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4">
-      <div class="flex items-start gap-3">
-        <Info class="w-5 h-5 text-blue-500 mt-0.5" />
-        <div>
-          <h3 class="font-medium text-blue-500">Template Variables</h3>
-          <p class="text-sm text-muted-foreground mt-1">
-            You can use these placeholders in responses:
-            <code class="bg-secondary px-1 rounded">{'{'}current_time{'}'}</code>,
-            <code class="bg-secondary px-1 rounded">{'{'}current_date{'}'}</code>,
-            <code class="bg-secondary px-1 rounded">{'{'}day_of_week{'}'}</code>
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <!-- FAQ Test -->
-    <div class="bg-card rounded-lg border border-border">
-      <div class="p-4 border-b border-border">
-        <h2 class="text-lg font-semibold flex items-center gap-2">
-          <TestTube2 class="w-5 h-5" />
-          Test FAQ Matching
-        </h2>
-      </div>
-      <div class="p-4">
-        <div class="flex gap-2">
-          <input
-            v-model="testText"
-            type="text"
-            placeholder="Enter text to test..."
-            class="flex-1 px-4 py-2 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
-            @keyup.enter="runTest"
-          />
-          <button
-            :disabled="testMutation.isPending.value || !testText"
-            class="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors"
-            @click="runTest"
-          >
-            Test
-          </button>
-        </div>
-
-        <div v-if="testResult" class="mt-4 p-4 rounded-lg" :class="testResult.match ? 'bg-green-500/10' : 'bg-red-500/10'">
-          <p v-if="testResult.match" class="text-green-500 font-medium">Match found!</p>
-          <p v-else class="text-red-500 font-medium">No match - will go to LLM</p>
-          <p v-if="testResult.response" class="mt-2 text-sm">
-            Response: <span class="text-muted-foreground">{{ testResult.response }}</span>
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <!-- FAQ Table -->
-    <div class="bg-card rounded-lg border border-border">
-      <div class="p-4 border-b border-border flex items-center justify-between">
-        <h2 class="text-lg font-semibold flex items-center gap-2">
-          <MessageSquare class="w-5 h-5" />
-          FAQ Entries
-          <span class="text-sm font-normal text-muted-foreground">({{ faqEntries.length }})</span>
-        </h2>
-      </div>
-
-      <div v-if="isLoading" class="p-8 text-center text-muted-foreground">
-        Loading...
-      </div>
-
-      <div v-else-if="faqEntries.length === 0" class="p-8 text-center text-muted-foreground">
-        {{ searchQuery ? 'No matching entries' : 'No FAQ entries yet' }}
-      </div>
-
-      <div v-else class="divide-y divide-border">
-        <div
-          v-for="entry in faqEntries"
-          :key="entry.trigger"
-          class="p-4 hover:bg-secondary/50 transition-colors"
-        >
-          <div class="flex items-start justify-between gap-4">
-            <div class="flex-1 min-w-0">
-              <div class="font-medium text-primary">{{ entry.trigger }}</div>
-              <div class="text-sm text-muted-foreground mt-1 line-clamp-2">
-                {{ entry.response }}
-              </div>
-            </div>
-            <div class="flex items-center gap-2 shrink-0">
-              <button
-                class="p-2 rounded-lg bg-secondary hover:bg-secondary/80 transition-colors"
-                title="Edit"
-                @click="openEditModal(entry)"
-              >
-                <Pencil class="w-4 h-4" />
-              </button>
-              <button
-                :disabled="deleteMutation.isPending.value"
-                class="p-2 rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
-                title="Delete"
-                @click="deleteMutation.mutate(entry.trigger)"
-              >
-                <Trash2 class="w-4 h-4" />
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Add/Edit Modal -->
-    <div
-      v-if="showAddModal"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      @click.self="closeModal"
-    >
-      <div class="bg-card border border-border rounded-lg w-full max-w-lg p-6">
-        <div class="flex items-center justify-between mb-4">
-          <h3 class="text-lg font-semibold">
-            {{ editingEntry ? 'Edit FAQ Entry' : 'Add FAQ Entry' }}
-          </h3>
-          <button
-            class="p-1 rounded hover:bg-secondary transition-colors"
-            @click="closeModal"
-          >
-            <X class="w-5 h-5" />
-          </button>
-        </div>
-
-        <div class="space-y-4">
-          <div>
-            <label class="block text-sm font-medium mb-2">Trigger (question/phrase)</label>
+        <!-- Search -->
+        <div class="p-3 border-b border-border">
+          <div class="relative">
+            <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
             <input
-              v-model="formTrigger"
+              v-model="searchQuery"
               type="text"
-              placeholder="e.g., привет"
-              class="w-full px-4 py-2 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
-            />
-            <p class="text-xs text-muted-foreground mt-1">Case-insensitive, partial matching</p>
-          </div>
-
-          <div>
-            <label class="block text-sm font-medium mb-2">Response</label>
-            <textarea
-              v-model="formResponse"
-              rows="4"
-              placeholder="e.g., Здравствуйте! Чем могу помочь?"
-              class="w-full px-4 py-2 bg-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-primary resize-none"
+              :placeholder="t('wiki.search')"
+              class="w-full pl-10 pr-4 py-2 bg-secondary rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary"
             />
           </div>
         </div>
 
-        <div class="flex justify-end gap-2 mt-6">
+        <!-- Document list -->
+        <div class="flex-1 overflow-y-auto">
+          <div v-if="isLoadingList" class="p-8 text-center text-muted-foreground">
+            <Loader2 class="w-5 h-5 animate-spin mx-auto mb-2" />
+            {{ t('wiki.loading') }}
+          </div>
+
+          <div v-else-if="documents.length === 0" class="p-8 text-center text-muted-foreground">
+            {{ t('wiki.noPages') }}
+          </div>
+
+          <div v-else class="divide-y divide-border">
+            <button
+              v-for="doc in documents"
+              :key="doc.id"
+              :class="[
+                'w-full text-left p-3 transition-colors hover:bg-secondary/50',
+                selectedDocId === doc.id ? 'bg-primary/10 border-l-2 border-l-primary' : ''
+              ]"
+              @click="selectDoc(doc)"
+            >
+              <div class="font-medium text-sm truncate">{{ doc.title }}</div>
+              <div class="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
+                <span>{{ doc.section_count }} {{ t('wiki.sections') }}</span>
+                <span>{{ formatSize(doc.file_size_bytes) }}</span>
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Content panel -->
+      <div
+        v-if="selectedDocId"
+        :class="[
+          'flex-1 flex flex-col border border-border rounded-lg bg-card overflow-hidden',
+          isMobileDetail ? 'flex' : 'hidden md:flex'
+        ]"
+      >
+        <!-- Content header -->
+        <div class="flex items-center gap-3 p-4 border-b border-border">
           <button
-            class="px-4 py-2 bg-secondary rounded-lg hover:bg-secondary/80 transition-colors"
-            @click="closeModal"
+            class="md:hidden p-1.5 rounded-lg hover:bg-secondary transition-colors"
+            @click="goBack"
           >
-            Cancel
+            <ArrowLeft class="w-5 h-5" />
           </button>
-          <button
-            :disabled="!formTrigger || !formResponse || addMutation.isPending.value || updateMutation.isPending.value"
-            class="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors"
-            @click="saveEntry"
-          >
-            {{ editingEntry ? 'Update' : 'Add' }}
-          </button>
+          <FileText class="w-5 h-5 text-primary shrink-0" />
+          <h2 class="font-semibold truncate">{{ selectedDoc?.title }}</h2>
+        </div>
+
+        <!-- Rendered content -->
+        <div class="flex-1 overflow-y-auto p-6">
+          <div v-if="isLoadingDoc" class="flex items-center justify-center py-12 text-muted-foreground">
+            <Loader2 class="w-5 h-5 animate-spin mr-2" />
+            {{ t('wiki.loading') }}
+          </div>
+          <div v-else class="chat-markdown max-w-none" v-html="renderedContent"></div>
+        </div>
+      </div>
+
+      <!-- Empty state (desktop, nothing selected) -->
+      <div
+        v-if="!selectedDocId && docsData?.documents?.length"
+        class="hidden md:flex flex-1 items-center justify-center border border-border rounded-lg bg-card"
+      >
+        <div class="text-center text-muted-foreground">
+          <BookOpen class="w-12 h-12 mx-auto mb-3 opacity-30" />
+          <p>{{ t('wiki.selectPage') }}</p>
         </div>
       </div>
     </div>

--- a/app/routers/wiki_rag.py
+++ b/app/routers/wiki_rag.py
@@ -505,7 +505,7 @@ async def get_document(doc_id: int, user: User = Depends(get_current_user)):
     if file_path.exists():
         try:
             full_content = file_path.read_text(encoding="utf-8")
-            content_preview = full_content[:2000]
+            content_preview = full_content
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary

- Replace FAQ CRUD editor page with a read-only Wiki pages viewer
- Backend: remove 2000-char content truncation in `wiki_rag.py` — return full document content
- `FaqView.vue` rewritten as master-detail wiki viewer (list + rendered markdown)
- Route changed: `/faq` → `/wiki`, icon `BookOpen`, moved to System nav section
- i18n: added `wiki.*` keys for ru/en/kk
- Demo mode: new `wiki.ts` mock with 5 sample wiki pages
- FAQ backend API preserved — still used by LLM service for quick-response matching

## NEWS

📚 **Страница Wiki в админ-панели**

Вместо редактора FAQ теперь в разделе «Система» есть страница Wiki. Она показывает все статьи базы знаний проекта с красивым рендерингом Markdown. Удобно читать документацию прямо из админки — список слева, содержимое справа, поиск по заголовкам.

## Test plan

- [ ] Navigate to `/#/wiki` — page loads with list of wiki documents
- [ ] Click a document — markdown content renders beautifully
- [ ] Search filters documents by title
- [ ] Mobile: back button returns to list view
- [ ] Demo mode shows 5 mock wiki pages
- [ ] FAQ backend still works: `curl /admin/faq`
- [ ] Nav item appears in System section with BookOpen icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)