### PR TITLE
feat(rbac): migrate frontend to API-driven permissions

### DIFF
--- a/admin/src/api/demo/auth.ts
+++ b/admin/src/api/demo/auth.ts
@@ -3,6 +3,31 @@ import type { DemoRoute } from './types'
 const demoRole = import.meta.env.VITE_DEMO_ROLE || 'admin'
 const demoDeploymentMode = import.meta.env.VITE_DEMO_DEPLOYMENT_MODE || 'full'
 
+const ALL_MODULES = [
+  'dashboard', 'chat', 'llm', 'speech', 'faq', 'channels',
+  'gsm', 'system', 'audit', 'usage', 'settings', 'users',
+  'sales', 'kanban', 'roles', 'billing',
+]
+
+function getDemoPermissions(): Record<string, string> {
+  if (demoRole === 'admin') {
+    return Object.fromEntries(ALL_MODULES.map(m => [m, 'manage']))
+  }
+  if (demoRole === 'user' || demoRole === 'web') {
+    // operator: edit on core modules, view on read-only modules
+    return {
+      chat: 'edit', llm: 'edit', faq: 'edit', channels: 'edit',
+      sales: 'edit', kanban: 'edit', settings: 'edit', usage: 'edit',
+      audit: 'view', system: 'view', dashboard: 'view',
+    }
+  }
+  // guest / viewer
+  return {
+    chat: 'view', faq: 'view', dashboard: 'view',
+    audit: 'view', usage: 'view', kanban: 'view', sales: 'view',
+  }
+}
+
 function createDemoToken(username: string): { access_token: string } {
   const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
   const payload = btoa(JSON.stringify({
@@ -54,5 +79,10 @@ export const authRoutes: DemoRoute[] = [
     method: 'GET',
     pattern: /^\/admin\/deployment-mode$/,
     handler: () => ({ mode: demoDeploymentMode }),
+  },
+  {
+    method: 'GET',
+    pattern: /^\/admin\/auth\/permissions$/,
+    handler: () => getDemoPermissions(),
   },
 ]

--- a/admin/src/components/AccordionNav.vue
+++ b/admin/src/components/AccordionNav.vue
@@ -2,7 +2,7 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { useAuthStore, type UserRole } from '../stores/auth'
+import { useAuthStore } from '../stores/auth'
 import { ChevronDown } from 'lucide-vue-next'
 import {
   LayoutDashboard,
@@ -36,14 +36,13 @@ const { t } = useI18n()
 const route = useRoute()
 const authStore = useAuthStore()
 
-const ROLE_LEVEL: Record<UserRole, number> = { guest: 0, web: 1, user: 1, admin: 2 }
+const LVL: Record<string, number> = { view: 1, edit: 2, manage: 3 }
 
-function isVisibleForRole(item: { minRole?: UserRole; excludeRoles?: UserRole[]; localOnly?: boolean }): boolean {
-  const userRole = authStore.user?.role || 'guest'
-  if (item.excludeRoles?.includes(userRole)) return false
+function isVisible(item: { module?: string; minLevel?: string; localOnly?: boolean }): boolean {
   if (item.localOnly && authStore.isCloudMode) return false
-  if (!item.minRole) return true
-  return ROLE_LEVEL[userRole] >= ROLE_LEVEL[item.minRole]
+  if (!item.module) return true
+  const min = item.minLevel || 'view'
+  return (LVL[authStore.permissions[item.module]] ?? 0) >= (LVL[min] ?? 1)
 }
 
 // Navigation groups with items
@@ -53,10 +52,10 @@ const allNavGroups = computed(() => [
     nameKey: 'nav.group.monitoring',
     icon: Activity,
     items: [
-      { path: '/', nameKey: 'nav.dashboard', icon: LayoutDashboard, excludeRoles: ['web', 'user'] as UserRole[], localOnly: true },
-      { path: '/monitoring', nameKey: 'nav.monitoring', icon: Activity, minRole: 'admin' as UserRole, localOnly: true },
-      { path: '/services', nameKey: 'nav.services', icon: Server, minRole: 'admin' as UserRole, localOnly: true },
-      { path: '/audit', nameKey: 'nav.audit', icon: FileText, minRole: 'admin' as UserRole },
+      { path: '/', nameKey: 'nav.dashboard', icon: LayoutDashboard, module: 'dashboard', localOnly: true },
+      { path: '/monitoring', nameKey: 'nav.monitoring', icon: Activity, module: 'system', localOnly: true },
+      { path: '/services', nameKey: 'nav.services', icon: Server, module: 'system', minLevel: 'manage', localOnly: true },
+      { path: '/audit', nameKey: 'nav.audit', icon: FileText, module: 'audit' },
     ]
   },
   {
@@ -64,10 +63,10 @@ const allNavGroups = computed(() => [
     nameKey: 'nav.group.ai',
     icon: Brain,
     items: [
-      { path: '/llm', nameKey: 'nav.llm', icon: Brain, minRole: 'user' as UserRole },
-      { path: '/tts', nameKey: 'nav.tts', icon: Mic, minRole: 'user' as UserRole, excludeRoles: ['web'] as UserRole[], localOnly: true },
-      { path: '/models', nameKey: 'nav.models', icon: AudioLines, minRole: 'admin' as UserRole, localOnly: true },
-      { path: '/finetune', nameKey: 'nav.finetune', icon: Sparkles, minRole: 'user' as UserRole },
+      { path: '/llm', nameKey: 'nav.llm', icon: Brain, module: 'llm' },
+      { path: '/tts', nameKey: 'nav.tts', icon: Mic, module: 'speech', localOnly: true },
+      { path: '/models', nameKey: 'nav.models', icon: AudioLines, module: 'system', minLevel: 'manage', localOnly: true },
+      { path: '/finetune', nameKey: 'nav.finetune', icon: Sparkles, module: 'llm' },
     ]
   },
   {
@@ -75,10 +74,10 @@ const allNavGroups = computed(() => [
     nameKey: 'nav.group.channels',
     icon: MessageCircle,
     items: [
-      { path: '/telegram', nameKey: 'nav.telegram', icon: Send, minRole: 'user' as UserRole },
-      { path: '/whatsapp', nameKey: 'nav.whatsapp', icon: WhatsApp, minRole: 'user' as UserRole },
-      { path: '/widget', nameKey: 'nav.widget', icon: Code2, minRole: 'user' as UserRole },
-      { path: '/gsm', nameKey: 'nav.gsm', icon: Phone, minRole: 'admin' as UserRole, localOnly: true },
+      { path: '/telegram', nameKey: 'nav.telegram', icon: Send, module: 'channels' },
+      { path: '/whatsapp', nameKey: 'nav.whatsapp', icon: WhatsApp, module: 'channels' },
+      { path: '/widget', nameKey: 'nav.widget', icon: Code2, module: 'channels' },
+      { path: '/gsm', nameKey: 'nav.gsm', icon: Phone, module: 'gsm', localOnly: true },
     ]
   },
   {
@@ -86,9 +85,9 @@ const allNavGroups = computed(() => [
     nameKey: 'nav.group.business',
     icon: ShoppingCart,
     items: [
-      { path: '/sales', nameKey: 'nav.sales', icon: ShoppingCart, minRole: 'user' as UserRole },
-      { path: '/crm', nameKey: 'nav.crm', icon: Users, minRole: 'user' as UserRole },
-      { path: '/kanban', nameKey: 'nav.kanban', icon: ClipboardList, minRole: 'user' as UserRole },
+      { path: '/sales', nameKey: 'nav.sales', icon: ShoppingCart, module: 'sales' },
+      { path: '/crm', nameKey: 'nav.crm', icon: Users, module: 'sales' },
+      { path: '/kanban', nameKey: 'nav.kanban', icon: ClipboardList, module: 'kanban' },
     ]
   },
   {
@@ -96,8 +95,8 @@ const allNavGroups = computed(() => [
     nameKey: 'nav.group.system',
     icon: Settings,
     items: [
-      { path: '/wiki', nameKey: 'nav.wiki', icon: BookOpen },
-      { path: '/settings', nameKey: 'common.settings', icon: Settings, minRole: 'user' as UserRole },
+      { path: '/wiki', nameKey: 'nav.wiki', icon: BookOpen, module: 'faq' },
+      { path: '/settings', nameKey: 'common.settings', icon: Settings },
       { path: '/about', nameKey: 'nav.about', icon: Info },
     ]
   }
@@ -108,7 +107,7 @@ const navGroups = computed(() =>
   allNavGroups.value
     .map(group => ({
       ...group,
-      items: group.items.filter(item => isVisibleForRole(item))
+      items: group.items.filter(item => isVisible(item))
     }))
     .filter(group => group.items.length > 0)
 )

--- a/admin/src/components/kanban/KanbanCardDetail.vue
+++ b/admin/src/components/kanban/KanbanCardDetail.vue
@@ -44,7 +44,7 @@ const newChecklistText = ref('')
 const showAddDependency = ref(false)
 const selectedDependencyId = ref<number | null>(null)
 
-const isAdmin = computed(() => authStore.isAdmin)
+const isAdmin = computed(() => authStore.canManage('kanban'))
 
 const githubIssueUrl = computed(() => {
   if (!props.task?.github_issue_number || !props.currentProject) return null

--- a/admin/src/router.ts
+++ b/admin/src/router.ts
@@ -35,115 +35,115 @@ const router = createRouter({
       path: '/',
       name: 'dashboard',
       component: DashboardView,
-      meta: { title: 'Dashboard', icon: 'LayoutDashboard', excludeRoles: ['web'], localOnly: true }
+      meta: { title: 'Dashboard', icon: 'LayoutDashboard', module: 'dashboard', localOnly: true }
     },
     {
       path: '/chat',
       name: 'chat',
       component: ChatView,
-      meta: { title: 'Chat', icon: 'MessageCircle' }
+      meta: { title: 'Chat', icon: 'MessageCircle', module: 'chat' }
     },
     {
       path: '/services',
       name: 'services',
       component: ServicesView,
-      meta: { title: 'Services', icon: 'Server', minRole: 'user', excludeRoles: ['web'], localOnly: true }
+      meta: { title: 'Services', icon: 'Server', module: 'system', minLevel: 'manage', localOnly: true }
     },
     {
       path: '/llm',
       name: 'llm',
       component: LlmView,
-      meta: { title: 'LLM', icon: 'Brain', minRole: 'user' }
+      meta: { title: 'LLM', icon: 'Brain', module: 'llm' }
     },
     {
       path: '/tts',
       name: 'tts',
       component: TtsView,
-      meta: { title: 'TTS', icon: 'Mic', minRole: 'user', excludeRoles: ['web'], localOnly: true }
+      meta: { title: 'TTS', icon: 'Mic', module: 'speech', localOnly: true }
     },
     {
       path: '/wiki',
       name: 'wiki',
       component: FaqView,
-      meta: { title: 'Wiki', icon: 'BookOpen' }
+      meta: { title: 'Wiki', icon: 'BookOpen', module: 'faq' }
     },
     {
       path: '/finetune',
       name: 'finetune',
       component: FinetuneView,
-      meta: { title: 'Fine-tune', icon: 'Sparkles' }
+      meta: { title: 'Fine-tune', icon: 'Sparkles', module: 'llm' }
     },
     {
       path: '/monitoring',
       name: 'monitoring',
       component: MonitoringView,
-      meta: { title: 'Monitoring', icon: 'Activity', minRole: 'user', excludeRoles: ['web'], localOnly: true }
+      meta: { title: 'Monitoring', icon: 'Activity', module: 'system', localOnly: true }
     },
     {
       path: '/models',
       name: 'models',
       component: ModelsView,
-      meta: { title: 'Models', icon: 'HardDrive', minRole: 'admin', localOnly: true }
+      meta: { title: 'Models', icon: 'HardDrive', module: 'system', minLevel: 'manage', localOnly: true }
     },
     {
       path: '/widget',
       name: 'widget',
       component: WidgetView,
-      meta: { title: 'Widget', icon: 'Code2', minRole: 'user' }
+      meta: { title: 'Widget', icon: 'Code2', module: 'channels' }
     },
     {
       path: '/telegram',
       name: 'telegram',
       component: TelegramView,
-      meta: { title: 'Telegram', icon: 'Send', minRole: 'user' }
+      meta: { title: 'Telegram', icon: 'Send', module: 'channels' }
     },
     {
       path: '/whatsapp',
       name: 'whatsapp',
       component: WhatsAppView,
-      meta: { title: 'WhatsApp', icon: 'MessageCircle', minRole: 'user' }
+      meta: { title: 'WhatsApp', icon: 'MessageCircle', module: 'channels' }
     },
     {
       path: '/gsm',
       name: 'gsm',
       component: GSMView,
-      meta: { title: 'GSM Telephony', icon: 'Phone', minRole: 'admin', localOnly: true }
+      meta: { title: 'GSM Telephony', icon: 'Phone', module: 'gsm', localOnly: true }
     },
     {
       path: '/audit',
       name: 'audit',
       component: AuditView,
-      meta: { title: 'Audit', icon: 'FileText', minRole: 'user', excludeRoles: ['web'] }
+      meta: { title: 'Audit', icon: 'FileText', module: 'audit' }
     },
     {
       path: '/usage',
       name: 'usage',
       component: UsageView,
-      meta: { title: 'Usage', icon: 'BarChart3', minRole: 'user', excludeRoles: ['web'] }
+      meta: { title: 'Usage', icon: 'BarChart3', module: 'usage' }
     },
     {
       path: '/settings',
       name: 'settings',
       component: SettingsView,
-      meta: { title: 'Settings', icon: 'Settings', minRole: 'user' }
+      meta: { title: 'Settings', icon: 'Settings' }
     },
     {
       path: '/crm',
       name: 'crm',
       component: CrmView,
-      meta: { title: 'CRM', icon: 'Users', minRole: 'user', excludeRoles: ['web'] }
+      meta: { title: 'CRM', icon: 'Users', module: 'sales' }
     },
     {
       path: '/kanban',
       name: 'kanban',
       component: KanbanView,
-      meta: { title: 'Kanban', icon: 'ClipboardList', minRole: 'user' }
+      meta: { title: 'Kanban', icon: 'ClipboardList', module: 'kanban' }
     },
     {
       path: '/sales',
       name: 'sales',
       component: SalesView,
-      meta: { title: 'Sales', icon: 'ShoppingCart', minRole: 'user' }
+      meta: { title: 'Sales', icon: 'ShoppingCart', module: 'sales' }
     },
     {
       path: '/about',
@@ -154,8 +154,7 @@ const router = createRouter({
   ]
 })
 
-// Role level mapping for route guards
-const ROLE_LEVEL: Record<string, number> = { guest: 0, web: 1, user: 1, admin: 2 }
+const LVL: Record<string, number> = { view: 1, edit: 2, manage: 3 }
 
 // Navigation guard for authentication and authorization
 router.beforeEach((to, from, next) => {
@@ -168,7 +167,7 @@ router.beforeEach((to, from, next) => {
     // Check if token is in localStorage but store not initialized
     const token = localStorage.getItem('admin_token')
     if (token && !authStore.isTokenExpired()) {
-      // Token exists and valid, check role below
+      // Token exists and valid, check permissions below
     } else {
       // Redirect to login
       next({ name: 'login', query: { redirect: to.fullPath } })
@@ -176,17 +175,8 @@ router.beforeEach((to, from, next) => {
     }
   } else if (to.name === 'login' && authStore.isAuthenticated) {
     // Already logged in, redirect to landing page
-    const landing = authStore.isWeb ? 'chat' : 'dashboard'
+    const landing = authStore.hasModule('dashboard') && !authStore.isCloudMode ? 'dashboard' : 'chat'
     next({ name: landing })
-    return
-  }
-
-  const userRole = authStore.user?.role || 'guest'
-
-  // Check excludeRoles (e.g. 'web' excluded from dashboard, services)
-  const excludeRoles = to.meta.excludeRoles as string[] | undefined
-  if (excludeRoles?.includes(userRole)) {
-    next({ name: 'chat' })
     return
   }
 
@@ -196,12 +186,12 @@ router.beforeEach((to, from, next) => {
     return
   }
 
-  // Check role-based access
-  const minRole = to.meta.minRole as string | undefined
-  if (minRole) {
-    if (ROLE_LEVEL[userRole] < ROLE_LEVEL[minRole]) {
-      // Insufficient role, redirect to landing page
-      const landing = userRole === 'web' ? 'chat' : 'dashboard'
+  // Module + level check
+  const mod = to.meta.module as string | undefined
+  if (mod) {
+    const minLvl = (to.meta.minLevel as string) || 'view'
+    if ((LVL[authStore.permissions[mod]] ?? 0) < (LVL[minLvl] ?? 1)) {
+      const landing = authStore.hasModule('dashboard') && !authStore.isCloudMode ? 'dashboard' : 'chat'
       next({ name: landing })
       return
     }

--- a/admin/src/stores/auth.ts
+++ b/admin/src/stores/auth.ts
@@ -9,49 +9,13 @@ export interface User {
   role: UserRole
 }
 
-// Role permissions
-export const ROLE_PERMISSIONS: Record<UserRole, string[]> = {
-  admin: ['*'], // All permissions
-  user: [
-    'chat.*',
-    'llm.view', 'llm.cloud.*',
-    'tts.view', 'tts.test',
-    'faq.*',
-    'telegram.*',
-    'widget.*',
-    'monitoring.view',
-    'services.view',
-    'audit.view',
-    'settings.profile',
-    'sales.*',
-    'crm.view',
-    'usage.view',
-  ],
-  web: [
-    'chat.*',
-    'llm.view', 'llm.cloud.*',
-    'faq.*',
-    'telegram.*',
-    'widget.*',
-    'monitoring.view',
-    'audit.view',
-    'settings.profile',
-    'sales.*',
-    'crm.view',
-    'usage.view',
-  ],
-  guest: [
-    'chat.demo',
-    'dashboard.view',
-    'faq.view',
-  ]
-}
-
 // Check if we're in dev mode (Vite sets this)
 const isDev = import.meta.env.DEV
 const isDemo = import.meta.env.VITE_DEMO_MODE === 'true'
 
 export type DeploymentMode = 'full' | 'cloud' | 'local'
+
+const LEVEL_ORDER: Record<string, number> = { view: 1, edit: 2, manage: 3 }
 
 export const useAuthStore = defineStore('auth', () => {
   const token = ref<string | null>(localStorage.getItem('admin_token'))
@@ -59,37 +23,23 @@ export const useAuthStore = defineStore('auth', () => {
   const deploymentMode = ref<DeploymentMode>('full')
   const isLoading = ref(false)
   const error = ref<string | null>(null)
+  const permissions = ref<Record<string, string>>({})
 
   const isAuthenticated = computed(() => !!token.value)
-  const isAdmin = computed(() => user.value?.role === 'admin')
-  const isUser = computed(() => user.value?.role === 'user' || user.value?.role === 'web' || isAdmin.value)
-  const isWeb = computed(() => user.value?.role === 'web')
-  const isGuest = computed(() => user.value?.role === 'guest')
+  const isAdmin = computed(() => canManage('users'))
   const isCloudMode = computed(() => deploymentMode.value === 'cloud')
 
-  // Legacy compat aliases
-  const isOperator = isUser
-  const isViewer = computed(() => !!user.value)
-
-  // Check if user has specific permission
-  function hasPermission(permission: string): boolean {
-    if (!user.value) return false
-    const permissions = ROLE_PERMISSIONS[user.value.role]
-    if (permissions.includes('*')) return true
-    // Check exact match or wildcard match (e.g. 'chat.*' matches 'chat.view')
-    return permissions.some(p => {
-      if (p === permission) return true
-      if (p.endsWith('.*')) {
-        const prefix = p.slice(0, -2)
-        return permission.startsWith(prefix + '.')
-      }
-      return false
-    })
+  function hasModule(module: string): boolean {
+    return module in permissions.value
   }
-
-  // Check if user can perform action on resource
-  function can(action: string, resource: string): boolean {
-    return hasPermission(`${resource}.${action}`)
+  function canView(module: string): boolean {
+    return (LEVEL_ORDER[permissions.value[module]] ?? 0) >= 1
+  }
+  function canEdit(module: string): boolean {
+    return (LEVEL_ORDER[permissions.value[module]] ?? 0) >= 2
+  }
+  function canManage(module: string): boolean {
+    return (LEVEL_ORDER[permissions.value[module]] ?? 0) >= 3
   }
 
   // Fetch deployment mode from backend
@@ -105,6 +55,14 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
+  // Fetch permissions from backend
+  async function fetchPermissions() {
+    try {
+      const resp = await fetch('/admin/auth/permissions', { headers: getAuthHeaders() })
+      if (resp.ok) permissions.value = await resp.json()
+    } catch { /* default empty */ }
+  }
+
   // Initialize from localStorage
   if (token.value) {
     try {
@@ -114,8 +72,9 @@ export const useAuthStore = defineStore('auth', () => {
         username: payload.sub,
         role: payload.role
       }
-      // Fetch deployment mode on init
+      // Fetch deployment mode and permissions on init
       fetchDeploymentMode()
+      fetchPermissions()
     } catch {
       token.value = null
       localStorage.removeItem('admin_token')
@@ -166,8 +125,9 @@ export const useAuthStore = defineStore('auth', () => {
         role: payload.role
       }
 
-      // Fetch deployment mode from backend
+      // Fetch deployment mode and permissions from backend
       await fetchDeploymentMode()
+      await fetchPermissions()
 
       return true
     } catch (e) {
@@ -192,6 +152,7 @@ export const useAuthStore = defineStore('auth', () => {
   function logout() {
     token.value = null
     user.value = null
+    permissions.value = {}
     localStorage.removeItem('admin_token')
   }
 
@@ -219,16 +180,14 @@ export const useAuthStore = defineStore('auth', () => {
     deploymentMode,
     isLoading,
     error,
+    permissions,
     isAuthenticated,
     isAdmin,
-    isUser,
-    isWeb,
-    isGuest,
     isCloudMode,
-    isOperator,
-    isViewer,
-    hasPermission,
-    can,
+    hasModule,
+    canView,
+    canEdit,
+    canManage,
     login,
     logout,
     getAuthHeaders,

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -262,7 +262,7 @@ const tokenUsage = computed(() => currentSession.value?.token_usage)
 const isSessionOwner = computed(() => {
   if (!currentSession.value) return false
   const ownerId = currentSession.value.owner_id
-  return authStore.isAdmin || ownerId === authStore.user?.id || ownerId === null || ownerId === undefined
+  return authStore.canManage('chat') || ownerId === authStore.user?.id || ownerId === null || ownerId === undefined
 })
 const isSharedWithMe = computed(() => currentSession.value?.is_shared_with_me === true)
 const isReadOnly = computed(() => isSharedWithMe.value && currentSession.value?.share_permission === 'read')

--- a/admin/src/views/CrmView.vue
+++ b/admin/src/views/CrmView.vue
@@ -631,7 +631,7 @@ onMounted(async () => {
               {{ isDatasetSyncing ? t('crm.dataset.syncing') : t('crm.dataset.syncButton') }}
             </button>
             <button
-              v-if="datasetStatus.synced && authStore.isAdmin"
+              v-if="datasetStatus.synced && authStore.canManage('sales')"
               class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg hover:bg-destructive/10 text-destructive"
               @click="clearDataset"
             >

--- a/admin/src/views/FinetuneView.vue
+++ b/admin/src/views/FinetuneView.vue
@@ -48,7 +48,7 @@ const activeTab = ref<'llm' | 'tts'>('llm')
 
 // LLM sub-mode: local LoRA vs cloud AI knowledge
 // Web role users only see Cloud AI
-const llmMode = ref<'local' | 'cloud'>(authStore.isWeb || authStore.isCloudMode ? 'cloud' : 'local')
+const llmMode = ref<'local' | 'cloud'>(!authStore.hasModule('speech') || authStore.isCloudMode ? 'cloud' : 'local')
 
 // ============== Cloud AI (Wiki RAG) State ==============
 const searchQuery = ref('')
@@ -564,7 +564,7 @@ onUnmounted(() => {
         LLM Training
       </button>
       <button
-        v-if="!authStore.isWeb && !authStore.isCloudMode"
+        v-if="authStore.hasModule('speech') && !authStore.isCloudMode"
         :class="[
           'flex items-center gap-2 px-4 py-2 rounded-lg transition-colors',
           activeTab === 'tts' ? 'bg-primary text-primary-foreground' : 'bg-secondary hover:bg-secondary/80'
@@ -579,7 +579,7 @@ onUnmounted(() => {
     <!-- ============== LLM TAB ============== -->
     <template v-if="activeTab === 'llm'">
       <!-- Local / Cloud AI Toggle (hidden for web/cloud — they only see Cloud AI) -->
-      <div v-if="!authStore.isWeb && !authStore.isCloudMode" class="bg-card rounded-lg border border-border p-4">
+      <div v-if="authStore.hasModule('speech') && !authStore.isCloudMode" class="bg-card rounded-lg border border-border p-4">
         <div class="grid grid-cols-2 gap-2 p-1 bg-secondary rounded-lg max-w-md">
           <button
             :class="[

--- a/admin/src/views/KanbanView.vue
+++ b/admin/src/views/KanbanView.vue
@@ -296,7 +296,7 @@ function selectProject(id: number | null) {
                 {{ project.github_owner }}/{{ project.github_repo }}
               </span>
             </button>
-            <div v-if="authStore.isAdmin" class="border-t border-border">
+            <div v-if="authStore.canManage('kanban')" class="border-t border-border">
               <button
                 class="w-full text-left px-4 py-2 hover:bg-secondary/50 last:rounded-b-lg text-sm text-primary flex items-center gap-2"
                 @click="openProjectCreate"
@@ -310,7 +310,7 @@ function selectProject(id: number | null) {
 
         <!-- Edit project button -->
         <button
-          v-if="kanbanStore.currentProject && authStore.isAdmin"
+          v-if="kanbanStore.currentProject && authStore.canManage('kanban')"
           class="p-1.5 rounded-lg hover:bg-muted transition-colors text-muted-foreground"
           :title="t('kanban.editProject')"
           @click="openProjectEdit"
@@ -321,7 +321,7 @@ function selectProject(id: number | null) {
       <div class="flex items-center gap-2">
         <!-- Sync button (GitHub projects only) -->
         <button
-          v-if="kanbanStore.currentProject && !authStore.isGuest"
+          v-if="kanbanStore.currentProject && authStore.canEdit('kanban')"
           class="flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg border border-border hover:bg-muted transition-colors"
           :disabled="kanbanStore.syncing"
           @click="handleSync"
@@ -366,7 +366,7 @@ function selectProject(id: number | null) {
           <RefreshCw class="w-4 h-4" :class="{ 'animate-spin': kanbanStore.loading }" />
         </button>
         <button
-          v-if="!authStore.isGuest"
+          v-if="authStore.canEdit('kanban')"
           class="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
           @click="openCreate"
         >
@@ -381,7 +381,7 @@ function selectProject(id: number | null) {
       v-if="kanbanStore.activeView === 'kanban'"
       :tasks-by-status="kanbanStore.tasksByStatus"
       :loading="kanbanStore.loading"
-      :disabled="authStore.isGuest"
+      :disabled="!authStore.canEdit('kanban')"
       :is-github-project="!!kanbanStore.currentProject"
       @reorder="handleReorder"
       @click-task="openDetail"
@@ -393,7 +393,7 @@ function selectProject(id: number | null) {
       v-else
       :tasks="kanbanStore.ganttTasks"
       :loading="kanbanStore.loading"
-      :disabled="authStore.isGuest"
+      :disabled="!authStore.canEdit('kanban')"
       @click-task="handleGanttClick"
       @date-change="handleDateChange"
     />

--- a/admin/src/views/LlmView.vue
+++ b/admin/src/views/LlmView.vue
@@ -640,7 +640,7 @@ function switchToCloudProvider(providerId: string) {
         <div v-if="backendLoading" class="text-muted-foreground">Loading...</div>
         <div v-else class="space-y-4">
           <!-- Backend Toggle (admin only can switch to vLLM) -->
-          <div v-if="authStore.isAdmin" class="flex items-center gap-4">
+          <div v-if="authStore.canManage('llm')" class="flex items-center gap-4">
             <div class="grid grid-cols-2 gap-2 p-1 bg-secondary rounded-lg">
               <button
                 :disabled="setBackendMutation.isPending.value"
@@ -845,7 +845,7 @@ function switchToCloudProvider(providerId: string) {
     </div>
 
     <!-- Available Models (vLLM) — admin only -->
-    <div v-if="isVllm && authStore.isAdmin" class="bg-card rounded-lg border border-border">
+    <div v-if="isVllm && authStore.canManage('llm')" class="bg-card rounded-lg border border-border">
       <div class="p-4 border-b border-border">
         <h2 class="text-lg font-semibold flex items-center gap-2">
           <Cpu class="w-5 h-5" />

--- a/admin/src/views/ServicesView.vue
+++ b/admin/src/views/ServicesView.vue
@@ -127,7 +127,7 @@ watch(logSearch, async () => {
     <!-- Toolbar -->
     <div class="flex items-center gap-4">
       <button
-        v-if="authStore.isAdmin"
+        v-if="authStore.canManage('system')"
         :disabled="startAllMutation.isPending.value"
         class="flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 transition-colors"
         @click="startAllMutation.mutate()"
@@ -136,7 +136,7 @@ watch(logSearch, async () => {
         Start All
       </button>
       <button
-        v-if="authStore.isAdmin"
+        v-if="authStore.canManage('system')"
         :disabled="stopAllMutation.isPending.value"
         class="flex items-center gap-2 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 transition-colors"
         @click="stopAllMutation.mutate()"
@@ -200,7 +200,7 @@ watch(logSearch, async () => {
               <Terminal class="w-4 h-4" />
             </button>
             <button
-              v-if="!service.is_running && authStore.isAdmin"
+              v-if="!service.is_running && authStore.canManage('system')"
               :disabled="startMutation.isPending.value"
               class="p-2 rounded-lg bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 transition-colors"
               title="Start"
@@ -210,7 +210,7 @@ watch(logSearch, async () => {
               <Play v-else class="w-4 h-4" />
             </button>
             <button
-              v-if="service.is_running && authStore.isAdmin"
+              v-if="service.is_running && authStore.canManage('system')"
               :disabled="stopMutation.isPending.value"
               class="p-2 rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
               title="Stop"
@@ -220,7 +220,7 @@ watch(logSearch, async () => {
               <Square v-else class="w-4 h-4" />
             </button>
             <button
-              v-if="authStore.isAdmin"
+              v-if="authStore.canManage('system')"
               :disabled="restartMutation.isPending.value"
               class="p-2 rounded-lg bg-secondary hover:bg-secondary/80 disabled:opacity-50 transition-colors"
               title="Restart"

--- a/admin/src/views/SettingsView.vue
+++ b/admin/src/views/SettingsView.vue
@@ -240,7 +240,7 @@ function toggleLocale() {
           </div>
 
           <!-- Display Name -->
-          <div v-if="!authStore.isGuest">
+          <div v-if="authStore.canEdit('settings')">
             <label class="block text-sm text-muted-foreground mb-1">{{ t('profile.displayName') }}</label>
             <div class="flex gap-2">
               <input
@@ -272,14 +272,14 @@ function toggleLocale() {
           </div>
 
           <!-- Guest notice -->
-          <div v-if="authStore.isGuest" class="text-sm text-muted-foreground italic">
+          <div v-if="!authStore.canEdit('settings')" class="text-sm text-muted-foreground italic">
             {{ t('profile.guestReadOnly') }}
           </div>
         </div>
       </div>
 
       <!-- Change Password -->
-      <div v-if="!authStore.isGuest" class="bg-card rounded-xl border border-border p-6">
+      <div v-if="authStore.canEdit('settings')" class="bg-card rounded-xl border border-border p-6">
         <h3 class="font-semibold flex items-center gap-2 mb-4">
           <Lock class="w-5 h-5" />
           {{ t('profile.changePassword') }}

--- a/admin/src/views/TtsView.vue
+++ b/admin/src/views/TtsView.vue
@@ -186,7 +186,7 @@ function createPreset() {
 
       <div class="p-4 space-y-6">
         <!-- XTTS Voices (hidden for web role) -->
-        <div v-if="xttsVoices.length && !authStore.isWeb" :class="['transition-opacity duration-200', !isXttsActive && 'opacity-60']">
+        <div v-if="xttsVoices.length && authStore.canEdit('speech')" :class="['transition-opacity duration-200', !isXttsActive && 'opacity-60']">
           <div class="flex items-center gap-2 mb-3">
             <h3 class="text-sm font-medium text-muted-foreground">XTTS v2 (GPU CC >= 7.0)</h3>
             <span v-if="isXttsActive" class="px-2 py-0.5 text-xs font-medium bg-primary/20 text-primary rounded-full">
@@ -307,7 +307,7 @@ function createPreset() {
     </div>
 
     <!-- XTTS Parameters (hidden for web role) -->
-    <div v-if="currentEngine === 'xtts' && !authStore.isWeb" class="bg-card rounded-lg border border-border">
+    <div v-if="currentEngine === 'xtts' && authStore.canEdit('speech')" class="bg-card rounded-lg border border-border">
       <div class="p-4 border-b border-border flex items-center justify-between">
         <h2 class="text-lg font-semibold flex items-center gap-2">
           <Settings2 class="w-5 h-5" />


### PR DESCRIPTION
## Summary
- Replace hardcoded `ROLE_PERMISSIONS` and role-based checks (`isAdmin`/`isGuest`/`isWeb`) with dynamic permissions from `GET /admin/auth/permissions`
- Add `hasModule()`/`canView()`/`canEdit()`/`canManage()` helpers to auth store
- Migrate router guards and nav visibility from `minRole`/`excludeRoles` to `module`/`minLevel`
- Update 9 view files (~24 permission check points) to use new permission functions

## Changes (13 files, -160/+138)
| File | Change |
|------|--------|
| `stores/auth.ts` | Remove `ROLE_PERMISSIONS`, `isUser`, `isWeb`, `isGuest`, `isOperator`, `isViewer`, `hasPermission`, `can`; add `permissions` ref, `fetchPermissions()`, `hasModule`/`canView`/`canEdit`/`canManage` |
| `router.ts` | Replace `minRole`/`excludeRoles` meta with `module`/`minLevel`; new permission-based guard |
| `AccordionNav.vue` | Replace `ROLE_LEVEL` + `isVisibleForRole()` with module-based `isVisible()` |
| `ChatView.vue` | `isAdmin` → `canManage('chat')` |
| `LlmView.vue` | `isAdmin` → `canManage('llm')` (2 places) |
| `ServicesView.vue` | `isAdmin` → `canManage('system')` (5 places) |
| `TtsView.vue` | `!isWeb` → `canEdit('speech')` (2 places) |
| `FinetuneView.vue` | `isWeb` → `!hasModule('speech')` (3 places) |
| `CrmView.vue` | `isAdmin` → `canManage('sales')` |
| `KanbanView.vue` | `isAdmin` → `canManage('kanban')`, `isGuest` → `!canEdit('kanban')` |
| `SettingsView.vue` | `isGuest` → `!canEdit('settings')` |
| `KanbanCardDetail.vue` | `isAdmin` → `canManage('kanban')` |
| `demo/auth.ts` | Add mock `GET /admin/auth/permissions` endpoint |

## Test plan
- [ ] `vue-tsc -b` passes (verified)
- [ ] `npm run build` passes (verified)
- [ ] Dead code grep clean: no `ROLE_PERMISSIONS`, `ROLE_LEVEL`, `isGuest`, `isWeb`, `isUser`, `excludeRoles`, `minRole` in src/
- [ ] Demo mode: login as admin → all nav items visible
- [ ] Demo mode: web role → restricted nav (no dashboard, services, TTS, monitoring, models, GSM)
- [ ] Production: permissions fetched from API on login and init

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)