### PR TITLE
feat(rbac): user identities for external contacts (#329)

### DIFF
--- a/alembic/versions/20260223_0007_add_user_identities.py
+++ b/alembic/versions/20260223_0007_add_user_identities.py
@@ -1,0 +1,70 @@
+"""Add user_identities table and make users.username/password_hash nullable.
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-02-23
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Users table: make username/password_hash nullable + add email.
+    # All changes in one batch_alter_table call to minimise table recreations.
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.alter_column("username", nullable=True)
+        batch_op.alter_column("password_hash", nullable=True)
+        batch_op.add_column(sa.Column("email", sa.String(255), nullable=True))
+
+    # email unique index (separate from batch to avoid SQLite constraint issues)
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+    # 2. Create user_identities table.
+    op.create_table(
+        "user_identities",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("provider", sa.String(20), nullable=False),
+        sa.Column("provider_uid", sa.String(255), nullable=False),
+        sa.Column("display_name", sa.String(200), nullable=True),
+        sa.Column("metadata_json", sa.Text(), nullable=True),
+        sa.Column(
+            "created",
+            sa.DateTime(),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("last_seen", sa.DateTime(), nullable=True),
+        sa.UniqueConstraint("provider", "provider_uid", name="uq_identity_provider_uid"),
+    )
+    op.create_index("ix_user_identities_user_id", "user_identities", ["user_id"])
+    op.create_index(
+        "ix_user_identities_provider_uid",
+        "user_identities",
+        ["provider", "provider_uid"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_identities_provider_uid", table_name="user_identities")
+    op.drop_index("ix_user_identities_user_id", table_name="user_identities")
+    op.drop_table("user_identities")
+
+    op.drop_index("ix_users_email", table_name="users")
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_column("email")
+        batch_op.alter_column("username", nullable=False)
+        batch_op.alter_column("password_hash", nullable=False)

--- a/db/integration.py
+++ b/db/integration.py
@@ -34,6 +34,7 @@ from db.repositories import (
     PresetRepository,
     RoleRepository,
     TelegramRepository,
+    UserIdentityRepository,
     UserRepository,
     UserSessionRepository,
     WhatsAppInstanceRepository,
@@ -496,6 +497,23 @@ class AsyncTelegramSessionManager:
             await repo.set_session(
                 user_id, chat_session_id, username, first_name, last_name, bot_id=bot_id
             )
+
+            # Track Telegram contact as user identity
+            try:
+                identity_repo = UserIdentityRepository(session)
+                display = first_name or username or str(user_id)
+                await identity_repo.find_or_create(
+                    provider="telegram",
+                    provider_uid=str(user_id),
+                    display_name=display,
+                    metadata_dict={
+                        "username": username,
+                        "first_name": first_name,
+                        "last_name": last_name,
+                    },
+                )
+            except Exception:
+                logger.debug("Failed to track Telegram identity for %s", user_id, exc_info=True)
 
     async def get_all_sessions(self, bot_id: Optional[str] = None) -> List[dict]:
         """Get all sessions (optionally for specific bot)."""
@@ -1544,6 +1562,52 @@ class AsyncClaudeCodeManager:
             return await repo.delete_session(session_id)
 
 
+# ============== User Identity Manager ==============
+
+
+class AsyncUserIdentityManager:
+    """Async manager for external user identities (Telegram, WhatsApp, Widget)."""
+
+    async def find_or_create(
+        self,
+        provider: str,
+        provider_uid: str,
+        display_name: Optional[str] = None,
+        metadata_dict: Optional[Dict[str, Any]] = None,
+    ) -> dict:
+        """Find existing identity or create contact user + identity."""
+        async with AsyncSessionLocal() as session:
+            repo = UserIdentityRepository(session)
+            return await repo.find_or_create(provider, provider_uid, display_name, metadata_dict)
+
+    async def get_identities_for_user(self, user_id: int) -> List[dict]:
+        """Get all identities linked to a user."""
+        async with AsyncSessionLocal() as session:
+            repo = UserIdentityRepository(session)
+            return await repo.get_identities_for_user(user_id)
+
+    async def link_identity(
+        self,
+        user_id: int,
+        provider: str,
+        provider_uid: str,
+        display_name: Optional[str] = None,
+        metadata_dict: Optional[Dict[str, Any]] = None,
+    ) -> dict:
+        """Link an external identity to an existing user."""
+        async with AsyncSessionLocal() as session:
+            repo = UserIdentityRepository(session)
+            return await repo.link_identity(
+                user_id, provider, provider_uid, display_name, metadata_dict
+            )
+
+    async def update_last_seen(self, provider: str, provider_uid: str) -> bool:
+        """Touch the last_seen timestamp for an identity."""
+        async with AsyncSessionLocal() as session:
+            repo = UserIdentityRepository(session)
+            return await repo.update_last_seen(provider, provider_uid)
+
+
 # ============== Global Instances ==============
 
 # These can be used directly in orchestrator
@@ -1561,6 +1625,7 @@ async_payment_manager = AsyncPaymentManager()
 async_amocrm_manager = AsyncAmoCRMManager()
 async_gsm_manager = AsyncGSMManager()
 async_user_manager = AsyncUserManager()
+async_user_identity_manager = AsyncUserIdentityManager()
 async_knowledge_doc_manager = AsyncKnowledgeDocManager()
 async_knowledge_collection_manager = AsyncKnowledgeCollectionManager()
 async_chat_share_manager = AsyncChatShareManager()

--- a/db/models.py
+++ b/db/models.py
@@ -72,11 +72,14 @@ class User(Base):
     __tablename__ = "users"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    username: Mapped[str] = mapped_column(String(100), unique=True, index=True)
-    password_hash: Mapped[str] = mapped_column(String(255))
+    username: Mapped[Optional[str]] = mapped_column(
+        String(100), unique=True, index=True, nullable=True
+    )
+    password_hash: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     salt: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
-    role: Mapped[str] = mapped_column(String(20), default="user")  # guest, user, admin
+    role: Mapped[str] = mapped_column(String(20), default="user")  # guest, user, admin, contact
     display_name: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True, unique=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, server_default="1", index=True)
     created: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, server_default=text("CURRENT_TIMESTAMP")
@@ -89,12 +92,17 @@ class User(Base):
     )
     last_login: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
+    identities: Mapped[list["UserIdentity"]] = relationship(
+        "UserIdentity", back_populates="user", cascade="all, delete-orphan", lazy="noload"
+    )
+
     def to_dict(self, include_sensitive: bool = False) -> dict:
         result: dict[str, Any] = {
             "id": self.id,
             "username": self.username,
             "role": self.role,
             "display_name": self.display_name,
+            "email": self.email,
             "is_active": self.is_active,
             "created": self.created.isoformat() if self.created else None,
             "updated": self.updated.isoformat() if self.updated else None,
@@ -104,6 +112,39 @@ class User(Base):
             result["password_hash"] = self.password_hash
             result["salt"] = self.salt
         return result
+
+
+class UserIdentity(Base):
+    """External identity linked to a user (Telegram, WhatsApp, Widget)."""
+
+    __tablename__ = "user_identities"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    provider: Mapped[str] = mapped_column(String(20), nullable=False)
+    provider_uid: Mapped[str] = mapped_column(String(255), nullable=False)
+    display_name: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    metadata_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, server_default=text("CURRENT_TIMESTAMP")
+    )
+    last_seen: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    user: Mapped["User"] = relationship("User", back_populates="identities")
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "provider": self.provider,
+            "provider_uid": self.provider_uid,
+            "display_name": self.display_name,
+            "metadata": json.loads(self.metadata_json) if self.metadata_json else None,
+            "created": self.created.isoformat() if self.created else None,
+            "last_seen": self.last_seen.isoformat() if self.last_seen else None,
+        }
 
 
 class UserSession(Base):

--- a/db/repositories/__init__.py
+++ b/db/repositories/__init__.py
@@ -39,6 +39,7 @@ from db.repositories.role import RoleRepository
 from db.repositories.telegram import TelegramRepository
 from db.repositories.usage import UsageLimitsRepository, UsageRepository
 from db.repositories.user import UserRepository
+from db.repositories.user_identity import UserIdentityRepository
 from db.repositories.user_session import UserSessionRepository
 from db.repositories.whatsapp_instance import WhatsAppInstanceRepository
 from db.repositories.widget_instance import WidgetInstanceRepository
@@ -82,6 +83,7 @@ __all__ = [
     "RoleRepository",
     "TelegramRepository",
     "UsageLimitsRepository",
+    "UserIdentityRepository",
     "UserRepository",
     "UserSessionRepository",
     "UsageRepository",

--- a/db/repositories/user.py
+++ b/db/repositories/user.py
@@ -16,7 +16,7 @@ from utils.password import hash_password, needs_rehash, verify_password
 
 logger = logging.getLogger(__name__)
 
-VALID_ROLES = ("guest", "web", "user", "admin")
+VALID_ROLES = ("guest", "web", "user", "admin", "contact")
 
 
 class UserRepository(BaseRepository[User]):
@@ -133,11 +133,32 @@ class UserRepository(BaseRepository[User]):
         await self.session.commit()
         return True
 
-    async def list_users(self, include_inactive: bool = False) -> List[dict]:
-        """List all users."""
+    async def create_contact_user(
+        self, display_name: Optional[str] = None, email: Optional[str] = None
+    ) -> dict:
+        """Create a contact-only user (no credentials, cannot log in)."""
+        user = User(
+            username=None,
+            password_hash=None,
+            role="contact",
+            display_name=display_name,
+            email=email,
+            is_active=True,
+        )
+        self.session.add(user)
+        await self.session.commit()
+        await self.session.refresh(user)
+        return user.to_dict()
+
+    async def list_users(
+        self, include_inactive: bool = False, include_contacts: bool = False
+    ) -> List[dict]:
+        """List users. By default hides inactive and contact-only users."""
         query = select(User).order_by(User.created)
         if not include_inactive:
             query = query.where(User.is_active == True)
+        if not include_contacts:
+            query = query.where(User.username.isnot(None))
 
         result = await self.session.execute(query)
         users = result.scalars().all()

--- a/db/repositories/user_identity.py
+++ b/db/repositories/user_identity.py
@@ -1,0 +1,121 @@
+"""Repository for user identity CRUD (Telegram, WhatsApp, Widget contacts)."""
+
+import json
+from datetime import datetime
+from typing import Any, List, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import User, UserIdentity
+from db.repositories.base import BaseRepository
+
+
+class UserIdentityRepository(BaseRepository[UserIdentity]):
+    """Repository for external user identities."""
+
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, UserIdentity)
+
+    async def get_by_provider_uid(self, provider: str, provider_uid: str) -> Optional[UserIdentity]:
+        """Look up an identity by provider + uid."""
+        result = await self.session.execute(
+            select(UserIdentity).where(
+                UserIdentity.provider == provider,
+                UserIdentity.provider_uid == provider_uid,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def find_or_create(
+        self,
+        provider: str,
+        provider_uid: str,
+        display_name: Optional[str] = None,
+        metadata_dict: Optional[dict[str, Any]] = None,
+    ) -> dict:
+        """Find existing identity or create a new contact user + identity.
+
+        Returns the linked user as a dict.
+        """
+        identity = await self.get_by_provider_uid(provider, provider_uid)
+
+        if identity:
+            # Update display_name / metadata if provided
+            changed = False
+            if display_name and display_name != identity.display_name:
+                identity.display_name = display_name
+                changed = True
+            if metadata_dict:
+                identity.metadata_json = json.dumps(metadata_dict, ensure_ascii=False)
+                changed = True
+            identity.last_seen = datetime.utcnow()
+            if changed:
+                await self.session.commit()
+            else:
+                await self.session.commit()
+
+            user = await self.session.get(User, identity.user_id)
+            return user.to_dict() if user else {}
+
+        # Create contact user (no credentials)
+        user = User(
+            username=None,
+            password_hash=None,
+            role="contact",
+            display_name=display_name,
+            is_active=True,
+        )
+        self.session.add(user)
+        await self.session.flush()  # get user.id
+
+        identity = UserIdentity(
+            user_id=user.id,
+            provider=provider,
+            provider_uid=provider_uid,
+            display_name=display_name,
+            metadata_json=json.dumps(metadata_dict, ensure_ascii=False) if metadata_dict else None,
+            last_seen=datetime.utcnow(),
+        )
+        self.session.add(identity)
+        await self.session.commit()
+        await self.session.refresh(user)
+        return user.to_dict()
+
+    async def get_identities_for_user(self, user_id: int) -> List[dict]:
+        """Get all identities for a user."""
+        result = await self.session.execute(
+            select(UserIdentity).where(UserIdentity.user_id == user_id)
+        )
+        return [i.to_dict() for i in result.scalars().all()]
+
+    async def link_identity(
+        self,
+        user_id: int,
+        provider: str,
+        provider_uid: str,
+        display_name: Optional[str] = None,
+        metadata_dict: Optional[dict[str, Any]] = None,
+    ) -> dict:
+        """Link an external identity to an existing user."""
+        identity = UserIdentity(
+            user_id=user_id,
+            provider=provider,
+            provider_uid=provider_uid,
+            display_name=display_name,
+            metadata_json=json.dumps(metadata_dict, ensure_ascii=False) if metadata_dict else None,
+            last_seen=datetime.utcnow(),
+        )
+        self.session.add(identity)
+        await self.session.commit()
+        await self.session.refresh(identity)
+        return identity.to_dict()
+
+    async def update_last_seen(self, provider: str, provider_uid: str) -> bool:
+        """Touch the last_seen timestamp for an identity."""
+        identity = await self.get_by_provider_uid(provider, provider_uid)
+        if not identity:
+            return False
+        identity.last_seen = datetime.utcnow()
+        await self.session.commit()
+        return True

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -3673,6 +3673,21 @@ async def widget_create_session(request: Request):
 
     system_prompt = instance_data.get("system_prompt")
     session = await async_chat_manager.create_session(None, system_prompt, "widget", instance_id)
+
+    # Track widget visitor as user identity
+    try:
+        from db.integration import async_user_identity_manager
+
+        await async_user_identity_manager.find_or_create(
+            provider="widget",
+            provider_uid=session["id"],
+            display_name=f"Widget visitor ({instance_id})",
+        )
+    except Exception:
+        logger.debug(
+            "Failed to track widget identity for session %s", session.get("id"), exc_info=True
+        )
+
     return {"session": session}
 
 

--- a/whatsapp_bot/handlers/messages.py
+++ b/whatsapp_bot/handlers/messages.py
@@ -36,6 +36,18 @@ async def handle_text_message(phone: str, text: str, message_id: str) -> None:
     lock = _get_lock(phone)
 
     async with lock:
+        # Track WhatsApp contact as user identity
+        try:
+            from db.integration import async_user_identity_manager
+
+            await async_user_identity_manager.find_or_create(
+                provider="whatsapp",
+                provider_uid=phone,
+                display_name=phone,
+            )
+        except Exception:
+            logger.debug("Failed to track WhatsApp identity for %s", phone, exc_info=True)
+
         await _process_message(phone, text, message_id)
 
 


### PR DESCRIPTION
## Summary
- **Migration 0011**: makes `users.username`/`password_hash` nullable, adds `email` column, creates `user_identities` table with UNIQUE(provider, provider_uid)
- **UserIdentity model** + `UserIdentityRepository` with `find_or_create` pattern (atomic lookup-or-create for contact user + identity)
- **AsyncUserIdentityManager** in `db/integration.py` — wraps repository for use from orchestrator/handlers
- **Telegram**: identity tracked in `AsyncTelegramSessionManager.set_session()` (provider=telegram, uid=chat_id)
- **WhatsApp**: identity tracked in `handle_text_message()` (provider=whatsapp, uid=phone)
- **Widget**: identity tracked in `widget_create_session()` (provider=widget, uid=session_id)
- Contact-only users: `username=NULL`, `password_hash=NULL`, `role=contact` — cannot log in
- Zero impact on auth flow, JWT, audit logs, admin panel, frontend

## Test plan
- [x] Migration applied: `user_identities` table created, users columns nullable
- [x] Existing credentialed users unaffected
- [x] ORM models import cleanly
- [x] Repository + integration manager import cleanly
- [x] `ruff check` + `ruff format` pass on all changed files
- [x] Frontend `vue-tsc` + `npm run build` pass
- [x] Health check: `curl localhost:8002/health` → healthy
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)