### PR TITLE
refactor(rbac): migrate system, speech, gsm routers to require_permission

### DIFF
--- a/app/routers/backup.py
+++ b/app/routers/backup.py
@@ -7,7 +7,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from app.services.backup_service import get_backup_service
-from auth_manager import User, require_admin
+from auth_manager import User, require_permission
 
 
 router = APIRouter(prefix="/admin/backup", tags=["backup"])
@@ -48,7 +48,7 @@ class BackupResponse(BaseModel):
 
 
 @router.get("/system-info")
-async def get_system_info(_: User = Depends(require_admin)) -> dict:
+async def get_system_info(_: User = Depends(require_permission("system", "view"))) -> dict:
     """
     Get system info for backup planning.
 
@@ -59,7 +59,7 @@ async def get_system_info(_: User = Depends(require_admin)) -> dict:
 
 
 @router.get("/list")
-async def list_backups(_: User = Depends(require_admin)) -> list[dict]:
+async def list_backups(_: User = Depends(require_permission("system", "view"))) -> list[dict]:
     """
     List all available backups.
 
@@ -70,7 +70,9 @@ async def list_backups(_: User = Depends(require_admin)) -> list[dict]:
 
 
 @router.get("/{filename}")
-async def get_backup_info(filename: str, _: User = Depends(require_admin)) -> dict:
+async def get_backup_info(
+    filename: str, _: User = Depends(require_permission("system", "view"))
+) -> dict:
     """
     Get detailed info about a specific backup.
 
@@ -85,7 +87,9 @@ async def get_backup_info(filename: str, _: User = Depends(require_admin)) -> di
 
 
 @router.get("/{filename}/download")
-async def download_backup(filename: str, _: User = Depends(require_admin)) -> FileResponse:
+async def download_backup(
+    filename: str, _: User = Depends(require_permission("system", "view"))
+) -> FileResponse:
     """
     Download a backup file.
 
@@ -105,7 +109,9 @@ async def download_backup(filename: str, _: User = Depends(require_admin)) -> Fi
 
 
 @router.post("/{filename}/validate")
-async def validate_backup(filename: str, _: User = Depends(require_admin)) -> dict:
+async def validate_backup(
+    filename: str, _: User = Depends(require_permission("system", "edit"))
+) -> dict:
     """
     Validate backup integrity by checking checksums.
 
@@ -117,7 +123,9 @@ async def validate_backup(filename: str, _: User = Depends(require_admin)) -> di
 
 
 @router.post("/create")
-async def create_backup(request: CreateBackupRequest, _: User = Depends(require_admin)) -> dict:
+async def create_backup(
+    request: CreateBackupRequest, _: User = Depends(require_permission("system", "manage"))
+) -> dict:
     """
     Create a new backup.
 
