### PR TITLE
docs: update RBAC and workspace documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,7 @@ Frontend: `auth.ts` store fetches deployment mode via `GET /admin/deployment-mod
 
 **ServiceContainer (`app/dependencies.py`)**: Singleton holding references to all initialized services (TTS, LLM, STT, Wiki RAG). Routers get services via FastAPI `Depends`. Populated during app startup in `orchestrator.py`.
 
-**Database layer** (`db/`): Async SQLAlchemy with aiosqlite. `db/database.py` creates the engine and `AsyncSessionLocal` factory. `db/integration.py` provides backward-compatible manager classes (e.g., `AsyncChatManager`, `AsyncFAQManager`) that wrap repository calls — these are used as module-level singletons imported by `orchestrator.py` and routers. Repositories in `db/repositories/` inherit from `BaseRepository` with generic CRUD.
+**Database layer** (`db/`): Async SQLAlchemy with aiosqlite. `db/database.py` creates the engine and `AsyncSessionLocal` factory. `db/integration.py` provides backward-compatible manager classes (e.g., `AsyncChatManager`, `AsyncFAQManager`) that wrap repository calls — these are used as module-level singletons imported by `orchestrator.py` and routers. Repositories in `db/repositories/` inherit from `BaseRepository` with generic CRUD and `_apply_workspace_filter(query, workspace_id)` for workspace-aware queries.
 
 **Telegram bots**: Run as subprocesses managed by `multi_bot_manager.py`. Each bot instance has independent config (LLM backend, TTS, prompts, system prompt). Bots with `auto_start=true` restart on app startup. Two Telegram frameworks: `python-telegram-bot` (legacy) and `aiogram` (new bots). In multi-instance mode, `BOT_INSTANCE_ID`, `BOT_INTERNAL_TOKEN`, and `ORCHESTRATOR_URL` env vars are passed to the subprocess. Config loading: manager pre-fetches config from DB and writes it to `/tmp/bot_config_{id}.json` (`BOT_CONFIG_FILE` env var); bot tries this file first (`load_config_from_file()`), then falls back to orchestrator API with retry logic (5 attempts, exponential backoff). `LLMRouter` in `telegram_bot/services/llm_router.py` routes LLM requests through the orchestrator chat API, auto-creates orchestrator DB sessions (mapping bot session IDs to real DB sessions via `_ensure_session()`), and uses the bot instance's `llm_backend` setting. `stream_renderer.py` handles both plain string chunks and OpenAI-format dicts.
 
@@ -290,8 +290,9 @@ Frontend: `auth.ts` store fetches deployment mode via `GET /admin/deployment-mod
 **RBAC auth guards** (in `auth_manager.py`):
 - `Depends(require_permission(module, level))` — checks module permission (all routers)
 - `user_has_level(user, module, level)` — inline check within endpoint (owner/manage logic)
+- `workspace_context(user, module)` — returns `(owner_id, workspace_id)` tuple for repository calls; `owner_id` is `None` for manage-level users, `workspace_id` always from JWT
 - `Depends(get_current_user)` — auth only, no RBAC check (self-service: auth.py)
-- Data isolation: `owner_id = None if user_has_level(user, mod, "manage") else user.id`
+- Data isolation: `owner_id, workspace_id = workspace_context(user, module)` → pass both to repository/manager
 
 **Workspaces + RBAC roles:** Permission resolution goes through `workspace_members` table (not legacy `users.role`). Default workspace (id=1) is seeded at startup; all users are auto-mapped using legacy role → RBAC role:
 - `admin` → RBAC `admin` — all 16 modules `manage`, sees all resources
@@ -342,7 +343,7 @@ RATE_LIMIT_DEFAULT=60/minute        # Default rate limit for all endpoints
 - **FastAPI Depends pattern** — `B008` (function-call-in-default-argument) is disabled for this reason
 - **Optional imports** — Services like vLLM and OpenVoice use try/except at module level with `*_AVAILABLE` flags
 - **SQLAlchemy mapped_column style** — Models use `Mapped[T]` with `mapped_column()` (declarative 2.0)
-- **Repository pattern** — `BaseRepository(Generic[T])` provides get_by_id, get_all, create, update, delete. Domain repos extend with custom queries.
+- **Repository pattern** — `BaseRepository(Generic[T])` provides get_by_id, get_all, create, update, delete, and `_apply_workspace_filter(query, workspace_id)` for multi-tenant filtering. Domain repos extend with custom queries and should call `_apply_workspace_filter()` in list/get methods.
 - **Admin panel** — See **Frontend Architecture** section below for full details (routing, stores, API layer, demo mode, components).
 - **mypy strict scope** — Only `db/`, `auth_manager.py`, `service_manager.py` require typed defs; other modules are relaxed. mypy is soft in CI (`|| true`).
 - **Pre-commit hooks** — ruff lint+format, mypy (core only), eslint, hadolint (Docker), plus standard checks (trailing whitespace, large files ≤1MB, private key detection, merge conflicts). See `.pre-commit-config.yaml`.

--- a/wiki-pages/API-Reference.md
+++ b/wiki-pages/API-Reference.md
@@ -345,33 +345,47 @@ data: [DONE]\n\n
 
 ## RBAC (контроль доступа)
 
