### PR TITLE
feat(rbac): add workspace_id to 13 resource tables

### DIFF
--- a/alembic/versions/20260223_0006_add_workspace_id_to_resources.py
+++ b/alembic/versions/20260223_0006_add_workspace_id_to_resources.py
@@ -1,0 +1,54 @@
+"""Add workspace_id to 13 resource tables.
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-02-23
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+# Tables that get workspace_id + their composite index columns.
+# Format: (table_name, index_name, index_columns)
+_TABLES = [
+    ("chat_sessions", "ix_chat_sessions_ws", ["workspace_id", "owner_id"]),
+    ("bot_instances", "ix_bot_instances_ws", ["workspace_id", "owner_id"]),
+    ("widget_instances", "ix_widget_instances_ws", ["workspace_id", "owner_id"]),
+    ("whatsapp_instances", "ix_whatsapp_instances_ws", ["workspace_id", "owner_id"]),
+    ("cloud_llm_providers", "ix_cloud_llm_providers_ws", ["workspace_id", "owner_id"]),
+    ("tts_presets", "ix_tts_presets_ws", ["workspace_id", "owner_id"]),
+    ("knowledge_documents", "ix_knowledge_documents_ws", ["workspace_id", "owner_id"]),
+    ("knowledge_collections", "ix_knowledge_collections_ws", ["workspace_id", "id"]),
+    ("claude_code_sessions", "ix_claude_code_sessions_ws", ["workspace_id", "owner_id"]),
+    ("faq_entries", "ix_faq_entries_ws", ["workspace_id", "id"]),
+    ("kanban_tasks", "ix_kanban_tasks_ws", ["workspace_id", "id"]),
+    ("kanban_projects", "ix_kanban_projects_ws", ["workspace_id", "id"]),
+    ("amocrm_config", "ix_amocrm_config_ws", ["workspace_id", "id"]),
+]
+
+
+def upgrade() -> None:
+    for table, ix_name, ix_cols in _TABLES:
+        # Plain ADD COLUMN — no FK constraint at DB level (ORM enforces it).
+        # Avoids both batch_alter_table issues (server_default recreation) and
+        # SQLite's lack of ALTER ADD CONSTRAINT support.
+        op.add_column(
+            table,
+            sa.Column("workspace_id", sa.Integer(), nullable=False, server_default="1"),
+        )
+        op.create_index(ix_name, table, ix_cols)
+
+
+def downgrade() -> None:
+    for table, ix_name, _ix_cols in reversed(_TABLES):
+        op.drop_index(ix_name, table_name=table)
+        with op.batch_alter_table(table) as batch_op:
+            batch_op.drop_column("workspace_id")

--- a/db/models.py
+++ b/db/models.py
@@ -299,6 +299,9 @@ class ChatSession(Base):
     owner_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("users.id"), nullable=True, index=True
     )
+    workspace_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workspaces.id"), nullable=False, server_default="1"
+    )
 
     # Pinned chat (stays at top of list)
     pinned: Mapped[bool] = mapped_column(Boolean, default=False, server_default="0")
@@ -473,6 +476,9 @@ class FAQEntry(Base):
     keywords: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON array
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     hit_count: Mapped[int] = mapped_column(Integer, default=0)
+    workspace_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workspaces.id"), nullable=False, server_default="1"
+    )
     created: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
@@ -507,6 +513,9 @@ class TTSPreset(Base):
     builtin: Mapped[bool] = mapped_column(Boolean, default=False)
     owner_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("users.id"), nullable=True, index=True
+    )
+    workspace_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workspaces.id"), nullable=False, server_default="1"
     )
     created: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated: Mapped[datetime] = mapped_column(
@@ -630,6 +639,9 @@ class BotInstance(Base):
     auto_start: Mapped[bool] = mapped_column(Boolean, default=False)  # Auto-start on app launch
     owner_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("users.id"), nullable=True, index=True
+    )
+    workspace_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workspaces.id"), nullable=False, server_default="1"
     )
 
     # Telegram configuration
@@ -829,6 +841,9 @@ class WidgetInstance(Base):
     owner_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("users.id"), nullable=True, index=True
     )
+    workspace_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workspaces.id"), nullable=False, server_default="1"
+    )
 
     # Appearance
     title: Mapped[str] = mapped_column(String(100), default="AI Ассистент")
@@ -950,6 +965,9 @@ class WhatsAppInstance(Base):
     auto_start: Mapped[bool] = mapped_column(Boolean, default=False)
     owner_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("users.id"), nullable=True, index=True
+    )
+    workspace_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workspaces.id"), nullable=False, server_default="1"
     )
 
     # WhatsApp Cloud API credentials
@@ -1104,6 +1122,9 @@ class CloudLLMProvider(Base):
     is_default: Mapped[bool] = mapped_column(Boolean, default=False)
     owner_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("users.id"), nullable=True, index=True
+    )
+    workspace_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workspaces.id"), nullable=False, server_default="1"
     )
 
     # Extended configuration (JSON)
@@ -2259,6 +2280,9 @@ class AmoCRMConfig(Base):
 
     # Metadata
     account_info: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON
+    workspace_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workspaces.id"), nullable=False, server_default="1"
+    )
     created: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
@@ -2429,6 +2453,9 @@ class KnowledgeCollection(Base):
     base_dir: Mapped[str] = mapped_column(
         String(200), default="wiki-pages", server_default="wiki-pages"
     )
+    workspace_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workspaces.id"), nullable=False, server_default="1"
+    )
     created: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, server_default=text("CURRENT_TIMESTAMP")
     )
@@ -2472,6 +2499,9 @@ class KnowledgeDocument(Base):
     )
     owner_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("users.id"), nullable=True, index=True
+    )
+    workspace_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workspaces.id"), nullable=False, server_default="1"
     )
     created: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, server_default=text("CURRENT_TIMESTAMP")
@@ -3006,6 +3036,9 @@ class ClaudeCodeSession(Base):
     cli_session_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     title: Mapped[str] = mapped_column(String(255), default="New session")
     owner_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), index=True)
+    workspace_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workspaces.id"), nullable=False, server_default="1"
+    )
     status: Mapped[str] = mapped_column(
         String(20), default="active"
     )  # active, completed, error, aborted
@@ -3064,6 +3097,9 @@ class KanbanProject(Base):
     label_mapping: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     sync_enabled: Mapped[bool] = mapped_column(Boolean, default=True, server_default="1")
     last_synced: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    workspace_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workspaces.id"), nullable=False, server_default="1"
+    )
     created: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, server_default=text("CURRENT_TIMESTAMP")
     )
@@ -3137,6 +3173,9 @@ class KanbanTask(Base):
         ForeignKey("kanban_projects.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
+    )
+    workspace_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workspaces.id"), nullable=False, server_default="1"
     )
     github_issue_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     created: Mapped[datetime] = mapped_column(


### PR DESCRIPTION
## Summary

- Adds `workspace_id INTEGER NOT NULL DEFAULT 1` column to 13 resource tables (Alembic migration `0010`)
- Updates all 13 ORM models with `ForeignKey("workspaces.id")` + `server_default="1"`
- Creates composite indexes (`ix_*_ws`) for future workspace-scoped queries

**Tables:** `chat_sessions`, `bot_instances`, `widget_instances`, `whatsapp_instances`, `cloud_llm_providers`, `tts_presets`, `knowledge_documents`, `knowledge_collections`, `claude_code_sessions`, `faq_entries`, `kanban_tasks`, `kanban_projects`, `amocrm_config`

Stage 6b of RBAC (#328). Pure DB migration — no query logic changes (that's 6c).

Closes #364

## Test plan

- [x] `alembic upgrade head` — migration applies cleanly
- [x] NULL check — all 13 tables have 0 NULL workspace_id values
- [x] ORM check — `ChatSession.workspace_id` accessible
- [x] `ruff check` + `ruff format --check` — pass
- [x] `py_compile db/models.py` — pass
- [x] `vue-tsc -b` — frontend unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)