@@ -135,7 +143,9 @@ async def create_backup(request: CreateBackupRequest, _: User = Depends(require_
 
 
 @router.post("/restore")
-async def restore_backup(request: RestoreBackupRequest, _: User = Depends(require_admin)) -> dict:
+async def restore_backup(
+    request: RestoreBackupRequest, _: User = Depends(require_permission("system", "manage"))
+) -> dict:
     """
     Restore from a backup.
 
@@ -162,7 +172,9 @@ async def restore_backup(request: RestoreBackupRequest, _: User = Depends(requir
 
 
 @router.delete("/{filename}")
-async def delete_backup(filename: str, _: User = Depends(require_admin)) -> dict:
+async def delete_backup(
+    filename: str, _: User = Depends(require_permission("system", "manage"))
+) -> dict:
     """
     Delete a backup file.
 

--- a/app/routers/gsm.py
+++ b/app/routers/gsm.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from app.dependencies import get_gsm_service
-from auth_manager import User, require_admin
+from auth_manager import User, require_permission
 
 
 logger = logging.getLogger(__name__)
@@ -188,7 +188,7 @@ def _require_gsm(gsm_service):
 
 @router.get("/status")
 async def gsm_status(
-    gsm_service=Depends(get_gsm_service), user: User = Depends(require_admin)
+    gsm_service=Depends(get_gsm_service), user: User = Depends(require_permission("gsm", "view"))
 ) -> GSMStatus:
     """Получить статус GSM модуля."""
     if gsm_service is None:
@@ -216,7 +216,7 @@ async def gsm_status(
 @router.post("/initialize")
 async def initialize_module(
     gsm_service=Depends(get_gsm_service),
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("gsm", "edit")),
 ):
     """Инициализировать GSM модуль."""
     gsm = _require_gsm(gsm_service)
@@ -239,7 +239,7 @@ async def initialize_module(
 
 
 @router.get("/config")
-async def get_gsm_config(user: User = Depends(require_admin)) -> GSMConfig:
+async def get_gsm_config(user: User = Depends(require_permission("gsm", "view"))) -> GSMConfig:
     """Получить конфигурацию GSM."""
     from db.integration import async_config_manager
 
@@ -252,7 +252,7 @@ async def get_gsm_config(user: User = Depends(require_admin)) -> GSMConfig:
 @router.put("/config")
 async def update_gsm_config(
     config: GSMConfig,
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("gsm", "edit")),
 ) -> GSMConfig:
     """Обновить конфигурацию GSM."""
     from db.integration import async_config_manager
@@ -270,7 +270,7 @@ async def list_calls(
     limit: int = 50,
     offset: int = 0,
     state: Optional[CallState] = None,
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("gsm", "view")),
 ) -> dict:
     """Список звонков из БД."""
     from db.integration import async_gsm_manager
@@ -289,7 +289,7 @@ async def list_calls(
 
 @router.get("/calls/active")
 async def get_active_call(
-    gsm_service=Depends(get_gsm_service), user: User = Depends(require_admin)
+    gsm_service=Depends(get_gsm_service), user: User = Depends(require_permission("gsm", "view"))
 ):
     """Получить активный звонок."""
     if gsm_service is None:
@@ -298,7 +298,7 @@ async def get_active_call(
 
 
 @router.get("/calls/{call_id}")
-async def get_call(call_id: str, user: User = Depends(require_admin)) -> dict:
+async def get_call(call_id: str, user: User = Depends(require_permission("gsm", "view"))) -> dict:
     """Детали звонка из БД."""
     from db.integration import async_gsm_manager
 
@@ -312,7 +312,7 @@ async def get_call(call_id: str, user: User = Depends(require_admin)) -> dict:
 @router.post("/calls/answer")
 async def answer_call(
     gsm_service=Depends(get_gsm_service),
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("gsm", "manage")),
 ):
     """Ответить на входящий звонок."""
     gsm = _require_gsm(gsm_service)
@@ -336,7 +336,7 @@ async def answer_call(
 @router.post("/calls/hangup")
 async def hangup_call(
     gsm_service=Depends(get_gsm_service),
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("gsm", "manage")),
 ):
     """Завершить текущий звонок."""
     gsm = _require_gsm(gsm_service)
@@ -362,7 +362,7 @@ async def hangup_call(
 async def dial_number(
     request: DialRequest,
     gsm_service=Depends(get_gsm_service),
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("gsm", "manage")),
 ):
     """Позвонить на номер."""
     gsm = _require_gsm(gsm_service)
@@ -387,7 +387,9 @@ async def dial_number(
 
 
 @router.get("/sms")
-async def list_sms(limit: int = 50, offset: int = 0, user: User = Depends(require_admin)) -> dict:
+async def list_sms(
+    limit: int = 50, offset: int = 0, user: User = Depends(require_permission("gsm", "view"))
+) -> dict:
     """Список SMS из БД."""
     from db.integration import async_gsm_manager
 
@@ -406,7 +408,7 @@ async def list_sms(limit: int = 50, offset: int = 0, user: User = Depends(requir
 async def send_sms(
     request: SendSMSRequest,
     gsm_service=Depends(get_gsm_service),
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("gsm", "manage")),
 ):
     """Отправить SMS."""
     gsm = _require_gsm(gsm_service)
@@ -434,7 +436,7 @@ async def send_sms(
 async def execute_at_command(
     request: ATCommandRequest,
     gsm_service=Depends(get_gsm_service),
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("gsm", "manage")),
 ) -> ATCommandResponse:
     """Выполнить AT команду (для отладки)."""
     gsm = _require_gsm(gsm_service)
@@ -448,7 +450,7 @@ async def execute_at_command(
 
 
 @router.get("/ports")
-async def list_serial_ports(user: User = Depends(require_admin)) -> dict:
+async def list_serial_ports(user: User = Depends(require_permission("gsm", "view"))) -> dict:
     """Список доступных serial портов."""
     dev_path = Path("/dev")
 

--- a/app/routers/monitor.py
+++ b/app/routers/monitor.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 
 from app.dependencies import get_container
-from auth_manager import User, get_current_user
+from auth_manager import User, require_permission
 from service_manager import get_service_manager
 from system_monitor import get_system_monitor
 
@@ -22,7 +22,7 @@ router = APIRouter(prefix="/admin/monitor", tags=["monitor"])
 
 
 @router.get("/gpu")
-async def admin_get_gpu_stats(user: User = Depends(get_current_user)):
+async def admin_get_gpu_stats(user: User = Depends(require_permission("system", "view"))):
     """Получить статистику GPU"""
     import torch
 
@@ -81,7 +81,7 @@ async def admin_get_gpu_stats(user: User = Depends(get_current_user)):
 
 
 @router.get("/gpu/stream")
-async def admin_stream_gpu_stats(user: User = Depends(get_current_user)):
+async def admin_stream_gpu_stats(user: User = Depends(require_permission("system", "view"))):
     """SSE streaming статистики GPU"""
     import torch
 
@@ -117,7 +117,7 @@ async def admin_stream_gpu_stats(user: User = Depends(get_current_user)):
 
 
 @router.get("/health")
-async def admin_get_health(user: User = Depends(get_current_user)):
+async def admin_get_health(user: User = Depends(require_permission("system", "view"))):
     """Расширенная проверка здоровья всех компонентов"""
     manager = get_service_manager()
     container = get_container()
@@ -163,7 +163,7 @@ async def admin_get_health(user: User = Depends(get_current_user)):
 
 
 @router.get("/metrics")
-async def admin_get_metrics(user: User = Depends(get_current_user)):
+async def admin_get_metrics(user: User = Depends(require_permission("system", "view"))):
     """Получить метрики системы"""
     import psutil
 
@@ -192,14 +192,14 @@ async def admin_get_metrics(user: User = Depends(get_current_user)):
 
 
 @router.get("/errors")
-async def admin_get_errors(user: User = Depends(get_current_user)):
+async def admin_get_errors(user: User = Depends(require_permission("system", "view"))):
     """Получить последние ошибки"""
     manager = get_service_manager()
     return {"errors": manager.last_errors, "timestamp": datetime.now().isoformat()}
 
 
 @router.post("/metrics/reset")
-async def admin_reset_metrics(user: User = Depends(get_current_user)):
+async def admin_reset_metrics(user: User = Depends(require_permission("system", "edit"))):
     """Сбросить метрики"""
     container = get_container()
     # Очищаем кэш TTS
@@ -211,14 +211,14 @@ async def admin_reset_metrics(user: User = Depends(get_current_user)):
 
 
 @router.get("/system")
-async def admin_get_system_status(user: User = Depends(get_current_user)):
+async def admin_get_system_status(user: User = Depends(require_permission("system", "view"))):
     """Полная информация о системе: GPU, CPU, RAM, диски, Docker, сеть"""
     monitor = get_system_monitor()
     return monitor.get_full_status()
 
 
 @router.get("/rate-limits")
-async def admin_get_rate_limits(user: User = Depends(get_current_user)):
+async def admin_get_rate_limits(user: User = Depends(require_permission("system", "view"))):
     """Get current rate limiting configuration"""
     from app.rate_limiter import get_rate_limit_status
 
@@ -226,7 +226,7 @@ async def admin_get_rate_limits(user: User = Depends(get_current_user)):
 
 
 @router.get("/security")
-async def admin_get_security_status(user: User = Depends(get_current_user)):
+async def admin_get_security_status(user: User = Depends(require_permission("system", "view"))):
     """Get current security configuration (rate limits, CORS, headers)"""
     import os
 

--- a/app/routers/services.py
+++ b/app/routers/services.py
@@ -4,7 +4,7 @@
 from fastapi import APIRouter, Depends
 
 from app.dependencies import get_container
-from auth_manager import User, get_current_user, require_admin
+from auth_manager import User, require_permission
 from service_manager import get_service_manager
 
 
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/admin/services", tags=["services"])
 
 
 @router.get("/status")
-async def admin_services_status(user: User = Depends(get_current_user)):
+async def admin_services_status(user: User = Depends(require_permission("system", "view"))):
     """Получить статус всех сервисов"""
     manager = get_service_manager()
     status = manager.get_all_status()
@@ -29,28 +29,34 @@ async def admin_services_status(user: User = Depends(get_current_user)):
 
 
 @router.post("/{service}/start")
-async def admin_start_service(service: str, user: User = Depends(require_admin)):
+async def admin_start_service(
+    service: str, user: User = Depends(require_permission("system", "manage"))
+):
     """Запустить сервис"""
     manager = get_service_manager()
     return await manager.start_service(service)
 
 
 @router.post("/{service}/stop")
-async def admin_stop_service(service: str, user: User = Depends(require_admin)):
+async def admin_stop_service(
+    service: str, user: User = Depends(require_permission("system", "manage"))
+):
     """Остановить сервис"""
     manager = get_service_manager()
     return await manager.stop_service(service)
 
 
 @router.post("/{service}/restart")
-async def admin_restart_service(service: str, user: User = Depends(require_admin)):
+async def admin_restart_service(
+    service: str, user: User = Depends(require_permission("system", "manage"))
+):
     """Перезапустить сервис"""
     manager = get_service_manager()
     return await manager.restart_service(service)
 
 
 @router.post("/start-all")
-async def admin_start_all_services(user: User = Depends(require_admin)):
+async def admin_start_all_services(user: User = Depends(require_permission("system", "manage"))):
     """Запустить все внешние сервисы"""
     manager = get_service_manager()
     results = {}
@@ -60,7 +66,7 @@ async def admin_start_all_services(user: User = Depends(require_admin)):
 
 
 @router.post("/stop-all")
-async def admin_stop_all_services(user: User = Depends(require_admin)):
+async def admin_stop_all_services(user: User = Depends(require_permission("system", "manage"))):
     """Остановить все внешние сервисы"""
     manager = get_service_manager()
     results = {}

--- a/app/routers/stt.py
+++ b/app/routers/stt.py
@@ -8,7 +8,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
 from app.dependencies import get_container
-from auth_manager import User, get_current_user
+from auth_manager import User, require_permission
 from stt_service import UnifiedSTTService, VoskSTTService
 
 
@@ -46,7 +46,7 @@ def get_unified_stt() -> Optional[UnifiedSTTService]:
 
 
 @router.get("/status")
-async def admin_stt_status(user: User = Depends(get_current_user)):
+async def admin_stt_status(user: User = Depends(require_permission("speech", "view"))):
     """Статус STT сервисов"""
     vosk_available = False
     whisper_available = False
@@ -82,7 +82,7 @@ async def admin_stt_status(user: User = Depends(get_current_user)):
 
 
 @router.get("/models")
-async def admin_stt_models(user: User = Depends(get_current_user)):
+async def admin_stt_models(user: User = Depends(require_permission("speech", "view"))):
     """Список доступных моделей STT"""
     models_dir = Path("models/vosk")
     models = []
@@ -115,7 +115,7 @@ async def admin_stt_transcribe(
     file: UploadFile = File(...),
     language: str = "ru",
     engine: str = "auto",
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("speech", "edit")),
 ):
     """
     Распознать речь из загруженного аудио файла
@@ -165,7 +165,7 @@ async def admin_stt_transcribe(
 @router.post("/test")
 async def admin_stt_test(
     text_to_speak: str = "Привет, это тест распознавания речи",
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("speech", "edit")),
 ):
     """
     Тест STT: синтезируем речь через TTS, затем распознаём обратно

--- a/app/routers/tts.py
+++ b/app/routers/tts.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 
 from app.dependencies import get_container
 from app.rate_limiter import RATE_LIMIT_TTS, limiter
-from auth_manager import User, get_current_user, require_not_guest
+from auth_manager import User, require_permission, user_has_level
 from db.integration import async_preset_manager
 from voice_clone_service import INTONATION_PRESETS
 
@@ -97,7 +97,7 @@ async def _reload_voice_presets():
 
 
 @router.get("/presets")
-async def admin_tts_presets(user: User = Depends(get_current_user)):
+async def admin_tts_presets(user: User = Depends(require_permission("speech", "view"))):
     """Список доступных TTS пресетов"""
     container = get_container()
     presets = {}
@@ -122,7 +122,7 @@ async def admin_tts_presets(user: User = Depends(get_current_user)):
 
 @router.post("/preset")
 async def admin_set_tts_preset(
-    request: AdminTTSPresetRequest, user: User = Depends(require_not_guest)
+    request: AdminTTSPresetRequest, user: User = Depends(require_permission("speech", "edit"))
 ):
     """Установить текущий пресет TTS"""
     container = get_container()
@@ -155,7 +155,9 @@ async def admin_set_tts_preset(
 @router.post("/test")
 @limiter.limit(RATE_LIMIT_TTS)
 async def admin_tts_test(
-    request: Request, tts_request: AdminTTSTestRequest, user: User = Depends(get_current_user)
+    request: Request,
+    tts_request: AdminTTSTestRequest,
+    user: User = Depends(require_permission("speech", "view")),
 ):
     """Тестовый синтез речи - возвращает аудио-файл для воспроизведения в браузере"""
     import time as t
@@ -253,7 +255,7 @@ async def admin_tts_test(
 
 
 @router.get("/cache")
-async def admin_tts_cache(user: User = Depends(get_current_user)):
+async def admin_tts_cache(user: User = Depends(require_permission("speech", "view"))):
     """Статистика кэша streaming TTS"""
     container = get_container()
     if container.streaming_tts_manager:
@@ -262,7 +264,7 @@ async def admin_tts_cache(user: User = Depends(get_current_user)):
 
 
 @router.delete("/cache")
-async def admin_clear_tts_cache(user: User = Depends(require_not_guest)):
+async def admin_clear_tts_cache(user: User = Depends(require_permission("speech", "edit"))):
     """Очистить кэш streaming TTS"""
     container = get_container()
     if container.streaming_tts_manager:
@@ -277,7 +279,7 @@ async def admin_clear_tts_cache(user: User = Depends(require_not_guest)):
 
 
 @router.get("/xtts/params")
-async def admin_get_xtts_params(user: User = Depends(get_current_user)):
+async def admin_get_xtts_params(user: User = Depends(require_permission("speech", "view"))):
     """Получить параметры XTTS"""
     container = get_container()
     service = container.anna_voice_service or container.voice_service
@@ -301,7 +303,7 @@ async def admin_get_xtts_params(user: User = Depends(get_current_user)):
 
 @router.post("/xtts/params")
 async def admin_set_xtts_params(
-    request: AdminXTTSParamsRequest, user: User = Depends(require_not_guest)
+    request: AdminXTTSParamsRequest, user: User = Depends(require_permission("speech", "edit"))
 ):
     """Установить параметры XTTS (для следующего синтеза)"""
     params = {k: v for k, v in request.model_dump().items() if v is not None}
@@ -313,7 +315,7 @@ async def admin_set_xtts_params(
 
 
 @router.get("/piper/params")
-async def admin_get_piper_params(user: User = Depends(get_current_user)):
+async def admin_get_piper_params(user: User = Depends(require_permission("speech", "view"))):
     """Получить параметры Piper TTS"""
     container = get_container()
     if not container.piper_service:
@@ -327,7 +329,7 @@ async def admin_get_piper_params(user: User = Depends(get_current_user)):
 
 @router.post("/piper/params")
 async def admin_set_piper_params(
-    request: AdminPiperParamsRequest, user: User = Depends(require_not_guest)
+    request: AdminPiperParamsRequest, user: User = Depends(require_permission("speech", "edit"))
 ):
     """Установить параметры Piper TTS"""
     container = get_container()
@@ -342,7 +344,7 @@ async def admin_set_piper_params(
 
 
 @router.get("/presets/custom")
-async def admin_get_custom_presets(user: User = Depends(get_current_user)):
+async def admin_get_custom_presets(user: User = Depends(require_permission("speech", "view"))):
     """Получить пользовательские пресеты TTS"""
     presets = await async_preset_manager.get_custom()
     return {"presets": presets}
@@ -350,10 +352,10 @@ async def admin_get_custom_presets(user: User = Depends(get_current_user)):
 
 @router.post("/presets/custom")
 async def admin_create_custom_preset(
-    request: AdminCustomPresetRequest, user: User = Depends(require_not_guest)
+    request: AdminCustomPresetRequest, user: User = Depends(require_permission("speech", "edit"))
 ):
     """Создать пользовательский пресет TTS"""
-    owner_id = None if user.role == "admin" else user.id
+    owner_id = None if user_has_level(user, "speech", "manage") else user.id
     await async_preset_manager.create(request.name, request.params, owner_id=owner_id)
     await _reload_voice_presets()
     return {"status": "ok", "preset": request.name}
@@ -361,7 +363,9 @@ async def admin_create_custom_preset(
 
 @router.put("/presets/custom/{name}")
 async def admin_update_custom_preset(
-    name: str, request: AdminCustomPresetRequest, user: User = Depends(require_not_guest)
+    name: str,
+    request: AdminCustomPresetRequest,
+    user: User = Depends(require_permission("speech", "edit")),
 ):
     """Обновить пользовательский пресет TTS"""
     result = await async_preset_manager.update(name, request.params)
@@ -373,7 +377,9 @@ async def admin_update_custom_preset(
 
 
 @router.delete("/presets/custom/{name}")
-async def admin_delete_custom_preset(name: str, user: User = Depends(require_not_guest)):
+async def admin_delete_custom_preset(
+    name: str, user: User = Depends(require_permission("speech", "edit"))
+):
     """Удалить пользовательский пресет TTS"""
     if not await async_preset_manager.delete(name):
         raise HTTPException(status_code=404, detail=f"Preset not found: {name}")
@@ -388,7 +394,9 @@ async def admin_delete_custom_preset(name: str, user: User = Depends(require_not
 @router.post("/stream")
 @limiter.limit(RATE_LIMIT_TTS)
 async def tts_stream(
-    request: Request, stream_request: StreamingTTSRequest, user: User = Depends(get_current_user)
+    request: Request,
+    stream_request: StreamingTTSRequest,
+    user: User = Depends(require_permission("speech", "view")),
 ):
     """
     Потоковый синтез речи - выдаёт аудио чанки по мере генерации.


### PR DESCRIPTION
## Summary
- Migrate 6 routers (55 HTTP endpoints) from legacy guards (`get_current_user` / `require_admin` / `require_not_guest`) to granular `require_permission(module, level)`
- **stt.py** → `speech:view` / `speech:edit` (4 endpoints)
- **services.py** → `system:view` / `system:manage` (6 endpoints)
- **monitor.py** → `system:view` / `system:edit` (9 endpoints)
- **backup.py** → `system:view` / `system:edit` / `system:manage` (8 endpoints)
- **gsm.py** → `gsm:view` / `gsm:edit` / `gsm:manage` (14 endpoints)
- **tts.py** → `speech:view` / `speech:edit` + `user_has_level` for ownership (14 HTTP + 1 WS unchanged)

Part of RBAC Stage 4 (#326), closes #342.

## Test plan
- [ ] Verify `ruff check` + `ruff format --check` pass on all 6 files
- [ ] Grep confirms zero `require_admin` / `require_not_guest` / `get_current_user` in target files
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)