### PR TITLE
refactor(rbac): migrate remaining routers to require_permission

### DIFF
--- a/app/routers/audit.py
+++ b/app/routers/audit.py
@@ -9,7 +9,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
 
-from auth_manager import User, get_current_user
+from auth_manager import User, require_permission
 from db.database import AsyncSessionLocal
 from db.repositories import AuditRepository
 
@@ -26,7 +26,7 @@ async def admin_get_audit_logs(
     to_date: Optional[str] = None,
     limit: int = 100,
     offset: int = 0,
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("audit", "view")),
 ):
     """Get audit logs with optional filters."""
     # Parse dates if provided
@@ -58,7 +58,7 @@ async def admin_get_audit_logs(
 
 
 @router.get("/stats")
-async def admin_get_audit_stats(user: User = Depends(get_current_user)):
+async def admin_get_audit_stats(user: User = Depends(require_permission("audit", "view"))):
     """Get audit log statistics."""
     async with AsyncSessionLocal() as session:
         repo = AuditRepository(session)
@@ -71,7 +71,7 @@ async def admin_export_audit_logs(
     from_date: Optional[str] = None,
     to_date: Optional[str] = None,
     format: str = "json",  # json or csv
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("audit", "view")),
 ):
     """Export audit logs as JSON or CSV."""
     # Parse dates
