### PR TITLE
fix: grant full permissions to internal bot users

### DIFF
--- a/auth_manager.py
+++ b/auth_manager.py
@@ -438,6 +438,10 @@ def user_has_level(user: User, module: str, min_level: str) -> bool:
 
 async def get_user_permissions(user: User) -> Dict[str, str]:
     """Get permissions dict for user via workspace_members lookup. Uses cache."""
+    # Internal bot users (user_id=0) with admin role get full manage access
+    if user.id == 0 and user.role == "admin":
+        return dict.fromkeys(("chat", "bots", "widgets", "llm", "tts", "system"), "manage")
+
     role_name = _member_role_cache.get(user.id, user.workspace_id)
     if role_name is None:
         from db.integration import async_workspace_manager


### PR DESCRIPTION
## Summary
- Internal bot tokens (`user_id=0`, role `admin`) had no `workspace_members` record
- `get_user_permissions()` fell back to `viewer` role → only `view` level
- Bots got 403 Forbidden on `POST /admin/chat/sessions` which requires `chat:edit`
- Added early return in `get_user_permissions()` granting full `manage` access for `user_id=0` + `admin` role

## Test plan
- [ ] Deploy to server, restart bots
- [ ] Verify Telegram bots respond (no 403 in logs)
- [ ] Verify admin panel login still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)