### PR TITLE
rbac: remove legacy guards, finalize RBAC migration

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -87,8 +87,9 @@ async def admin_update_profile(
     user: User = Depends(get_current_user),
 ):
     """Update user profile (display name)."""
-    if user.role == "guest":
-        raise HTTPException(status_code=403, detail="Guest cannot update profile")
+    user.permissions = await get_user_permissions(user)
+    if not user_has_level(user, "settings", "edit"):
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
 
     result = await async_user_manager.update_profile(user.id, display_name=request.display_name)
     if not result:
@@ -105,8 +106,9 @@ async def admin_change_password(
     user: User = Depends(get_current_user),
 ):
     """Change current user's password. Revokes all sessions and issues a new token."""
-    if user.role == "guest":
-        raise HTTPException(status_code=403, detail="Guest cannot change password")
+    user.permissions = await get_user_permissions(user)
+    if not user_has_level(user, "settings", "edit"):
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
 
     # Verify old password
     auth_result = await authenticate_user(user.username, request.old_password)

--- a/app/routers/roles.py
+++ b/app/routers/roles.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from auth_manager import User, invalidate_permissions_cache, require_admin
+from auth_manager import User, invalidate_permissions_cache, require_permission
 from db.integration import async_audit_logger, async_role_manager
 
 
@@ -44,14 +44,16 @@ def _validate_permissions(permissions: Dict[str, str]) -> None:
 
 
 @router.get("")
-async def list_roles(user: User = Depends(require_admin)):
+async def list_roles(user: User = Depends(require_permission("users", "manage"))):
     """List all roles with permissions."""
     roles = await async_role_manager.get_all_with_permissions()
     return roles
 
 
 @router.post("", status_code=201)
-async def create_role(body: RoleCreate, user: User = Depends(require_admin)):
+async def create_role(
+    body: RoleCreate, user: User = Depends(require_permission("users", "manage"))
+):
     """Create a new custom role."""
     if body.permissions:
         _validate_permissions(body.permissions)
@@ -78,7 +80,7 @@ async def create_role(body: RoleCreate, user: User = Depends(require_admin)):
 
 
 @router.get("/{role_id}")
-async def get_role(role_id: int, user: User = Depends(require_admin)):
+async def get_role(role_id: int, user: User = Depends(require_permission("users", "manage"))):
     """Get a single role by ID."""
     role = await async_role_manager.get_with_permissions(role_id)
     if not role:
@@ -87,7 +89,9 @@ async def get_role(role_id: int, user: User = Depends(require_admin)):
 
 
 @router.put("/{role_id}")
-async def update_role(role_id: int, body: RoleUpdate, user: User = Depends(require_admin)):
+async def update_role(
+    role_id: int, body: RoleUpdate, user: User = Depends(require_permission("users", "manage"))
+):
     """Update a role. System roles: can update permissions, cannot change name."""
     if body.permissions is not None:
         _validate_permissions(body.permissions)
@@ -113,7 +117,7 @@ async def update_role(role_id: int, body: RoleUpdate, user: User = Depends(requi
 
 
 @router.delete("/{role_id}")
-async def delete_role(role_id: int, user: User = Depends(require_admin)):
+async def delete_role(role_id: int, user: User = Depends(require_permission("users", "manage"))):
     """Delete a custom role. System roles cannot be deleted."""
     role = await async_role_manager.get_with_permissions(role_id)
     if not role:

--- a/auth_manager.py
+++ b/auth_manager.py
@@ -355,23 +355,6 @@ async def get_optional_user(
     return await _validate_session(token_payload)
 
 
-def require_admin(user: User = Depends(get_current_user)) -> User:
-    """Dependency to require admin role."""
-    if user.role != "admin":
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
-    return user
-
-
-def require_not_guest(user: User = Depends(get_current_user)) -> User:
-    """Dependency to block guest from write operations. Allows user and admin."""
-    if user.role == "guest":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Guest accounts cannot perform this action",
-        )
-    return user
-
-
 def require_permission(module: str, min_level: str):
     """FastAPI Depends factory: checks user has >= min_level for module."""
 
@@ -388,14 +371,6 @@ def require_permission(module: str, min_level: str):
         return user
 
     return _dependency
-
-
-def verify_ownership(user: User, record_owner_id: Optional[int]) -> None:
-    """Raise 404 if user doesn't own the record (admin bypasses)."""
-    if user.role == "admin":
-        return
-    if record_owner_id is not None and record_owner_id != user.id:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
 
 
 # ============== RBAC Helpers ==============


### PR DESCRIPTION
## Summary

Финальный шаг RBAC Этап 4 — удаление устаревших guard-функций после миграции всех роутеров.

- **roles.py**: 5 эндпоинтов `require_admin` → `require_permission("users", "manage")`
- **auth.py**: 2 inline `user.role == "guest"` → `user_has_level(user, "settings", "edit")` (вариант B — сохраняет `get_current_user` как dependency)
- **auth_manager.py**: удалены `require_admin()`, `require_not_guest()`, `verify_ownership()`

### Grep-верификация

```
grep -r 'require_admin\|require_not_guest\|verify_ownership' **/*.py  → пусто
grep -r 'role == "guest"\|role != "admin"' **/*.py  → пусто
```

Closes #344. Part of #326.

## Test plan

- [ ] `ruff check` проходит
- [ ] Grep: ноль legacy-паттернов в кодовой базе
- [ ] Логин/профиль/смена пароля работает для admin
- [ ] Guest не может обновить профиль / сменить пароль (403)
- [ ] GET/POST/PUT/DELETE /admin/roles работает для admin
- [ ] Non-admin не может управлять ролями (403)
- [ ] `curl localhost:8002/health` → healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)