### PR TITLE
fix: register bot internal sessions in DB for RBAC validation

### DIFF
--- a/multi_bot_manager.py
+++ b/multi_bot_manager.py
@@ -117,13 +117,18 @@ class MultiBotManager:
                 env["ORCHESTRATOR_URL"] = "http://127.0.0.1:8002"
 
             # Generate internal JWT for subprocess to authenticate with orchestrator API
+            # Must use create_session() to register in user_sessions table (RBAC validation)
             try:
-                from auth_manager import create_access_token
+                from auth_manager import create_session
 
-                token, _, _ = create_access_token(
-                    username="__internal_bot__", role="admin", user_id=0
+                login_resp = await create_session(
+                    username="__internal_bot__",
+                    role="admin",
+                    user_id=0,
+                    ip=None,
+                    user_agent="MultiBotManager",
                 )
-                env["BOT_INTERNAL_TOKEN"] = token
+                env["BOT_INTERNAL_TOKEN"] = login_resp.access_token
             except Exception as e:
                 logger.warning(f"Could not generate internal token: {e}")
 

--- a/whatsapp_manager.py
+++ b/whatsapp_manager.py
@@ -112,13 +112,18 @@ class WhatsAppManager:
             env["PYTHONUNBUFFERED"] = "1"
 
             # Generate internal JWT for subprocess to authenticate with orchestrator API
+            # Must use create_session() to register in user_sessions table (RBAC validation)
             try:
-                from auth_manager import create_access_token
+                from auth_manager import create_session
 
-                token, _, _ = create_access_token(
-                    username="__internal_wa_bot__", role="admin", user_id=0
+                login_resp = await create_session(
+                    username="__internal_wa_bot__",
+                    role="admin",
+                    user_id=0,
+                    ip=None,
+                    user_agent="WhatsAppManager",
                 )
-                env["WA_INTERNAL_TOKEN"] = token
+                env["WA_INTERNAL_TOKEN"] = login_resp.access_token
             except Exception as e:
                 logger.warning(f"Could not generate internal token: {e}")
 


### PR DESCRIPTION
## Summary
- Bot subprocesses (Telegram, WhatsApp) used `create_access_token()` which generates JWT without registering in `user_sessions` table
- After RBAC migration, `_validate_session()` requires session records in DB — unregistered tokens get 401 Unauthorized
- Changed both `multi_bot_manager.py` and `whatsapp_manager.py` to use `create_session()` which registers the session properly

## Test plan
- [ ] Deploy to server and restart bots
- [ ] Verify Telegram bots respond to messages (no 401 in logs)
- [ ] Verify WhatsApp bot authentication works
- [ ] Check that bot internal sessions appear in `user_sessions` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)