-Система использует 3 уровня защиты эндпоинтов:
+Система использует permission-based RBAC с 16 модулями и 3 уровнями доступа.
 
-| Dependency | Роли | Применение |
-|------------|------|------------|
-| `get_current_user` | Любой авторизованный | Read endpoints |
-| `require_not_guest` | user, web, admin | Write endpoints |
-| `require_admin` | admin | Sensitive operations |
+### Защита эндпоинтов
 
-### Роли пользователей
+| Dependency | Описание | Применение |
+|------------|----------|------------|
+| `require_permission(module, level)` | Проверяет permission модуля | Все бизнес-эндпоинты |
+| `get_current_user` | Только аутентификация | Self-service (auth.py) |
 
-| Роль | Права | Ограничения |
-|------|-------|-------------|
-| **admin** | Полный доступ | Видит все ресурсы всех пользователей |
-| **user** | Read + Write своих ресурсов | Полный доступ к админ-панели |
-| **web** | Как user, но упрощённый UI | Скрыты: Dashboard, Services, vLLM, Models |
-| **guest** | Read-only (demo) | Только просмотр, без изменений |
+Уровни: `view` (чтение) → `edit` (изменение) → `manage` (полный доступ).
+
+### Роли (динамические, в БД)
+
+| Роль | Описание | Модули |
+|------|----------|--------|
+| **admin** | Полный доступ | Все 16 модулей — `manage` |
+| **operator** | Работа с ресурсами | 8 модулей `edit` + 3 `view` |
+| **viewer** | Только просмотр | 7 модулей `view` |
+
+Legacy роли (`admin`, `user`, `web`, `guest`) маппятся на RBAC-роли через `workspace_members` при создании пользователя.
 
 ### Изоляция данных
 
-Для пользователей с ролью `user` и `web` применяется фильтрация по `owner_id`:
+Двухуровневая фильтрация: **owner_id** (кто создал) + **workspace_id** (какому workspace принадлежит):
 
 ```python
-owner_id = None if user.role == "admin" else user.id
-# Пользователь видит только свои ресурсы
+from auth_manager import workspace_context
+
+owner_id, workspace_id = workspace_context(user, "chat")
+# owner_id = None для manage-level (видит все ресурсы workspace)
+# workspace_id = всегда из JWT (user.workspace_id)
+sessions = await manager.list_sessions(owner_id=owner_id, workspace_id=workspace_id)
 ```
 
-Ресурсы с `owner_id`: ChatSession, BotInstance, WidgetInstance, CloudLLMProvider, TTSPreset
+Ресурсы с `owner_id` + `workspace_id`: ChatSession, BotInstance, WidgetInstance, WhatsAppInstance, CloudLLMProvider, TTSPreset, KnowledgeDocument, ClaudeCodeSession и др. (13 таблиц).
+
+### Workspaces
+
+Workspace — контейнер всех ресурсов. Default workspace (id=1) создаётся автоматически. JWT содержит `workspace_id`. Репозитории фильтруют через `BaseRepository._apply_workspace_filter()`.
+
+> **Статус:** workspace_id колонки добавлены на 13 таблиц, инфраструктура фильтрации готова. Workspace-aware запросы внедряются поэтапно (#365).
 
 ## Формат ошибок
 

--- a/wiki-pages/Settings.md
+++ b/wiki-pages/Settings.md
@@ -13,7 +13,7 @@
 | **ID** | Числовой идентификатор | Нет |
 | **Имя пользователя** | Логин | Нет |
 | **Отображаемое имя** | Display name | Да |
-| **Роль** | admin / user / web / guest | Нет (только через CLI) |
+| **Роль** | admin / user / web / guest (RBAC) | Нет (только через CLI) |
 | **Дата создания** | Когда создан аккаунт | Нет |
 | **Последний вход** | Время последнего логина | Нет |
 
@@ -134,7 +134,20 @@ python scripts/manage_users.py enable <user>                 # Активиро�
 python scripts/manage_users.py delete <user>                 # Удалить
 ```
 
-Роли: `admin`, `user`, `web`, `guest`. Подробнее о ролях: [[API-Reference]].
+### Роли и RBAC
+
+Legacy роли при создании пользователя автоматически маппятся на RBAC-роли через `workspace_members`:
+
+| Legacy роль | RBAC роль | Доступ |
+|-------------|-----------|--------|
+| `admin` | **admin** | Все 16 модулей — `manage` |
+| `user` | **operator** | 8 модулей `edit` + 3 `view` |
+| `web` | **operator** | Аналогично `user` |
+| `guest` | **viewer** | 7 модулей `view` (только чтение) |
+
+Уровни доступа: `view` (чтение) → `edit` (изменение) → `manage` (полный доступ).
+
+Подробнее о RBAC: [[API-Reference]].
 
 ## API
 


### PR DESCRIPTION
## Summary
- Updated CLAUDE.md with `_apply_workspace_filter()` and `workspace_context()` documentation
- Rewrote RBAC section in API-Reference wiki to reflect new permission-based system (`require_permission`, data isolation, workspaces)
- Updated Settings wiki with RBAC role mapping table (legacy roles → RBAC roles)

Follows merge of PR #383 (feat/rbac-6c-0-workspace-helpers).

## Test plan
- [ ] Verify wiki pages render correctly on GitHub
- [ ] Verify CLAUDE.md changes are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)