### PR TITLE
feat(rbac): workspace_id filtering for Channels (#378)

### DIFF
--- a/app/routers/telegram.py
+++ b/app/routers/telegram.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from auth_manager import User, require_permission, user_has_level
+from auth_manager import User, require_permission, workspace_context
 from db.integration import (
     async_audit_logger,
     async_bot_instance_manager,
@@ -361,9 +361,9 @@ async def admin_list_bot_instances(
     enabled_only: bool = False, user: User = Depends(require_permission("channels", "view"))
 ):
     """List all Telegram bot instances"""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
+    owner_id, ws_id = workspace_context(user, "channels")
     instances = await async_bot_instance_manager.list_instances(
-        enabled_only=enabled_only, owner_id=owner_id
+        enabled_only=enabled_only, owner_id=owner_id, workspace_id=ws_id
     )
 
     # Add running status from multi_bot_manager
@@ -379,10 +379,11 @@ async def admin_create_bot_instance(
     request: BotInstanceCreateRequest, user: User = Depends(require_permission("channels", "edit"))
 ):
     """Create a new Telegram bot instance"""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
+    owner_id, ws_id = workspace_context(user, "channels")
     # Convert request to dict, removing None values
     kwargs = {k: v for k, v in request.model_dump().items() if v is not None}
     kwargs["owner_id"] = owner_id
+    kwargs["workspace_id"] = ws_id
 
     instance = await async_bot_instance_manager.create_instance(**kwargs)
 
@@ -405,11 +406,13 @@ async def admin_get_bot_instance(
     user: User = Depends(require_permission("channels", "view")),
 ):
     """Get a specific bot instance"""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
+    owner_id, ws_id = workspace_context(user, "channels")
     if include_token:
         instance = await async_bot_instance_manager.get_instance_with_token(instance_id)
     else:
-        instance = await async_bot_instance_manager.get_instance(instance_id, owner_id=owner_id)
+        instance = await async_bot_instance_manager.get_instance(
+            instance_id, owner_id=owner_id, workspace_id=ws_id
+        )
 
     if not instance:
         raise HTTPException(status_code=404, detail="Bot instance not found")
@@ -430,8 +433,10 @@ async def admin_update_bot_instance(
 ):
     """Update a bot instance"""
     # Check if exists and verify ownership
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
-    existing = await async_bot_instance_manager.get_instance(instance_id, owner_id=owner_id)
+    owner_id, ws_id = workspace_context(user, "channels")
+    existing = await async_bot_instance_manager.get_instance(
+        instance_id, owner_id=owner_id, workspace_id=ws_id
+    )
     if not existing:
         raise HTTPException(status_code=404, detail="Bot instance not found")
 
@@ -457,11 +462,13 @@ async def admin_delete_bot_instance(
     instance_id: str, user: User = Depends(require_permission("channels", "edit"))
 ):
     """Delete a bot instance"""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
+    owner_id, ws_id = workspace_context(user, "channels")
     # Stop bot if running
     await multi_bot_manager.stop_bot(instance_id)
 
-    success = await async_bot_instance_manager.delete_instance(instance_id, owner_id=owner_id)
+    success = await async_bot_instance_manager.delete_instance(
+        instance_id, owner_id=owner_id, workspace_id=ws_id
+    )
     if not success:
         raise HTTPException(status_code=404, detail="Bot instance not found")
 
@@ -478,10 +485,15 @@ async def admin_start_bot_instance(
     instance_id: str, user: User = Depends(require_permission("channels", "edit"))
 ):
     """Start a specific bot instance and enable auto-start"""
-    # Check if instance exists
-    instance = await async_bot_instance_manager.get_instance_with_token(instance_id)
+    # Workspace gate-check
+    instance = await async_bot_instance_manager.get_instance(
+        instance_id, workspace_id=user.workspace_id
+    )
     if not instance:
         raise HTTPException(status_code=404, detail="Bot instance not found")
+
+    # Re-fetch with token for start logic
+    instance = await async_bot_instance_manager.get_instance_with_token(instance_id)
 
     if not instance.get("bot_token"):
         raise HTTPException(status_code=400, detail="Bot token not configured")
@@ -503,6 +515,13 @@ async def admin_stop_bot_instance(
     instance_id: str, user: User = Depends(require_permission("channels", "edit"))
 ):
     """Stop a specific bot instance and disable auto-start"""
+    # Workspace gate-check
+    instance = await async_bot_instance_manager.get_instance(
+        instance_id, workspace_id=user.workspace_id
+    )
+    if not instance:
+        raise HTTPException(status_code=404, detail="Bot instance not found")
+
     result = await multi_bot_manager.stop_bot(instance_id)
 
     # Save auto_start=False so bot doesn't restart on app launch
@@ -517,6 +536,13 @@ async def admin_restart_bot_instance(
     instance_id: str, user: User = Depends(require_permission("channels", "edit"))
 ):
     """Restart a specific bot instance"""
+    # Workspace gate-check
+    instance = await async_bot_instance_manager.get_instance(
+        instance_id, workspace_id=user.workspace_id
+    )
+    if not instance:
+        raise HTTPException(status_code=404, detail="Bot instance not found")
+
     result = await multi_bot_manager.restart_bot(instance_id)
     return result
 
@@ -526,8 +552,10 @@ async def admin_get_bot_instance_status(
     instance_id: str, user: User = Depends(require_permission("channels", "view"))
 ):
     """Get status of a specific bot instance"""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
-    instance = await async_bot_instance_manager.get_instance(instance_id, owner_id=owner_id)
+    owner_id, ws_id = workspace_context(user, "channels")
+    instance = await async_bot_instance_manager.get_instance(
+        instance_id, owner_id=owner_id, workspace_id=ws_id
+    )
     if not instance:
         raise HTTPException(status_code=404, detail="Bot instance not found")
 
@@ -551,6 +579,13 @@ async def admin_get_bot_instance_sessions(
     instance_id: str, user: User = Depends(require_permission("channels", "view"))
 ):
     """Get sessions for a specific bot instance"""
+    # Workspace gate-check
+    instance = await async_bot_instance_manager.get_instance(
+        instance_id, workspace_id=user.workspace_id
+    )
+    if not instance:
+        raise HTTPException(status_code=404, detail="Bot instance not found")
+
     sessions = await async_telegram_manager.get_sessions_for_bot(instance_id)
     return {"sessions": sessions}
 
@@ -581,6 +616,13 @@ async def admin_clear_bot_instance_sessions(
     instance_id: str, user: User = Depends(require_permission("channels", "edit"))
 ):
     """Clear all sessions for a specific bot instance"""
+    # Workspace gate-check
+    instance = await async_bot_instance_manager.get_instance(
+        instance_id, workspace_id=user.workspace_id
+    )
+    if not instance:
+        raise HTTPException(status_code=404, detail="Bot instance not found")
+
     count = await async_telegram_manager.clear_sessions_for_bot(instance_id)
     return {"status": "ok", "message": f"Cleared {count} sessions"}
 
@@ -590,6 +632,13 @@ async def admin_get_bot_instance_logs(
     instance_id: str, lines: int = 100, user: User = Depends(require_permission("channels", "view"))
 ):
     """Get recent logs for a bot instance"""
+    # Workspace gate-check
+    instance = await async_bot_instance_manager.get_instance(
+        instance_id, workspace_id=user.workspace_id
+    )
+    if not instance:
+        raise HTTPException(status_code=404, detail="Bot instance not found")
+
     logs = await multi_bot_manager.get_recent_logs(instance_id, lines)
     return {"logs": logs}
 

--- a/app/routers/whatsapp.py
+++ b/app/routers/whatsapp.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from auth_manager import User, require_permission, user_has_level
+from auth_manager import User, require_permission, workspace_context
 from db.integration import async_audit_logger, async_whatsapp_instance_manager
 from whatsapp_manager import whatsapp_manager
 
@@ -88,9 +88,9 @@ async def list_whatsapp_instances(
     enabled_only: bool = False, user: User = Depends(require_permission("channels", "view"))
 ):
     """List all WhatsApp bot instances."""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
+    owner_id, ws_id = workspace_context(user, "channels")
     instances = await async_whatsapp_instance_manager.list_instances(
-        enabled_only=enabled_only, owner_id=owner_id
+        enabled_only=enabled_only, owner_id=owner_id, workspace_id=ws_id
     )
 
     # Add running status from whatsapp_manager
@@ -107,10 +107,11 @@ async def create_whatsapp_instance(
     user: User = Depends(require_permission("channels", "edit")),
 ):
     """Create a new WhatsApp bot instance."""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
+    owner_id, ws_id = workspace_context(user, "channels")
     # Convert request to dict, removing None values
     kwargs = {k: v for k, v in request.model_dump().items() if v is not None}
     kwargs["owner_id"] = owner_id
+    kwargs["workspace_id"] = ws_id
 
     instance = await async_whatsapp_instance_manager.create_instance(**kwargs)
 
@@ -133,12 +134,12 @@ async def get_whatsapp_instance(
     user: User = Depends(require_permission("channels", "view")),
 ):
     """Get a specific WhatsApp bot instance."""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
+    owner_id, ws_id = workspace_context(user, "channels")
     if include_token:
         instance = await async_whatsapp_instance_manager.get_instance_with_token(instance_id)
     else:
         instance = await async_whatsapp_instance_manager.get_instance(
-            instance_id, owner_id=owner_id
+            instance_id, owner_id=owner_id, workspace_id=ws_id
         )
 
     if not instance:
@@ -160,8 +161,10 @@ async def update_whatsapp_instance(
 ):
     """Update a WhatsApp bot instance."""
     # Check if exists and verify ownership
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
-    existing = await async_whatsapp_instance_manager.get_instance(instance_id, owner_id=owner_id)
+    owner_id, ws_id = workspace_context(user, "channels")
+    existing = await async_whatsapp_instance_manager.get_instance(
+        instance_id, owner_id=owner_id, workspace_id=ws_id
+    )
     if not existing:
         raise HTTPException(status_code=404, detail="WhatsApp instance not found")
 
@@ -187,11 +190,13 @@ async def delete_whatsapp_instance(
     instance_id: str, user: User = Depends(require_permission("channels", "edit"))
 ):
     """Delete a WhatsApp bot instance."""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
+    owner_id, ws_id = workspace_context(user, "channels")
     # Stop bot if running
     await whatsapp_manager.stop_bot(instance_id)
 
-    success = await async_whatsapp_instance_manager.delete_instance(instance_id, owner_id=owner_id)
+    success = await async_whatsapp_instance_manager.delete_instance(
+        instance_id, owner_id=owner_id, workspace_id=ws_id
+    )
     if not success:
         raise HTTPException(status_code=404, detail="WhatsApp instance not found")
 
@@ -214,10 +219,15 @@ async def start_whatsapp_instance(
     instance_id: str, user: User = Depends(require_permission("channels", "edit"))
 ):
     """Start a specific WhatsApp bot instance and enable auto-start."""
-    # Check if instance exists
-    instance = await async_whatsapp_instance_manager.get_instance_with_token(instance_id)
+    # Workspace gate-check
+    instance = await async_whatsapp_instance_manager.get_instance(
+        instance_id, workspace_id=user.workspace_id
+    )
     if not instance:
         raise HTTPException(status_code=404, detail="WhatsApp instance not found")
+
+    # Re-fetch with token for start logic
+    instance = await async_whatsapp_instance_manager.get_instance_with_token(instance_id)
 
     if not instance.get("enabled"):
         raise HTTPException(status_code=400, detail="WhatsApp instance is disabled")
@@ -236,6 +246,13 @@ async def stop_whatsapp_instance(
     instance_id: str, user: User = Depends(require_permission("channels", "edit"))
 ):
     """Stop a specific WhatsApp bot instance and disable auto-start."""
+    # Workspace gate-check
+    instance = await async_whatsapp_instance_manager.get_instance(
+        instance_id, workspace_id=user.workspace_id
+    )
+    if not instance:
+        raise HTTPException(status_code=404, detail="WhatsApp instance not found")
+
     result = await whatsapp_manager.stop_bot(instance_id)
 
     # Save auto_start=False so bot doesn't restart on app launch
@@ -250,6 +267,13 @@ async def restart_whatsapp_instance(
     instance_id: str, user: User = Depends(require_permission("channels", "edit"))
 ):
     """Restart a specific WhatsApp bot instance."""
+    # Workspace gate-check
+    instance = await async_whatsapp_instance_manager.get_instance(
+        instance_id, workspace_id=user.workspace_id
+    )
+    if not instance:
+        raise HTTPException(status_code=404, detail="WhatsApp instance not found")
+
     result = await whatsapp_manager.restart_bot(instance_id)
     return result
 
@@ -259,8 +283,10 @@ async def get_whatsapp_instance_status(
     instance_id: str, user: User = Depends(require_permission("channels", "view"))
 ):
     """Get status of a specific WhatsApp bot instance."""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
-    instance = await async_whatsapp_instance_manager.get_instance(instance_id, owner_id=owner_id)
+    owner_id, ws_id = workspace_context(user, "channels")
+    instance = await async_whatsapp_instance_manager.get_instance(
+        instance_id, owner_id=owner_id, workspace_id=ws_id
+    )
     if not instance:
         raise HTTPException(status_code=404, detail="WhatsApp instance not found")
 
@@ -279,8 +305,10 @@ async def get_whatsapp_instance_logs(
     instance_id: str, lines: int = 100, user: User = Depends(require_permission("channels", "view"))
 ):
     """Get recent logs for a WhatsApp bot instance."""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
-    instance = await async_whatsapp_instance_manager.get_instance(instance_id, owner_id=owner_id)
+    owner_id, ws_id = workspace_context(user, "channels")
+    instance = await async_whatsapp_instance_manager.get_instance(
+        instance_id, owner_id=owner_id, workspace_id=ws_id
+    )
     if not instance:
         raise HTTPException(status_code=404, detail="WhatsApp instance not found")
 

--- a/app/routers/widget.py
+++ b/app/routers/widget.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from app.cors_middleware import get_cors_middleware
-from auth_manager import User, require_permission, user_has_level
+from auth_manager import User, require_permission, workspace_context
 from db.integration import (
     async_audit_logger,
     async_config_manager,
@@ -167,9 +167,9 @@ async def admin_list_widget_instances(
     enabled_only: bool = False, user: User = Depends(require_permission("channels", "view"))
 ):
     """List all widget instances"""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
+    owner_id, ws_id = workspace_context(user, "channels")
     instances = await async_widget_instance_manager.list_instances(
-        enabled_only=enabled_only, owner_id=owner_id
+        enabled_only=enabled_only, owner_id=owner_id, workspace_id=ws_id
     )
     return {"instances": instances}
 
@@ -180,9 +180,10 @@ async def admin_create_widget_instance(
     user: User = Depends(require_permission("channels", "edit")),
 ):
     """Create a new widget instance"""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
+    owner_id, ws_id = workspace_context(user, "channels")
     kwargs = {k: v for k, v in request.model_dump().items() if v is not None}
     kwargs["owner_id"] = owner_id
+    kwargs["workspace_id"] = ws_id
 
     instance = await async_widget_instance_manager.create_instance(**kwargs)
 
@@ -205,8 +206,10 @@ async def admin_get_widget_instance(
     instance_id: str, user: User = Depends(require_permission("channels", "view"))
 ):
     """Get a specific widget instance"""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
-    instance = await async_widget_instance_manager.get_instance(instance_id, owner_id=owner_id)
+    owner_id, ws_id = workspace_context(user, "channels")
+    instance = await async_widget_instance_manager.get_instance(
+        instance_id, owner_id=owner_id, workspace_id=ws_id
+    )
     if not instance:
         raise HTTPException(status_code=404, detail="Widget instance not found")
 
@@ -220,8 +223,10 @@ async def admin_update_widget_instance(
     user: User = Depends(require_permission("channels", "edit")),
 ):
     """Update a widget instance"""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
-    existing = await async_widget_instance_manager.get_instance(instance_id, owner_id=owner_id)
+    owner_id, ws_id = workspace_context(user, "channels")
+    existing = await async_widget_instance_manager.get_instance(
+        instance_id, owner_id=owner_id, workspace_id=ws_id
+    )
     if not existing:
         raise HTTPException(status_code=404, detail="Widget instance not found")
 
@@ -248,8 +253,10 @@ async def admin_delete_widget_instance(
     instance_id: str, user: User = Depends(require_permission("channels", "edit"))
 ):
     """Delete a widget instance"""
-    owner_id = None if user_has_level(user, "channels", "manage") else user.id
-    success = await async_widget_instance_manager.delete_instance(instance_id, owner_id=owner_id)
+    owner_id, ws_id = workspace_context(user, "channels")
+    success = await async_widget_instance_manager.delete_instance(
+        instance_id, owner_id=owner_id, workspace_id=ws_id
+    )
     if not success:
         raise HTTPException(status_code=404, detail="Widget instance not found")
 

--- a/db/integration.py
+++ b/db/integration.py
@@ -590,20 +590,30 @@ class AsyncBotInstanceManager:
     """Async manager for Telegram bot instances."""
 
     async def list_instances(
-        self, enabled_only: bool = False, owner_id: Optional[int] = None
+        self,
+        enabled_only: bool = False,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> List[dict]:
         """List all bot instances."""
         async with AsyncSessionLocal() as session:
             repo = BotInstanceRepository(session)
-            return await repo.list_instances(enabled_only=enabled_only, owner_id=owner_id)
+            return await repo.list_instances(
+                enabled_only=enabled_only, owner_id=owner_id, workspace_id=workspace_id
+            )
 
     async def get_instance(
-        self, instance_id: str, owner_id: Optional[int] = None
+        self,
+        instance_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> Optional[dict]:
         """Get bot instance by ID."""
         async with AsyncSessionLocal() as session:
             repo = BotInstanceRepository(session)
-            return await repo.get_instance(instance_id, owner_id=owner_id)
+            return await repo.get_instance(
+                instance_id, owner_id=owner_id, workspace_id=workspace_id
+            )
 
     async def get_instance_with_token(self, instance_id: str) -> Optional[dict]:
         """Get bot instance with token (for internal use)."""
@@ -623,11 +633,18 @@ class AsyncBotInstanceManager:
             repo = BotInstanceRepository(session)
             return await repo.update_instance(instance_id, **kwargs)
 
-    async def delete_instance(self, instance_id: str, owner_id: Optional[int] = None) -> bool:
+    async def delete_instance(
+        self,
+        instance_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
+    ) -> bool:
         """Delete bot instance."""
         async with AsyncSessionLocal() as session:
             repo = BotInstanceRepository(session)
-            return await repo.delete_instance(instance_id, owner_id=owner_id)
+            return await repo.delete_instance(
+                instance_id, owner_id=owner_id, workspace_id=workspace_id
+            )
 
     async def set_enabled(self, instance_id: str, enabled: bool) -> bool:
         """Enable or disable bot instance."""
@@ -679,20 +696,30 @@ class AsyncWidgetInstanceManager:
     """Async manager for website widget instances."""
 
     async def list_instances(
-        self, enabled_only: bool = False, owner_id: Optional[int] = None
+        self,
+        enabled_only: bool = False,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> List[dict]:
         """List all widget instances."""
         async with AsyncSessionLocal() as session:
             repo = WidgetInstanceRepository(session)
-            return await repo.list_instances(enabled_only=enabled_only, owner_id=owner_id)
+            return await repo.list_instances(
+                enabled_only=enabled_only, owner_id=owner_id, workspace_id=workspace_id
+            )
 
     async def get_instance(
-        self, instance_id: str, owner_id: Optional[int] = None
+        self,
+        instance_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> Optional[dict]:
         """Get widget instance by ID."""
         async with AsyncSessionLocal() as session:
             repo = WidgetInstanceRepository(session)
-            return await repo.get_instance(instance_id, owner_id=owner_id)
+            return await repo.get_instance(
+                instance_id, owner_id=owner_id, workspace_id=workspace_id
+            )
 
     async def create_instance(self, name: str, **kwargs: Any) -> dict:
         """Create new widget instance."""
@@ -706,11 +733,18 @@ class AsyncWidgetInstanceManager:
             repo = WidgetInstanceRepository(session)
             return await repo.update_instance(instance_id, **kwargs)
 
-    async def delete_instance(self, instance_id: str, owner_id: Optional[int] = None) -> bool:
+    async def delete_instance(
+        self,
+        instance_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
+    ) -> bool:
         """Delete widget instance."""
         async with AsyncSessionLocal() as session:
             repo = WidgetInstanceRepository(session)
-            return await repo.delete_instance(instance_id, owner_id=owner_id)
+            return await repo.delete_instance(
+                instance_id, owner_id=owner_id, workspace_id=workspace_id
+            )
 
     async def set_enabled(self, instance_id: str, enabled: bool) -> bool:
         """Enable or disable widget instance."""
@@ -750,20 +784,30 @@ class AsyncWhatsAppInstanceManager:
     """Async manager for WhatsApp bot instances."""
 
     async def list_instances(
-        self, enabled_only: bool = False, owner_id: Optional[int] = None
+        self,
+        enabled_only: bool = False,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> List[dict]:
         """List all WhatsApp instances."""
         async with AsyncSessionLocal() as session:
             repo = WhatsAppInstanceRepository(session)
-            return await repo.list_instances(enabled_only=enabled_only, owner_id=owner_id)
+            return await repo.list_instances(
+                enabled_only=enabled_only, owner_id=owner_id, workspace_id=workspace_id
+            )
 
     async def get_instance(
-        self, instance_id: str, owner_id: Optional[int] = None
+        self,
+        instance_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> Optional[dict]:
         """Get WhatsApp instance by ID."""
         async with AsyncSessionLocal() as session:
             repo = WhatsAppInstanceRepository(session)
-            return await repo.get_instance(instance_id, owner_id=owner_id)
+            return await repo.get_instance(
+                instance_id, owner_id=owner_id, workspace_id=workspace_id
+            )
 
     async def get_instance_with_token(self, instance_id: str) -> Optional[dict]:
         """Get WhatsApp instance with token (for internal use)."""
@@ -783,11 +827,18 @@ class AsyncWhatsAppInstanceManager:
             repo = WhatsAppInstanceRepository(session)
             return await repo.update_instance(instance_id, **kwargs)
 
-    async def delete_instance(self, instance_id: str, owner_id: Optional[int] = None) -> bool:
+    async def delete_instance(
+        self,
+        instance_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
+    ) -> bool:
         """Delete WhatsApp instance."""
         async with AsyncSessionLocal() as session:
             repo = WhatsAppInstanceRepository(session)
-            return await repo.delete_instance(instance_id, owner_id=owner_id)
+            return await repo.delete_instance(
+                instance_id, owner_id=owner_id, workspace_id=workspace_id
+            )
 
     async def set_enabled(self, instance_id: str, enabled: bool) -> bool:
         """Enable or disable WhatsApp instance."""

--- a/db/repositories/bot_instance.py
+++ b/db/repositories/bot_instance.py
@@ -56,9 +56,12 @@ class BotInstanceRepository(BaseRepository[BotInstance]):
         return instance
 
     async def list_instances(
-        self, enabled_only: bool = False, owner_id: Optional[int] = None
+        self,
+        enabled_only: bool = False,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> List[dict]:
-        """List bot instances, filtered by owner."""
+        """List bot instances, filtered by owner and workspace."""
         query = select(BotInstance).order_by(BotInstance.updated.desc())
         if enabled_only:
             query = query.where(BotInstance.enabled == True)
@@ -66,19 +69,28 @@ class BotInstanceRepository(BaseRepository[BotInstance]):
             query = query.where(
                 (BotInstance.owner_id == owner_id) | (BotInstance.owner_id.is_(None))
             )
+        query = self._apply_workspace_filter(query, workspace_id)
 
         result = await self.session.execute(query)
         instances = result.scalars().all()
         return [i.to_dict() for i in instances]
 
     async def get_instance(
-        self, instance_id: str, owner_id: Optional[int] = None
+        self,
+        instance_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> Optional[dict]:
-        """Get bot instance by ID, with optional owner check."""
-        instance = await self.session.get(BotInstance, instance_id)
+        """Get bot instance by ID, with optional owner/workspace check."""
+        query = select(BotInstance).where(BotInstance.id == instance_id)
+        if owner_id is not None:
+            query = query.where(
+                (BotInstance.owner_id == owner_id) | (BotInstance.owner_id.is_(None))
+            )
+        query = self._apply_workspace_filter(query, workspace_id)
+        result = await self.session.execute(query)
+        instance = result.scalar_one_or_none()
         if not instance:
-            return None
-        if owner_id is not None and instance.owner_id is not None and instance.owner_id != owner_id:
             return None
         return instance.to_dict()
 
@@ -103,12 +115,18 @@ class BotInstanceRepository(BaseRepository[BotInstance]):
             # Append timestamp to make unique
             instance_id = f"{instance_id}-{int(datetime.utcnow().timestamp())}"
 
+        # Build creation kwargs
+        create_kwargs: dict[str, Any] = {}
+        if kwargs.get("workspace_id") is not None:
+            create_kwargs["workspace_id"] = kwargs["workspace_id"]
+
         instance = BotInstance(
             id=instance_id,
             name=name,
             description=description,
             enabled=kwargs.get("enabled", True),
             owner_id=kwargs.get("owner_id"),
+            **create_kwargs,
             # Telegram
             bot_token=bot_token,
             welcome_message=kwargs.get("welcome_message", DEFAULT_BOT_CONFIG["welcome_message"]),
@@ -230,12 +248,23 @@ class BotInstanceRepository(BaseRepository[BotInstance]):
         data: dict[str, Any] = instance.to_dict()
         return data
 
-    async def delete_instance(self, instance_id: str, owner_id: Optional[int] = None) -> bool:
-        """Delete bot instance, with optional owner check."""
-        instance = await self.session.get(BotInstance, instance_id)
+    async def delete_instance(
+        self,
+        instance_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
+    ) -> bool:
+        """Delete bot instance, with optional owner/workspace check."""
+        query = select(BotInstance).where(BotInstance.id == instance_id)
+        if owner_id is not None:
+            query = query.where(
+                (BotInstance.owner_id == owner_id) | (BotInstance.owner_id.is_(None))
+            )
+        if workspace_id is not None and hasattr(BotInstance, "workspace_id"):
+            query = query.where(BotInstance.workspace_id == workspace_id)
+        result = await self.session.execute(query)
+        instance = result.scalar_one_or_none()
         if not instance:
-            return False
-        if owner_id is not None and instance.owner_id is not None and instance.owner_id != owner_id:
             return False
 
         await self.session.delete(instance)

--- a/db/repositories/whatsapp_instance.py
+++ b/db/repositories/whatsapp_instance.py
@@ -53,9 +53,12 @@ class WhatsAppInstanceRepository(BaseRepository[WhatsAppInstance]):
         return instance
 
     async def list_instances(
-        self, enabled_only: bool = False, owner_id: Optional[int] = None
+        self,
+        enabled_only: bool = False,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> List[dict]:
-        """List WhatsApp instances, filtered by owner."""
+        """List WhatsApp instances, filtered by owner and workspace."""
         query = select(WhatsAppInstance).order_by(WhatsAppInstance.updated.desc())
         if enabled_only:
             query = query.where(WhatsAppInstance.enabled == True)
@@ -63,19 +66,28 @@ class WhatsAppInstanceRepository(BaseRepository[WhatsAppInstance]):
             query = query.where(
                 (WhatsAppInstance.owner_id == owner_id) | (WhatsAppInstance.owner_id.is_(None))
             )
+        query = self._apply_workspace_filter(query, workspace_id)
 
         result = await self.session.execute(query)
         instances = result.scalars().all()
         return [i.to_dict() for i in instances]
 
     async def get_instance(
-        self, instance_id: str, owner_id: Optional[int] = None
+        self,
+        instance_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> Optional[dict]:
-        """Get WhatsApp instance by ID, with optional owner check."""
-        instance = await self.session.get(WhatsAppInstance, instance_id)
+        """Get WhatsApp instance by ID, with optional owner/workspace check."""
+        query = select(WhatsAppInstance).where(WhatsAppInstance.id == instance_id)
+        if owner_id is not None:
+            query = query.where(
+                (WhatsAppInstance.owner_id == owner_id) | (WhatsAppInstance.owner_id.is_(None))
+            )
+        query = self._apply_workspace_filter(query, workspace_id)
+        result = await self.session.execute(query)
+        instance = result.scalar_one_or_none()
         if not instance:
-            return None
-        if owner_id is not None and instance.owner_id is not None and instance.owner_id != owner_id:
             return None
         return instance.to_dict()
 
@@ -99,6 +111,11 @@ class WhatsAppInstanceRepository(BaseRepository[WhatsAppInstance]):
         if existing:
             instance_id = f"{instance_id}-{int(datetime.utcnow().timestamp())}"
 
+        # Build creation kwargs
+        create_kwargs: dict[str, Any] = {}
+        if kwargs.get("workspace_id") is not None:
+            create_kwargs["workspace_id"] = kwargs["workspace_id"]
+
         instance = WhatsAppInstance(
             id=instance_id,
             name=name,
@@ -106,6 +123,7 @@ class WhatsAppInstanceRepository(BaseRepository[WhatsAppInstance]):
             enabled=kwargs.get("enabled", True),
             auto_start=kwargs.get("auto_start", False),
             owner_id=kwargs.get("owner_id"),
+            **create_kwargs,
             # WhatsApp API
             phone_number_id=phone_number_id,
             waba_id=kwargs.get("waba_id"),
@@ -191,12 +209,23 @@ class WhatsAppInstanceRepository(BaseRepository[WhatsAppInstance]):
         data: dict[str, Any] = instance.to_dict()
         return data
 
-    async def delete_instance(self, instance_id: str, owner_id: Optional[int] = None) -> bool:
-        """Delete WhatsApp instance, with optional owner check."""
-        instance = await self.session.get(WhatsAppInstance, instance_id)
+    async def delete_instance(
+        self,
+        instance_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
+    ) -> bool:
+        """Delete WhatsApp instance, with optional owner/workspace check."""
+        query = select(WhatsAppInstance).where(WhatsAppInstance.id == instance_id)
+        if owner_id is not None:
+            query = query.where(
+                (WhatsAppInstance.owner_id == owner_id) | (WhatsAppInstance.owner_id.is_(None))
+            )
+        if workspace_id is not None and hasattr(WhatsAppInstance, "workspace_id"):
+            query = query.where(WhatsAppInstance.workspace_id == workspace_id)
+        result = await self.session.execute(query)
+        instance = result.scalar_one_or_none()
         if not instance:
-            return False
-        if owner_id is not None and instance.owner_id is not None and instance.owner_id != owner_id:
             return False
 
         await self.session.delete(instance)

--- a/db/repositories/widget_instance.py
+++ b/db/repositories/widget_instance.py
@@ -61,9 +61,12 @@ class WidgetInstanceRepository(BaseRepository[WidgetInstance]):
         return instance
 
     async def list_instances(
-        self, enabled_only: bool = False, owner_id: Optional[int] = None
+        self,
+        enabled_only: bool = False,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> List[dict]:
-        """List widget instances, filtered by owner."""
+        """List widget instances, filtered by owner and workspace."""
         query = select(WidgetInstance).order_by(WidgetInstance.updated.desc())
         if enabled_only:
             query = query.where(WidgetInstance.enabled == True)
@@ -71,19 +74,28 @@ class WidgetInstanceRepository(BaseRepository[WidgetInstance]):
             query = query.where(
                 (WidgetInstance.owner_id == owner_id) | (WidgetInstance.owner_id.is_(None))
             )
+        query = self._apply_workspace_filter(query, workspace_id)
 
         result = await self.session.execute(query)
         instances = result.scalars().all()
         return [i.to_dict() for i in instances]
 
     async def get_instance(
-        self, instance_id: str, owner_id: Optional[int] = None
+        self,
+        instance_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> Optional[dict]:
-        """Get widget instance by ID, with optional owner check."""
-        instance = await self.session.get(WidgetInstance, instance_id)
+        """Get widget instance by ID, with optional owner/workspace check."""
+        query = select(WidgetInstance).where(WidgetInstance.id == instance_id)
+        if owner_id is not None:
+            query = query.where(
+                (WidgetInstance.owner_id == owner_id) | (WidgetInstance.owner_id.is_(None))
+            )
+        query = self._apply_workspace_filter(query, workspace_id)
+        result = await self.session.execute(query)
+        instance = result.scalar_one_or_none()
         if not instance:
-            return None
-        if owner_id is not None and instance.owner_id is not None and instance.owner_id != owner_id:
             return None
         return instance.to_dict()
 
@@ -99,12 +111,18 @@ class WidgetInstanceRepository(BaseRepository[WidgetInstance]):
             # Append timestamp to make unique
             instance_id = f"{instance_id}-{int(datetime.utcnow().timestamp())}"
 
+        # Build creation kwargs
+        create_kwargs: dict[str, Any] = {}
+        if kwargs.get("workspace_id") is not None:
+            create_kwargs["workspace_id"] = kwargs["workspace_id"]
+
         instance = WidgetInstance(
             id=instance_id,
             name=name,
             description=description,
             enabled=kwargs.get("enabled", True),
             owner_id=kwargs.get("owner_id"),
+            **create_kwargs,
             # Appearance
             title=kwargs.get("title", DEFAULT_WIDGET_CONFIG["title"]),
             greeting=kwargs.get("greeting", DEFAULT_WIDGET_CONFIG["greeting"]),
@@ -187,12 +205,23 @@ class WidgetInstanceRepository(BaseRepository[WidgetInstance]):
         data: dict[str, Any] = instance.to_dict()
         return data
 
-    async def delete_instance(self, instance_id: str, owner_id: Optional[int] = None) -> bool:
-        """Delete widget instance, with optional owner check."""
-        instance = await self.session.get(WidgetInstance, instance_id)
+    async def delete_instance(
+        self,
+        instance_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
+    ) -> bool:
+        """Delete widget instance, with optional owner/workspace check."""
+        query = select(WidgetInstance).where(WidgetInstance.id == instance_id)
+        if owner_id is not None:
+            query = query.where(
+                (WidgetInstance.owner_id == owner_id) | (WidgetInstance.owner_id.is_(None))
+            )
+        if workspace_id is not None and hasattr(WidgetInstance, "workspace_id"):
+            query = query.where(WidgetInstance.workspace_id == workspace_id)
+        result = await self.session.execute(query)
+        instance = result.scalar_one_or_none()
         if not instance:
-            return False
-        if owner_id is not None and instance.owner_id is not None and instance.owner_id != owner_id:
             return False
 
         await self.session.delete(instance)


### PR DESCRIPTION
## Summary

- Add `workspace_id` parameter to `list_instances`, `get_instance`, `delete_instance` in all 3 channel repositories (BotInstance, WhatsAppInstance, WidgetInstance)
- Pass `workspace_id` through all 3 integration managers (AsyncBotInstanceManager, AsyncWidgetInstanceManager, AsyncWhatsAppInstanceManager)
- Replace `user_has_level()` pattern with `workspace_context()` in all CRUD endpoints across 3 routers (telegram, whatsapp, widget)
- Add workspace gate-checks on action endpoints (start/stop/restart/logs/sessions) that previously had no workspace filtering
- System methods (`get_auto_start_instances`, `get_instance_with_token`, `get_enabled_instances`) and public endpoints (payments, sessions POST, YooMoney callback) remain untouched

## Files changed (7)

| Layer | Files | Changes |
|-------|-------|---------|
| Repository | `bot_instance.py`, `whatsapp_instance.py`, `widget_instance.py` | `workspace_id` on list/get/delete + `_apply_workspace_filter()`; create via kwargs |
| Integration | `integration.py` (3 managers) | Passthrough `workspace_id` to repo methods |
| Router | `telegram.py`, `whatsapp.py`, `widget.py` | `workspace_context()` on CRUD; gate-checks on actions |

## Pattern

Same gate-check approach as Chat (#385): filter workspace_id at instance entry points (list/get/create/delete), not on every sub-operation. Action endpoints validate workspace membership via `get_instance(id, workspace_id=user.workspace_id)` before proceeding.

## Test plan

- [ ] List instances returns only current workspace's instances
- [ ] Create instance assigns correct workspace_id
- [ ] Get/update/delete instance rejects cross-workspace access (404)
- [ ] Start/stop/restart reject cross-workspace instances (404)
- [ ] Logs/sessions/status endpoints respect workspace isolation
- [ ] Public endpoints (payments, sessions POST, YooMoney callback) still work without auth
- [ ] System auto-start works without workspace context
- [ ] Single-workspace deployment (workspace_id=1) behaves identically to before

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)