### PR TITLE
fix(deploy): install devDependencies and increase health check timeout

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -48,7 +48,7 @@ log "Installing bridge dependencies..."
 # Install/update npm deps
 log "Installing npm dependencies..."
 cd "$REPO_DIR/admin"
-npm ci --silent 2>&1 | tee -a "$LOG_FILE"
+npm ci --include=dev --silent 2>&1 | tee -a "$LOG_FILE"
 
 # Ensure .env.production.local exists (base path override)
 if [ ! -f "$REPO_DIR/admin/.env.production.local" ]; then
@@ -77,7 +77,7 @@ log "Restarting orchestrator..."
 systemctl restart ai-secretary 2>&1 | tee -a "$LOG_FILE"
 
 # Wait and verify
-sleep 5
+sleep 20
 if curl -sf http://localhost:8002/health > /dev/null 2>&1; then
     log "=== Deploy completed successfully ==="
 else


### PR DESCRIPTION
## Summary
Fixes #359

## Changes
1. **npm ci --include=dev**: Ensures devDependencies (like `vue-tsc`) are installed during deployment. Without this flag, `npm ci` skips devDependencies when NODE_ENV=production is set, causing build failures.

2. **Health check sleep 5 → 20 seconds**: Gives the orchestrator more time to start before checking /health endpoint, reducing false warnings on slower systems.

## Root Cause
The deploy script was running `npm ci --silent` which respects NODE_ENV. In production environments where NODE_ENV=production, devDependencies are skipped. Since `vue-tsc` is a devDependency required for building the admin panel, the build would fail with "vue-tsc not found".