### PR TITLE
feat: require_permission() infrastructure (RBAC 4a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,11 +293,11 @@ Frontend: `auth.ts` store fetches deployment mode via `GET /admin/deployment-mod
 - `Depends(require_admin)` — admin only (vLLM, GSM, backups, models)
 - Data isolation: `owner_id = None if user.role == "admin" else user.id` in routers
 
-**4 roles** (`VALID_ROLES` in `db/repositories/user.py`):
-- `admin` — full access, sees all resources
-- `user` — read + write own resources, full admin panel
-- `web` — same backend access as `user`, but frontend hides: Dashboard, Services, TTS, Monitoring, Audit, Usage (via `excludeRoles`). Models hidden via `minRole: 'admin'`. Landing page: `/chat`
-- `guest` — read-only (demo access)
+**4 legacy roles** (`VALID_ROLES` in `db/repositories/user.py`), mapped to RBAC roles via `get_role_for_legacy()`:
+- `admin` → RBAC `admin` — full access, sees all resources
+- `user` → RBAC `operator` — read + write own resources, full admin panel
+- `web` → RBAC `operator` — same backend access as `user`, but frontend hides: Dashboard, Services, TTS, Monitoring, Audit, Usage (via `excludeRoles`). Models hidden via `minRole: 'admin'`. Landing page: `/chat`
+- `guest` → RBAC `viewer` — read-only (demo access)
 - Frontend role exclusion: routes/nav items support `excludeRoles: ['web']` meta for per-role hiding
 - CLI: `python scripts/manage_users.py create <user> <pass> --role web`
 

--- a/app/routers/roles.py
+++ b/app/routers/roles.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from auth_manager import User, require_admin
+from auth_manager import User, invalidate_permissions_cache, require_admin
 from db.integration import async_audit_logger, async_role_manager
 
 
@@ -101,6 +101,8 @@ async def update_role(role_id: int, body: RoleUpdate, user: User = Depends(requi
     if not role:
         raise HTTPException(status_code=404, detail="Role not found")
 
+    invalidate_permissions_cache()
+
     await async_audit_logger.log(
         action="update",
         resource="role",
@@ -121,6 +123,7 @@ async def delete_role(role_id: int, user: User = Depends(require_admin)):
         raise HTTPException(status_code=400, detail="Cannot delete a system role")
 
     await async_role_manager.delete_role(role_id)
+    invalidate_permissions_cache()
 
     await async_audit_logger.log(
         action="delete",

--- a/auth_manager.py
+++ b/auth_manager.py
@@ -72,6 +72,7 @@ class User(BaseModel):
     id: int
     username: str
     role: str
+    permissions: Dict[str, str] = {}
 
 
 # ============== Security ==============
@@ -107,6 +108,37 @@ class SessionCache:
 
 
 _session_cache = SessionCache()
+
+
+# ============== Permissions Cache ==============
+
+
+class PermissionsCache:
+    """In-memory cache mapping role_name → permissions dict."""
+
+    def __init__(self) -> None:
+        self._cache: Dict[str, Dict[str, str]] = {}
+
+    async def get(self, role_name: str) -> Dict[str, str]:
+        """Get permissions for role, loading from DB on cache miss."""
+        if role_name in self._cache:
+            return self._cache[role_name]
+        from db.integration import async_role_manager
+
+        role = await async_role_manager.get_by_name(role_name)
+        perms = role.get("permissions", {}) if role else {}
+        self._cache[role_name] = perms
+        return perms
+
+    def invalidate(self, role_name: Optional[str] = None) -> None:
+        """Clear cache. If role_name given, clear only that entry."""
+        if role_name:
+            self._cache.pop(role_name, None)
+        else:
+            self._cache.clear()
+
+
+_permissions_cache = PermissionsCache()
 
 
 # ============== Password Helpers ==============
@@ -340,6 +372,24 @@ def require_not_guest(user: User = Depends(get_current_user)) -> User:
     return user
 
 
+def require_permission(module: str, min_level: str):
+    """FastAPI Depends factory: checks user has >= min_level for module."""
+
+    async def _dependency(user: User = Depends(get_current_user)) -> User:
+        role_name = get_role_for_legacy(user.role)
+        perms = await _permissions_cache.get(role_name)
+        user.permissions = perms
+        user_level = perms.get(module, "")
+        if not level_gte(user_level, min_level):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Permission denied: requires {module}:{min_level}",
+            )
+        return user
+
+    return _dependency
+
+
 def verify_ownership(user: User, record_owner_id: Optional[int]) -> None:
     """Raise 404 if user doesn't own the record (admin bypasses)."""
     if user.role == "admin":
@@ -366,15 +416,20 @@ def get_role_for_legacy(legacy_role: str) -> str:
     return _LEGACY_ROLE_MAP.get(legacy_role, "viewer")
 
 
-async def get_user_permissions(user: User) -> Dict[str, str]:
-    """Get permissions dict for user. Uses legacy role → role mapping."""
-    from db.integration import async_role_manager
+def user_has_level(user: User, module: str, min_level: str) -> bool:
+    """Check if user has >= min_level for module. Requires permissions pre-loaded."""
+    return level_gte(user.permissions.get(module, ""), min_level)
 
+
+async def get_user_permissions(user: User) -> Dict[str, str]:
+    """Get permissions dict for user. Uses cache."""
     role_name = get_role_for_legacy(user.role)
-    role = await async_role_manager.get_by_name(role_name)
-    if not role:
-        return {}
-    return role.get("permissions", {})
+    return await _permissions_cache.get(role_name)
+
+
+def invalidate_permissions_cache(role_name: Optional[str] = None) -> None:
+    """Clear permissions cache. Called when roles are modified."""
+    _permissions_cache.invalidate(role_name)
 
 
 # ============== Status ==============


### PR DESCRIPTION
## Summary

Closes #336

Adds the permission-checking infrastructure needed before migrating any router from legacy guards (`require_admin`/`require_not_guest`) to granular RBAC.

- **`User.permissions`** — new `Dict[str, str]` field on Pydantic model (backwards-compatible default `{}`)
- **`PermissionsCache`** — in-memory role→permissions cache with async DB fallback, avoids per-request DB hits
- **`require_permission(module, min_level)`** — FastAPI `Depends` factory that loads permissions, populates `user.permissions`, and raises 403 if insufficient
- **`user_has_level(user, module, min_level)`** — sync helper for inline checks in routers (replaces `user.role == "admin"` patterns)
- **`invalidate_permissions_cache()`** — called from `roles.py` on role update/delete
- **`get_user_permissions()`** — now uses cache instead of direct DB query
- **CLAUDE.md** — documents legacy role → RBAC role mapping

### What this does NOT change
- No router guards modified (that's #337–#343)
- No legacy guards removed (that's #344)
- No SQLAlchemy model changes

## Test plan
- [ ] `ruff check auth_manager.py app/routers/roles.py` — passes
- [ ] `python -c "from auth_manager import require_permission, user_has_level, invalidate_permissions_cache"` — OK
- [ ] Service restarts cleanly, `/health` returns OK
- [ ] Existing `/admin/auth/permissions` and `/admin/roles` endpoints still work
- [ ] Role update/delete correctly invalidates permissions cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)