### PR TITLE
feat(rbac): workspace_context helper + BaseRepository workspace filter (#376)

### DIFF
--- a/auth_manager.py
+++ b/auth_manager.py
@@ -436,6 +436,22 @@ def user_has_level(user: User, module: str, min_level: str) -> bool:
     return level_gte(user.permissions.get(module, ""), min_level)
 
 
+def workspace_context(user: User, module: str) -> tuple[Optional[int], int]:
+    """Extract (owner_id, workspace_id) from user for repository calls.
+
+    Returns:
+        (owner_id, workspace_id) — owner_id is None for managers (manage-level),
+        workspace_id is always set from user's JWT.
+
+    Usage in routers::
+
+        owner_id, workspace_id = workspace_context(user, "chat")
+        result = await manager.list(..., owner_id=owner_id, workspace_id=workspace_id)
+    """
+    owner_id = None if user_has_level(user, module, "manage") else user.id
+    return owner_id, user.workspace_id
+
+
 async def get_user_permissions(user: User) -> Dict[str, str]:
     """Get permissions dict for user via workspace_members lookup. Uses cache."""
     # Internal bot users (user_id=0) with admin role get full manage access

--- a/db/repositories/base.py
+++ b/db/repositories/base.py
@@ -19,6 +19,15 @@ class BaseRepository(Generic[T]):
         self.session = session
         self.model = model
 
+    def _apply_workspace_filter(self, query, workspace_id: Optional[int]):
+        """Add WHERE workspace_id = :workspace_id if model supports it.
+
+        Pass workspace_id=None to skip filtering (backward compatible).
+        """
+        if workspace_id is not None and hasattr(self.model, "workspace_id"):
+            query = query.where(self.model.workspace_id == workspace_id)
+        return query
+
     async def get_by_id(self, id_value: Any) -> Optional[T]:
         """Get entity by primary key."""
         result: Optional[T] = await self.session.get(self.model, id_value)


### PR DESCRIPTION
## Summary

Инфраструктура для workspace-aware запросов (RBAC 6c-0, #376).

- **`BaseRepository._apply_workspace_filter(query, workspace_id)`** — generic WHERE-фильтр по `workspace_id`. Пропускает фильтрацию при `workspace_id=None` (backward compatible). Проверяет наличие атрибута `workspace_id` на модели.
- **`workspace_context(user, module)`** — хелпер для роутеров, возвращает `(owner_id, workspace_id)`. Заменяет повторяющийся паттерн `owner_id = None if user_has_level(...) else user.id` + ручное извлечение `workspace_id`.

Новый код пока **не вызывается** — это фундамент для последующих этапов 6c-1..6c-5.

## Closes

Closes #376

## Test plan

- [ ] `ruff check . && ruff format --check .` — lint проходит
- [ ] `curl http://localhost:8002/health` — сервер стартует без ошибок
- [ ] Существующая функциональность не затронута (новый код не вызывается)

🤖 Generated with [Claude Code](https://claude.com/claude-code)