@@ -111,7 +111,9 @@ async def admin_export_audit_logs(
 
 
 @router.post("/cleanup")
-async def admin_cleanup_audit_logs(days: int = 90, user: User = Depends(get_current_user)):
+async def admin_cleanup_audit_logs(
+    days: int = 90, user: User = Depends(require_permission("audit", "manage"))
+):
     """Delete audit logs older than specified days."""
     if days < 7:
         raise HTTPException(status_code=400, detail="Minimum retention period is 7 days")

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -18,6 +18,7 @@ from auth_manager import (
     get_current_user,
     get_user_permissions,
     revoke_session,
+    user_has_level,
 )
 from db.integration import async_audit_logger, async_session_manager, async_user_manager
 
@@ -150,8 +151,10 @@ async def delete_session(
     user: User = Depends(get_current_user),
 ):
     """Revoke a specific session. Users can revoke their own sessions; admins can revoke any."""
-    # Check ownership: non-admins can only revoke their own sessions
-    if user.role != "admin":
+    # Load permissions for inline check
+    user.permissions = await get_user_permissions(user)
+    # Check ownership: non-manage users can only revoke their own sessions
+    if not user_has_level(user, "users", "manage"):
         db_session = await async_session_manager.get_by_jti(jti)
         if db_session is None or db_session.user_id != user.id:
             raise HTTPException(status_code=404, detail="Session not found")

--- a/app/routers/claude_code.py
+++ b/app/routers/claude_code.py
@@ -25,7 +25,7 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 
-from auth_manager import TokenPayload, decode_token, require_admin
+from auth_manager import TokenPayload, decode_token, require_permission
 
 
 router = APIRouter(prefix="/admin/claude-code", tags=["claude-code"])
@@ -576,7 +576,7 @@ async def _handle_abort(user_id: int) -> None:
 
 
 @router.get("/sessions")
-async def list_sessions(user=Depends(require_admin)):
+async def list_sessions(user=Depends(require_permission("claude_code", "manage"))):
     """List Claude Code sessions."""
     from db.integration import async_claude_code_manager
 
@@ -585,7 +585,7 @@ async def list_sessions(user=Depends(require_admin)):
 
 
 @router.get("/sessions/{session_id}")
-async def get_session(session_id: str, user=Depends(require_admin)):
+async def get_session(session_id: str, user=Depends(require_permission("claude_code", "manage"))):
     """Get a specific Claude Code session."""
     from db.integration import async_claude_code_manager
 
@@ -596,7 +596,9 @@ async def get_session(session_id: str, user=Depends(require_admin)):
 
 
 @router.delete("/sessions/{session_id}")
-async def delete_session(session_id: str, user=Depends(require_admin)):
+async def delete_session(
+    session_id: str, user=Depends(require_permission("claude_code", "manage"))
+):
     """Delete a Claude Code session."""
     from db.integration import async_claude_code_manager
 
@@ -607,6 +609,6 @@ async def delete_session(session_id: str, user=Depends(require_admin)):
 
 
 @router.get("/directories")
-async def list_directories(user=Depends(require_admin)):
+async def list_directories(user=Depends(require_permission("claude_code", "manage"))):
     """List allowed working directories for Claude Code."""
     return {"directories": _ALLOWED_CWDS, "default": _DEFAULT_CWD}

--- a/app/routers/kanban.py
+++ b/app/routers/kanban.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from auth_manager import User, get_current_user, require_admin, require_not_guest
+from auth_manager import User, require_permission, user_has_level
 from db.integration import async_audit_logger, async_kanban_manager, async_kanban_project_manager
 
 
@@ -79,14 +79,16 @@ class ProjectUpdate(BaseModel):
 
 
 @router.get("/projects")
-async def get_projects(user: User = Depends(get_current_user)):
+async def get_projects(user: User = Depends(require_permission("kanban", "view"))):
     """Get all kanban projects."""
     projects = await async_kanban_project_manager.get_all_projects()
     return {"projects": projects}
 
 
 @router.post("/projects")
-async def create_project(request: ProjectCreate, user: User = Depends(require_admin)):
+async def create_project(
+    request: ProjectCreate, user: User = Depends(require_permission("kanban", "manage"))
+):
     """Create a new kanban project (admin only)."""
     kwargs = {
         "name": request.name,
@@ -113,7 +115,9 @@ async def create_project(request: ProjectCreate, user: User = Depends(require_ad
 
 @router.patch("/projects/{project_id}")
 async def update_project(
-    project_id: int, request: ProjectUpdate, user: User = Depends(require_admin)
+    project_id: int,
+    request: ProjectUpdate,
+    user: User = Depends(require_permission("kanban", "manage")),
 ):
     """Update a kanban project (admin only)."""
     existing = await async_kanban_project_manager.get_project(project_id)
@@ -147,7 +151,9 @@ async def update_project(
 
 
 @router.delete("/projects/{project_id}")
-async def delete_project(project_id: int, user: User = Depends(require_admin)):
+async def delete_project(
+    project_id: int, user: User = Depends(require_permission("kanban", "manage"))
+):
     """Delete a kanban project (admin only)."""
     existing = await async_kanban_project_manager.get_project(project_id)
     if not existing:
@@ -164,7 +170,7 @@ async def delete_project(project_id: int, user: User = Depends(require_admin)):
 
 
 @router.post("/projects/{project_id}/sync")
-async def sync_project(project_id: int, user: User = Depends(require_not_guest)):
+async def sync_project(project_id: int, user: User = Depends(require_permission("kanban", "edit"))):
     """Trigger full sync of GitHub issues for a project."""
     existing = await async_kanban_project_manager.get_project(project_id)
     if not existing:
@@ -202,11 +208,11 @@ async def _push_github_status(task: dict, new_status: str):
 
 @router.get("/tasks")
 async def get_tasks(
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("kanban", "view")),
     project_id: Optional[int] = Query(None),
 ):
     """Get tasks visible to the current user, optionally filtered by project."""
-    is_admin = user.role == "admin"
+    is_admin = user_has_level(user, "kanban", "manage")
     tasks = await async_kanban_manager.get_visible_tasks_for_project(
         project_id, user.username, is_admin
     )
@@ -214,7 +220,9 @@ async def get_tasks(
 
 
 @router.post("/tasks")
-async def create_task(request: TaskCreate, user: User = Depends(require_not_guest)):
+async def create_task(
+    request: TaskCreate, user: User = Depends(require_permission("kanban", "edit"))
+):
     """Create a new task (always draft + private)."""
     tags_json = json.dumps(request.tags, ensure_ascii=False) if request.tags else None
     task = await async_kanban_manager.create_task(
@@ -240,14 +248,14 @@ async def update_task(
     task_id: int,
     request: TaskUpdate,
     background_tasks: BackgroundTasks,
-    user: User = Depends(require_not_guest),
+    user: User = Depends(require_permission("kanban", "edit")),
 ):
     """Update a task. Non-admin can only edit own tasks."""
     existing = await async_kanban_manager.get_task(task_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Task not found")
 
-    if user.role != "admin" and existing["created_by"] != user.username:
+    if not user_has_level(user, "kanban", "manage") and existing["created_by"] != user.username:
         raise HTTPException(status_code=403, detail="Can only edit own tasks")
 
     update_data = {}
@@ -288,7 +296,7 @@ async def update_task(
 
 
 @router.delete("/tasks/{task_id}")
-async def delete_task(task_id: int, user: User = Depends(require_admin)):
+async def delete_task(task_id: int, user: User = Depends(require_permission("kanban", "manage"))):
     """Delete a task (admin only)."""
     existing = await async_kanban_manager.get_task(task_id)
     if not existing:
@@ -311,7 +319,7 @@ async def delete_task(task_id: int, user: User = Depends(require_admin)):
 async def reorder_task(
     request: TaskReorder,
     background_tasks: BackgroundTasks,
-    user: User = Depends(require_not_guest),
+    user: User = Depends(require_permission("kanban", "edit")),
 ):
     """Reorder a task (update status + position)."""
     # Get existing task before reorder (for GitHub push check)
@@ -335,13 +343,19 @@ async def reorder_task(
 
 
 @router.post("/dependencies")
-async def add_dependency(request: DependencyCreate, user: User = Depends(require_not_guest)):
+async def add_dependency(
+    request: DependencyCreate, user: User = Depends(require_permission("kanban", "edit"))
+):
     """Add a dependency between tasks."""
     # Check target task exists and is not private
     target = await async_kanban_manager.get_task(request.blocker_id)
     if not target:
         raise HTTPException(status_code=404, detail="Blocker task not found")
-    if target["is_private"] and target["created_by"] != user.username and user.role != "admin":
+    if (
+        target["is_private"]
+        and target["created_by"] != user.username
+        and not user_has_level(user, "kanban", "manage")
+    ):
         raise HTTPException(status_code=409, detail="Cannot depend on a private task")
 
     dependent = await async_kanban_manager.get_task(request.dependent_id)
@@ -360,7 +374,7 @@ async def add_dependency(request: DependencyCreate, user: User = Depends(require
 async def remove_dependency(
     blocker_id: int = Query(...),
     dependent_id: int = Query(...),
-    user: User = Depends(require_not_guest),
+    user: User = Depends(require_permission("kanban", "edit")),
 ):
     """Remove a dependency between tasks."""
     removed = await async_kanban_manager.remove_dependency(blocker_id, dependent_id)
@@ -376,7 +390,7 @@ async def remove_dependency(
 async def add_checklist_item(
     task_id: int,
     request: ChecklistItemCreate,
-    user: User = Depends(require_not_guest),
+    user: User = Depends(require_permission("kanban", "edit")),
 ):
     """Add a checklist item to a task."""
     existing = await async_kanban_manager.get_task(task_id)
@@ -388,7 +402,9 @@ async def add_checklist_item(
 
 
 @router.patch("/checklist/{item_id}/toggle")
-async def toggle_checklist_item(item_id: int, user: User = Depends(require_not_guest)):
+async def toggle_checklist_item(
+    item_id: int, user: User = Depends(require_permission("kanban", "edit"))
+):
     """Toggle a checklist item's done status."""
     item = await async_kanban_manager.toggle_checklist_item(item_id)
     if not item:
@@ -397,7 +413,9 @@ async def toggle_checklist_item(item_id: int, user: User = Depends(require_not_g
 
 
 @router.delete("/checklist/{item_id}")
-async def delete_checklist_item(item_id: int, user: User = Depends(require_not_guest)):
+async def delete_checklist_item(
+    item_id: int, user: User = Depends(require_permission("kanban", "edit"))
+):
     """Delete a checklist item."""
     deleted = await async_kanban_manager.delete_checklist_item(item_id)
     if not deleted:

--- a/app/routers/legal.py
+++ b/app/routers/legal.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 
-from auth_manager import User, require_admin
+from auth_manager import User, require_permission
 from db.database import AsyncSessionLocal
 from db.models import CONSENT_TYPES
 from db.repositories.consent import ConsentRepository
@@ -85,7 +85,7 @@ async def get_consent_types():
 @router.get("/admin/legal/consents/{user_id}")
 async def admin_get_user_consents(
     user_id: str,
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("settings", "manage")),
 ):
     """Get all consents for a user."""
     async with AsyncSessionLocal() as session:
@@ -189,7 +189,7 @@ async def admin_grant_required_consents(
 async def admin_revoke_consent(
     user_id: str,
     consent_type: str,
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("settings", "manage")),
 ):
     """Revoke a consent (admin only)."""
     if consent_type not in CONSENT_TYPES:
@@ -213,7 +213,7 @@ async def admin_check_consents(user_id: str):
 
 
 @router.get("/admin/legal/stats")
-async def admin_get_consent_stats(user: User = Depends(require_admin)):
+async def admin_get_consent_stats(user: User = Depends(require_permission("settings", "manage"))):
     """Get consent statistics."""
     async with AsyncSessionLocal() as session:
         repo = ConsentRepository(session)
@@ -229,7 +229,7 @@ async def admin_get_consent_stats(user: User = Depends(require_admin)):
 @router.post("/admin/legal/gdpr/delete")
 async def admin_gdpr_delete_data(
     request: DataDeletionRequest,
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("settings", "manage")),
 ):
     """Delete all user data (GDPR right to erasure)."""
     if not request.confirm:

--- a/app/routers/usage.py
+++ b/app/routers/usage.py
@@ -7,7 +7,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from auth_manager import User, get_current_user, require_admin
+from auth_manager import User, require_permission
 from db.database import AsyncSessionLocal
 from db.repositories.usage import UsageLimitsRepository, UsageRepository
 
@@ -56,7 +56,7 @@ async def admin_get_usage_logs(
     to_date: Optional[str] = None,
     limit: int = 100,
     offset: int = 0,
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("usage", "view")),
 ):
     """Get usage logs with optional filters."""
     # Parse dates if provided
@@ -91,7 +91,7 @@ async def admin_get_usage_logs(
 async def admin_get_usage_stats(
     service_type: Optional[str] = None,
     period_days: int = 30,
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("usage", "view")),
 ):
     """Get usage statistics for the specified period."""
     if period_days < 1 or period_days > 365:
@@ -134,7 +134,7 @@ async def admin_log_usage(request: UsageLogRequest):
 @router.post("/cleanup")
 async def admin_cleanup_usage_logs(
     days: int = 90,
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("usage", "manage")),
 ):
     """Delete usage logs older than specified days."""
     if days < 7:
@@ -156,7 +156,7 @@ async def admin_cleanup_usage_logs(
 @router.get("/limits")
 async def admin_get_limits(
     enabled_only: bool = True,
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("usage", "manage")),
 ):
     """Get all usage limits."""
     async with AsyncSessionLocal() as session:
@@ -169,7 +169,7 @@ async def admin_get_limits(
 async def admin_get_limit(
     service_type: str,
     limit_type: str,
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("usage", "manage")),
 ):
     """Get a specific usage limit."""
     async with AsyncSessionLocal() as session:
@@ -183,7 +183,7 @@ async def admin_get_limit(
 @router.post("/limits")
 async def admin_set_limit(
     request: UsageLimitRequest,
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("usage", "manage")),
 ):
     """Create or update a usage limit."""
     if request.service_type not in ("tts", "stt", "llm"):
@@ -207,7 +207,7 @@ async def admin_set_limit(
 async def admin_delete_limit(
     service_type: str,
     limit_type: str,
-    user: User = Depends(require_admin),
+    user: User = Depends(require_permission("usage", "manage")),
 ):
     """Delete a usage limit."""
     async with AsyncSessionLocal() as session:
@@ -257,7 +257,7 @@ async def admin_check_usage(
 
 @router.get("/summary")
 async def admin_get_usage_summary(
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("usage", "view")),
 ):
     """
     Get a summary of usage across all services.


### PR DESCRIPTION
## Summary
- Migrate 6 remaining routers (~30 guard replacements) from legacy guards to granular `require_permission(module, level)`
- **kanban.py** → `kanban:view` / `kanban:edit` / `kanban:manage` (15 endpoints + 3 inline `user_has_level`)
- **audit.py** → `audit:view` / `audit:manage` (4 endpoints). **Fix**: `POST /cleanup` was accessible to any authenticated user, now requires `audit:manage`
- **usage.py** → `usage:view` / `usage:manage` (8 endpoints, 2 internal without auth unchanged)
- **claude_code.py** → `claude_code:manage` (4 REST endpoints, WebSocket with custom auth unchanged)
- **legal.py** → `settings:manage` (4 admin endpoints, 7 public endpoints unchanged)
- **auth.py** → keeps `get_current_user` (self-service infrastructure); inline `user.role != "admin"` in `delete_session` → `user_has_level("users", "manage")`

Completes RBAC Stage 4 (#326), closes #343.

## Test plan
- [ ] `ruff check` + `ruff format --check` pass on all 6 files
- [ ] Grep confirms zero `require_admin` / `require_not_guest` in target files
- [ ] `get_current_user` only remains in auth.py (intentional — self-service endpoints)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)