### PR TITLE
fix: frontend auth redirect loop on invalid/expired tokens

### DIFF
--- a/admin/src/router.ts
+++ b/admin/src/router.ts
@@ -186,9 +186,9 @@ router.beforeEach((to, from, next) => {
     return
   }
 
-  // Module + level check
+  // Module + level check (skip if permissions not loaded yet — avoid redirect loops)
   const mod = to.meta.module as string | undefined
-  if (mod) {
+  if (mod && Object.keys(authStore.permissions).length > 0) {
     const minLvl = (to.meta.minLevel as string) || 'view'
     if ((LVL[authStore.permissions[mod]] ?? 0) < (LVL[minLvl] ?? 1)) {
       const landing = authStore.hasModule('dashboard') && !authStore.isCloudMode ? 'dashboard' : 'chat'

--- a/admin/src/stores/auth.ts
+++ b/admin/src/stores/auth.ts
@@ -60,7 +60,12 @@ export const useAuthStore = defineStore('auth', () => {
   async function fetchPermissions() {
     try {
       const resp = await fetch('/admin/auth/permissions', { headers: getAuthHeaders() })
-      if (resp.ok) permissions.value = await resp.json()
+      if (resp.ok) {
+        permissions.value = await resp.json()
+      } else if (resp.status === 401) {
+        // Token invalid/expired/session revoked — force logout
+        logout()
+      }
     } catch { /* default empty */ }
   }
 


### PR DESCRIPTION
## Summary

- **auth.ts**: Force `logout()` when `/admin/auth/permissions` returns 401 (invalid/expired/revoked token). Previously, old tokens without `jti` stayed in localStorage, keeping `isAuthenticated=true` while all API calls failed silently.
- **router.ts**: Skip module permission check when `permissions` object is empty (not loaded yet). Prevents infinite redirect loop when permissions haven't been fetched.

Fixes login hanging that occurred after PR #374 introduced session-based auth — old tokens in localStorage triggered the redirect loop.

## Test plan

- [ ] Clear localStorage, login as admin — should work immediately
- [ ] Inject an invalid token into localStorage, reload — should redirect to login page (not hang)
- [ ] Login as restricted user — should see only permitted routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)