### PR TITLE
refactor(rbac): migrate faq + wiki_rag to require_permission (#341)

### DIFF
--- a/app/routers/faq.py
+++ b/app/routers/faq.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from app.dependencies import get_container
-from auth_manager import User, get_current_user, require_not_guest
+from auth_manager import User, require_permission
 from db.integration import async_audit_logger, async_faq_manager
 
 
@@ -31,14 +31,16 @@ async def _reload_llm_faq():
 
 
 @router.get("")
-async def admin_get_faq(user: User = Depends(get_current_user)):
+async def admin_get_faq(user: User = Depends(require_permission("faq", "view"))):
     """Получить все FAQ записи"""
     faq = await async_faq_manager.get_all()
     return {"faq": faq}
 
 
 @router.post("")
-async def admin_add_faq(request: AdminFAQRequest, user: User = Depends(require_not_guest)):
+async def admin_add_faq(
+    request: AdminFAQRequest, user: User = Depends(require_permission("faq", "edit"))
+):
     """Добавить FAQ запись"""
     await async_faq_manager.add(request.trigger, request.response)
 
@@ -59,7 +61,7 @@ async def admin_add_faq(request: AdminFAQRequest, user: User = Depends(require_n
 
 @router.put("/{trigger}")
 async def admin_update_faq(
-    trigger: str, request: AdminFAQRequest, user: User = Depends(require_not_guest)
+    trigger: str, request: AdminFAQRequest, user: User = Depends(require_permission("faq", "edit"))
 ):
     """Обновить FAQ запись"""
     result = await async_faq_manager.update(trigger, request.trigger, request.response)
@@ -81,7 +83,7 @@ async def admin_update_faq(
 
 
 @router.delete("/{trigger}")
-async def admin_delete_faq(trigger: str, user: User = Depends(require_not_guest)):
+async def admin_delete_faq(trigger: str, user: User = Depends(require_permission("faq", "edit"))):
     """Удалить FAQ запись"""
     if not await async_faq_manager.delete(trigger):
         raise HTTPException(status_code=404, detail=f"Trigger not found: {trigger}")
@@ -97,7 +99,7 @@ async def admin_delete_faq(trigger: str, user: User = Depends(require_not_guest)
 
 
 @router.post("/reload")
-async def admin_reload_faq(user: User = Depends(require_not_guest)):
+async def admin_reload_faq(user: User = Depends(require_permission("faq", "edit"))):
     """Перезагрузить FAQ из БД"""
     await _reload_llm_faq()
     container = get_container()
@@ -107,13 +109,15 @@ async def admin_reload_faq(user: User = Depends(require_not_guest)):
 
 
 @router.post("/save")
-async def admin_save_faq(user: User = Depends(require_not_guest)):
+async def admin_save_faq(user: User = Depends(require_permission("faq", "edit"))):
     """Сохранить FAQ (уже автоматически сохраняется)"""
     return {"status": "ok", "message": "FAQ is saved automatically on each change"}
 
 
 @router.post("/test")
-async def admin_test_faq(request: AdminFAQTestRequest, user: User = Depends(get_current_user)):
+async def admin_test_faq(
+    request: AdminFAQTestRequest, user: User = Depends(require_permission("faq", "view"))
+):
     """Тестировать FAQ поиск"""
     container = get_container()
     llm_service = container.llm_service

--- a/app/routers/wiki_rag.py
+++ b/app/routers/wiki_rag.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile
 from pydantic import BaseModel
 
 from app.dependencies import get_container
-from auth_manager import User, get_current_user, require_not_guest
+from auth_manager import User, require_permission, user_has_level
 from db.integration import (
     async_audit_logger,
     async_knowledge_collection_manager,
@@ -172,7 +172,7 @@ def _get_wiki_rag():
 
 
 @router.get("/collections")
-async def list_collections(user: User = Depends(get_current_user)):
+async def list_collections(user: User = Depends(require_permission("wiki", "view"))):
     """List all knowledge collections."""
     collections = await async_knowledge_collection_manager.get_all()
     return {"collections": collections}
@@ -181,7 +181,7 @@ async def list_collections(user: User = Depends(get_current_user)):
 @router.post("/collections")
 async def create_collection(
     request: CollectionCreateRequest,
-    user: User = Depends(require_not_guest),
+    user: User = Depends(require_permission("wiki", "edit")),
 ):
     """Create a new knowledge collection."""
     slug = request.slug or _slugify(request.name)
@@ -217,7 +217,9 @@ async def create_collection(
 
 
 @router.get("/collections/{collection_id}")
-async def get_collection(collection_id: int, user: User = Depends(get_current_user)):
+async def get_collection(
+    collection_id: int, user: User = Depends(require_permission("wiki", "view"))
+):
     """Get a single knowledge collection."""
     collection = await async_knowledge_collection_manager.get_by_id(collection_id)
     if not collection:
@@ -229,7 +231,7 @@ async def get_collection(collection_id: int, user: User = Depends(get_current_us
 async def update_collection(
     collection_id: int,
     request: CollectionUpdateRequest,
-    user: User = Depends(require_not_guest),
+    user: User = Depends(require_permission("wiki", "edit")),
 ):
     """Update a knowledge collection."""
     collection = await async_knowledge_collection_manager.get_by_id(collection_id)
@@ -256,7 +258,7 @@ async def update_collection(
 @router.delete("/collections/{collection_id}")
 async def delete_collection(
     collection_id: int,
-    user: User = Depends(require_not_guest),
+    user: User = Depends(require_permission("wiki", "edit")),
 ):
     """Delete a knowledge collection. Cannot delete 'default'."""
     collection = await async_knowledge_collection_manager.get_by_id(collection_id)
@@ -286,7 +288,7 @@ async def delete_collection(
 @router.post("/collections/{collection_id}/reload")
 async def reload_collection_index(
     collection_id: int,
-    user: User = Depends(require_not_guest),
+    user: User = Depends(require_permission("wiki", "manage")),
 ):
     """Re-index a specific collection."""
     wiki_rag = _get_wiki_rag()
@@ -323,7 +325,7 @@ async def reload_collection_index(
 
 
 @router.get("/stats")
-async def wiki_rag_stats(user: User = Depends(get_current_user)):
+async def wiki_rag_stats(user: User = Depends(require_permission("wiki", "view"))):
     """Get Wiki RAG index statistics and source file list."""
     wiki_rag = _get_wiki_rag()
     if not wiki_rag:
@@ -344,7 +346,7 @@ async def wiki_rag_stats(user: User = Depends(get_current_user)):
 
 
 @router.post("/reload")
-async def wiki_rag_reload(user: User = Depends(require_not_guest)):
+async def wiki_rag_reload(user: User = Depends(require_permission("wiki", "manage"))):
     """Re-index wiki-pages/ directory."""
     wiki_rag = _get_wiki_rag()
     if not wiki_rag:
@@ -363,7 +365,7 @@ async def wiki_rag_reload(user: User = Depends(require_not_guest)):
 
 
 @router.post("/reindex-embeddings")
-async def wiki_rag_reindex_embeddings(user: User = Depends(require_not_guest)):
+async def wiki_rag_reindex_embeddings(user: User = Depends(require_permission("wiki", "manage"))):
     """Force rebuild all embedding vectors from scratch."""
     wiki_rag = _get_wiki_rag()
     if not wiki_rag:
@@ -384,7 +386,7 @@ async def wiki_rag_reindex_embeddings(user: User = Depends(require_not_guest)):
 @router.post("/search")
 async def wiki_rag_search(
     request: WikiSearchRequest,
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("wiki", "view")),
 ):
     """Test search: query → scored results. Optionally filter by collection."""
     wiki_rag = _get_wiki_rag()
@@ -400,7 +402,7 @@ async def wiki_rag_search(
 @router.get("/documents")
 async def list_documents(
     collection_id: Optional[int] = Query(None),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("wiki", "view")),
 ):
     """List knowledge base documents. Optionally filter by collection_id."""
     synced = await _sync_disk_to_db()
@@ -417,7 +419,7 @@ async def list_documents(
 async def upload_document(
     file: UploadFile,
     collection_id: Optional[int] = Form(None),
-    user: User = Depends(require_not_guest),
+    user: User = Depends(require_permission("wiki", "edit")),
 ):
     """Upload .md or .txt file to wiki-pages/ and register in DB."""
     if not file.filename:
@@ -459,7 +461,7 @@ async def upload_document(
         title = first_header.group(1).strip()
 
     # Create DB record
-    owner_id = None if user.role == "admin" else user.id
+    owner_id = None if user_has_level(user, "wiki", "manage") else user.id
     doc = await async_knowledge_doc_manager.create(
         filename=filename,
         title=title,
@@ -493,7 +495,7 @@ async def upload_document(
 
 
 @router.get("/documents/{doc_id}")
-async def get_document(doc_id: int, user: User = Depends(get_current_user)):
+async def get_document(doc_id: int, user: User = Depends(require_permission("wiki", "view"))):
     """Get document metadata + content preview."""
     doc = await async_knowledge_doc_manager.get_by_id(doc_id)
     if not doc:
@@ -516,7 +518,7 @@ async def get_document(doc_id: int, user: User = Depends(get_current_user)):
 async def update_document(
     doc_id: int,
     request: DocumentUpdateRequest,
-    user: User = Depends(require_not_guest),
+    user: User = Depends(require_permission("wiki", "edit")),
 ):
     """Update document title and/or content."""
     doc = await async_knowledge_doc_manager.get_by_id(doc_id)
@@ -562,7 +564,7 @@ async def update_document(
 
 
 @router.delete("/documents/{doc_id}")
-async def delete_document(doc_id: int, user: User = Depends(require_not_guest)):
+async def delete_document(doc_id: int, user: User = Depends(require_permission("wiki", "edit"))):
     """Delete document from disk and DB, re-index."""
     doc = await async_knowledge_doc_manager.get_by_id(doc_id)
     if not doc:


### PR DESCRIPTION
## Summary
- **faq.py** (8 endpoints): `get_current_user` → `faq:view` (2), `require_not_guest` → `faq:edit` (5), `POST /test` → `faq:view` (1). No inline role checks.
- **wiki_rag.py** (15 endpoints): `get_current_user` → `wiki:view` (6), `require_not_guest` → `wiki:edit` (6) / `wiki:manage` (3 reindex endpoints). 1 inline `user.role == "admin"` → `user_has_level(user, "wiki", "manage")`.

### Permission matrix

| Module | view | edit | manage |
|--------|------|------|--------|
| **faq** | GET list, POST test | POST/PUT/DELETE CRUD, reload, save | — |
| **wiki** | GET collections, stats, search, documents | POST/PUT/DELETE collections, upload/update/delete documents | reload, reindex-embeddings, collection reload |

Closes #341
Part of #326

## Test plan
- [ ] `ruff check` passes on both files
- [ ] viewer can search FAQ and wiki but cannot create/upload
- [ ] operator can CRUD FAQ entries and upload wiki documents
- [ ] only manage-level users can trigger reindex

🤖 Generated with [Claude Code](https://claude.com/claude-code)