### PR TITLE
feat(rbac): 6c-3 workspace filtering for Cloud LLM Providers & TTS Presets

### DIFF
--- a/app/routers/llm.py
+++ b/app/routers/llm.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from app.dependencies import get_container
-from auth_manager import User, require_permission, user_has_level
+from auth_manager import User, require_permission, workspace_context
 from cloud_llm_service import PROVIDER_TYPES, CloudLLMService, GeminiProvider
 from db.integration import async_audit_logger, async_cloud_provider_manager
 from service_manager import get_service_manager
@@ -637,8 +637,10 @@ async def admin_list_cloud_providers(
     enabled_only: bool = False, user: User = Depends(require_permission("llm", "view"))
 ):
     """List all cloud LLM providers"""
-    owner_id = None if user_has_level(user, "llm", "manage") else user.id
-    providers = await async_cloud_provider_manager.list_providers(enabled_only, owner_id=owner_id)
+    owner_id, ws_id = workspace_context(user, "llm")
+    providers = await async_cloud_provider_manager.list_providers(
+        enabled_only, owner_id=owner_id, workspace_id=ws_id
+    )
     return {
         "providers": providers,
         "provider_types": PROVIDER_TYPES,
@@ -652,11 +654,13 @@ async def admin_get_cloud_provider(
     user: User = Depends(require_permission("llm", "view")),
 ):
     """Get cloud provider by ID"""
-    owner_id = None if user_has_level(user, "llm", "manage") else user.id
+    owner_id, ws_id = workspace_context(user, "llm")
     if include_key:
         provider = await async_cloud_provider_manager.get_provider_with_key(provider_id)
     else:
-        provider = await async_cloud_provider_manager.get_provider(provider_id, owner_id=owner_id)
+        provider = await async_cloud_provider_manager.get_provider(
+            provider_id, owner_id=owner_id, workspace_id=ws_id
+        )
 
     if not provider:
         raise HTTPException(status_code=404, detail="Provider not found")
@@ -668,7 +672,7 @@ async def admin_create_cloud_provider(
     data: CloudProviderCreate, user: User = Depends(require_permission("llm", "edit"))
 ):
     """Create new cloud LLM provider"""
-    owner_id = None if user_has_level(user, "llm", "manage") else user.id
+    owner_id, ws_id = workspace_context(user, "llm")
     try:
         provider = await async_cloud_provider_manager.create_provider(
             name=data.name,
@@ -681,6 +685,7 @@ async def admin_create_cloud_provider(
             config=data.config,
             description=data.description,
             owner_id=owner_id,
+            workspace_id=ws_id,
         )
 
         # Audit log
@@ -705,8 +710,10 @@ async def admin_update_cloud_provider(
 ):
     """Update cloud LLM provider"""
     # Verify ownership
-    owner_id = None if user_has_level(user, "llm", "manage") else user.id
-    existing = await async_cloud_provider_manager.get_provider(provider_id, owner_id=owner_id)
+    owner_id, ws_id = workspace_context(user, "llm")
+    existing = await async_cloud_provider_manager.get_provider(
+        provider_id, owner_id=owner_id, workspace_id=ws_id
+    )
     if not existing:
         raise HTTPException(status_code=404, detail="Provider not found")
 
@@ -734,8 +741,10 @@ async def admin_delete_cloud_provider(
     provider_id: str, user: User = Depends(require_permission("llm", "edit"))
 ):
     """Delete cloud LLM provider"""
-    owner_id = None if user_has_level(user, "llm", "manage") else user.id
-    if not await async_cloud_provider_manager.delete_provider(provider_id, owner_id=owner_id):
+    owner_id, ws_id = workspace_context(user, "llm")
+    if not await async_cloud_provider_manager.delete_provider(
+        provider_id, owner_id=owner_id, workspace_id=ws_id
+    ):
         raise HTTPException(status_code=404, detail="Provider not found")
 
     # Audit log
@@ -755,8 +764,10 @@ async def admin_test_cloud_provider(
 ):
     """Test cloud provider connection"""
     # Verify ownership before testing
-    owner_id = None if user_has_level(user, "llm", "manage") else user.id
-    if not await async_cloud_provider_manager.get_provider(provider_id, owner_id=owner_id):
+    owner_id, ws_id = workspace_context(user, "llm")
+    if not await async_cloud_provider_manager.get_provider(
+        provider_id, owner_id=owner_id, workspace_id=ws_id
+    ):
         raise HTTPException(status_code=404, detail="Provider not found")
     provider_config = await async_cloud_provider_manager.get_provider_with_key(provider_id)
     if not provider_config:
@@ -817,8 +828,10 @@ async def admin_set_default_cloud_provider(
 ):
     """Set cloud provider as default"""
     # Verify ownership
-    owner_id = None if user_has_level(user, "llm", "manage") else user.id
-    if not await async_cloud_provider_manager.get_provider(provider_id, owner_id=owner_id):
+    owner_id, ws_id = workspace_context(user, "llm")
+    if not await async_cloud_provider_manager.get_provider(
+        provider_id, owner_id=owner_id, workspace_id=ws_id
+    ):
         raise HTTPException(status_code=404, detail="Provider not found")
 
     if not await async_cloud_provider_manager.set_default(provider_id):

--- a/app/routers/tts.py
+++ b/app/routers/tts.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 
 from app.dependencies import get_container
 from app.rate_limiter import RATE_LIMIT_TTS, limiter
-from auth_manager import User, require_permission, user_has_level
+from auth_manager import User, require_permission, workspace_context
 from db.integration import async_preset_manager
 from voice_clone_service import INTONATION_PRESETS
 
@@ -346,7 +346,8 @@ async def admin_set_piper_params(
 @router.get("/presets/custom")
 async def admin_get_custom_presets(user: User = Depends(require_permission("speech", "view"))):
     """Получить пользовательские пресеты TTS"""
-    presets = await async_preset_manager.get_custom()
+    owner_id, ws_id = workspace_context(user, "speech")
+    presets = await async_preset_manager.get_custom(owner_id=owner_id, workspace_id=ws_id)
     return {"presets": presets}
 
 
@@ -355,8 +356,10 @@ async def admin_create_custom_preset(
     request: AdminCustomPresetRequest, user: User = Depends(require_permission("speech", "edit"))
 ):
     """Создать пользовательский пресет TTS"""
-    owner_id = None if user_has_level(user, "speech", "manage") else user.id
-    await async_preset_manager.create(request.name, request.params, owner_id=owner_id)
+    owner_id, ws_id = workspace_context(user, "speech")
+    await async_preset_manager.create(
+        request.name, request.params, owner_id=owner_id, workspace_id=ws_id
+    )
     await _reload_voice_presets()
     return {"status": "ok", "preset": request.name}
 
@@ -381,7 +384,8 @@ async def admin_delete_custom_preset(
     name: str, user: User = Depends(require_permission("speech", "edit"))
 ):
     """Удалить пользовательский пресет TTS"""
-    if not await async_preset_manager.delete(name):
+    _owner_id, ws_id = workspace_context(user, "speech")
+    if not await async_preset_manager.delete(name, workspace_id=ws_id):
         raise HTTPException(status_code=404, detail=f"Preset not found: {name}")
 
     await _reload_voice_presets()

--- a/db/integration.py
+++ b/db/integration.py
@@ -421,23 +421,35 @@ class AsyncFAQManager:
 class AsyncPresetManager:
     """Async TTS preset manager using database."""
 
-    async def get_all(self, owner_id: Optional[int] = None) -> Dict[str, dict]:
+    async def get_all(
+        self, owner_id: Optional[int] = None, workspace_id: Optional[int] = None
+    ) -> Dict[str, dict]:
         """Get all presets."""
         async with AsyncSessionLocal() as session:
             repo = PresetRepository(session)
-            return await repo.get_all_presets(owner_id=owner_id)
+            return await repo.get_all_presets(owner_id=owner_id, workspace_id=workspace_id)
 
-    async def get_custom(self) -> Dict[str, dict]:
+    async def get_custom(
+        self, owner_id: Optional[int] = None, workspace_id: Optional[int] = None
+    ) -> Dict[str, dict]:
         """Get only custom presets."""
         async with AsyncSessionLocal() as session:
             repo = PresetRepository(session)
-            return await repo.get_custom_presets()
+            return await repo.get_custom_presets(owner_id=owner_id, workspace_id=workspace_id)
 
-    async def create(self, name: str, params: dict, owner_id: Optional[int] = None) -> dict:
+    async def create(
+        self,
+        name: str,
+        params: dict,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
+    ) -> dict:
         """Create new preset."""
         async with AsyncSessionLocal() as session:
             repo = PresetRepository(session)
-            return await repo.create_preset(name, params, owner_id=owner_id)
+            return await repo.create_preset(
+                name, params, owner_id=owner_id, workspace_id=workspace_id
+            )
 
     async def update(self, name: str, params: dict) -> Optional[dict]:
         """Update preset."""
@@ -445,11 +457,11 @@ class AsyncPresetManager:
             repo = PresetRepository(session)
             return await repo.update_preset(name, params)
 
-    async def delete(self, name: str) -> bool:
+    async def delete(self, name: str, workspace_id: Optional[int] = None) -> bool:
         """Delete preset."""
         async with AsyncSessionLocal() as session:
             repo = PresetRepository(session)
-            return await repo.delete_preset(name)
+            return await repo.delete_preset(name, workspace_id=workspace_id)
 
 
 # ============== Config Manager ==============
@@ -884,20 +896,30 @@ class AsyncCloudProviderManager:
     """Async manager for cloud LLM providers."""
 
     async def list_providers(
-        self, enabled_only: bool = False, owner_id: Optional[int] = None
+        self,
+        enabled_only: bool = False,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> List[dict]:
         """List all cloud providers."""
         async with AsyncSessionLocal() as session:
             repo = CloudProviderRepository(session)
-            return await repo.list_providers(enabled_only=enabled_only, owner_id=owner_id)
+            return await repo.list_providers(
+                enabled_only=enabled_only, owner_id=owner_id, workspace_id=workspace_id
+            )
 
     async def get_provider(
-        self, provider_id: str, owner_id: Optional[int] = None
+        self,
+        provider_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> Optional[dict]:
         """Get provider by ID (without API key)."""
         async with AsyncSessionLocal() as session:
             repo = CloudProviderRepository(session)
-            return await repo.get_provider(provider_id, owner_id=owner_id)
+            return await repo.get_provider(
+                provider_id, owner_id=owner_id, workspace_id=workspace_id
+            )
 
     async def get_provider_with_key(self, provider_id: str) -> Optional[dict]:
         """Get provider with API key (for internal use)."""
@@ -929,11 +951,18 @@ class AsyncCloudProviderManager:
             repo = CloudProviderRepository(session)
             return await repo.update_provider(provider_id, **kwargs)
 
-    async def delete_provider(self, provider_id: str, owner_id: Optional[int] = None) -> bool:
+    async def delete_provider(
+        self,
+        provider_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
+    ) -> bool:
         """Delete cloud provider."""
         async with AsyncSessionLocal() as session:
             repo = CloudProviderRepository(session)
-            return await repo.delete_provider(provider_id, owner_id=owner_id)
+            return await repo.delete_provider(
+                provider_id, owner_id=owner_id, workspace_id=workspace_id
+            )
 
     async def set_default(self, provider_id: str) -> bool:
         """Set provider as default."""

--- a/db/repositories/cloud_provider.py
+++ b/db/repositories/cloud_provider.py
@@ -37,9 +37,12 @@ class CloudProviderRepository(BaseRepository[CloudLLMProvider]):
         return base or f"provider-{int(datetime.utcnow().timestamp())}"
 
     async def list_providers(
-        self, enabled_only: bool = False, owner_id: Optional[int] = None
+        self,
+        enabled_only: bool = False,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> List[dict]:
-        """List providers, filtered by owner."""
+        """List providers, filtered by owner and workspace."""
         query = select(CloudLLMProvider).order_by(CloudLLMProvider.updated.desc())
         if enabled_only:
             query = query.where(CloudLLMProvider.enabled == True)
@@ -47,19 +50,28 @@ class CloudProviderRepository(BaseRepository[CloudLLMProvider]):
             query = query.where(
                 (CloudLLMProvider.owner_id == owner_id) | (CloudLLMProvider.owner_id.is_(None))
             )
+        query = self._apply_workspace_filter(query, workspace_id)
 
         result = await self.session.execute(query)
         providers = result.scalars().all()
         return [p.to_dict() for p in providers]
 
     async def get_provider(
-        self, provider_id: str, owner_id: Optional[int] = None
+        self,
+        provider_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> Optional[dict]:
-        """Get provider by ID (without API key), with optional owner check."""
-        provider = await self.session.get(CloudLLMProvider, provider_id)
+        """Get provider by ID (without API key), with optional owner/workspace check."""
+        query = select(CloudLLMProvider).where(CloudLLMProvider.id == provider_id)
+        if owner_id is not None:
+            query = query.where(
+                (CloudLLMProvider.owner_id == owner_id) | (CloudLLMProvider.owner_id.is_(None))
+            )
+        query = self._apply_workspace_filter(query, workspace_id)
+        result = await self.session.execute(query)
+        provider = result.scalar_one_or_none()
         if not provider:
-            return None
-        if owner_id is not None and provider.owner_id is not None and provider.owner_id != owner_id:
             return None
         return provider.to_dict()
 
@@ -110,6 +122,10 @@ class CloudProviderRepository(BaseRepository[CloudLLMProvider]):
         if kwargs.get("is_default", False):
             await self._unset_all_defaults()
 
+        create_kwargs: dict[str, Any] = {}
+        if kwargs.get("workspace_id") is not None:
+            create_kwargs["workspace_id"] = kwargs["workspace_id"]
+
         provider = CloudLLMProvider(
             id=provider_id,
             name=name,
@@ -123,6 +139,7 @@ class CloudProviderRepository(BaseRepository[CloudLLMProvider]):
             description=kwargs.get("description"),
             created=datetime.utcnow(),
             updated=datetime.utcnow(),
+            **create_kwargs,
         )
 
         if kwargs.get("config"):
@@ -175,12 +192,23 @@ class CloudProviderRepository(BaseRepository[CloudLLMProvider]):
         data: dict[str, Any] = provider.to_dict()
         return data
 
-    async def delete_provider(self, provider_id: str, owner_id: Optional[int] = None) -> bool:
-        """Delete provider, with optional owner check."""
-        provider = await self.session.get(CloudLLMProvider, provider_id)
+    async def delete_provider(
+        self,
+        provider_id: str,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
+    ) -> bool:
+        """Delete provider, with optional owner/workspace check."""
+        query = select(CloudLLMProvider).where(CloudLLMProvider.id == provider_id)
+        if owner_id is not None:
+            query = query.where(
+                (CloudLLMProvider.owner_id == owner_id) | (CloudLLMProvider.owner_id.is_(None))
+            )
+        if workspace_id is not None and hasattr(CloudLLMProvider, "workspace_id"):
+            query = query.where(CloudLLMProvider.workspace_id == workspace_id)
+        result = await self.session.execute(query)
+        provider = result.scalar_one_or_none()
         if not provider:
-            return False
-        if owner_id is not None and provider.owner_id is not None and provider.owner_id != owner_id:
             return False
 
         await self.session.delete(provider)

--- a/db/repositories/preset.py
+++ b/db/repositories/preset.py
@@ -32,14 +32,17 @@ class PresetRepository(BaseRepository[TTSPreset]):
         await cache_delete(self._cache_key())
 
     async def get_all_presets(
-        self, include_builtin: bool = True, owner_id: Optional[int] = None
+        self,
+        include_builtin: bool = True,
+        owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> Dict[str, dict]:
         """
-        Get all presets as name->params dict, filtered by owner.
-        Uses Redis cache when no owner filter.
+        Get all presets as name->params dict, filtered by owner and workspace.
+        Uses Redis cache when no owner/workspace filter.
         """
-        # Try cache first (only when no owner filter)
-        if owner_id is None:
+        # Try cache first (only when no owner/workspace filter)
+        if owner_id is None and workspace_id is None:
             cached: Optional[Dict[str, dict]] = await cache_get(self._cache_key())
             if cached:
                 if not include_builtin:
@@ -50,6 +53,7 @@ class PresetRepository(BaseRepository[TTSPreset]):
         query = select(TTSPreset)
         if owner_id is not None:
             query = query.where((TTSPreset.owner_id == owner_id) | (TTSPreset.owner_id.is_(None)))
+        query = self._apply_workspace_filter(query, workspace_id)
         result = await self.session.execute(query)
         presets = result.scalars().all()
 
@@ -60,17 +64,21 @@ class PresetRepository(BaseRepository[TTSPreset]):
                 "builtin": p.builtin,
             }
 
-        # Cache for 10 minutes (only when no owner filter)
-        if owner_id is None:
+        # Cache for 10 minutes (only when no owner/workspace filter)
+        if owner_id is None and workspace_id is None:
             await cache_set(self._cache_key(), preset_dict, self.CACHE_TTL)
 
         if not include_builtin:
             return {k: v for k, v in preset_dict.items() if not v.get("builtin", False)}
         return preset_dict
 
-    async def get_custom_presets(self) -> Dict[str, dict]:
+    async def get_custom_presets(
+        self, owner_id: Optional[int] = None, workspace_id: Optional[int] = None
+    ) -> Dict[str, dict]:
         """Get only custom (non-builtin) presets."""
-        return await self.get_all_presets(include_builtin=False)
+        return await self.get_all_presets(
+            include_builtin=False, owner_id=owner_id, workspace_id=workspace_id
+        )
 
     async def get_by_name(self, name: str) -> Optional[dict]:
         """Get preset by name."""
@@ -84,8 +92,13 @@ class PresetRepository(BaseRepository[TTSPreset]):
         params: dict,
         builtin: bool = False,
         owner_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> dict:
         """Create new preset."""
+        create_kwargs: dict[str, Any] = {}
+        if workspace_id is not None:
+            create_kwargs["workspace_id"] = workspace_id
+
         preset = TTSPreset(
             name=name,
             params=json.dumps(params, ensure_ascii=False),
@@ -93,6 +106,7 @@ class PresetRepository(BaseRepository[TTSPreset]):
             owner_id=owner_id,
             created=datetime.utcnow(),
             updated=datetime.utcnow(),
+            **create_kwargs,
         )
 
         self.session.add(preset)
@@ -123,13 +137,16 @@ class PresetRepository(BaseRepository[TTSPreset]):
         data: dict[str, Any] = preset.to_dict()
         return data
 
-    async def delete_preset(self, name: str) -> bool:
-        """Delete preset by name."""
-        result = await self.session.execute(
+    async def delete_preset(self, name: str, workspace_id: Optional[int] = None) -> bool:
+        """Delete preset by name, with optional workspace check."""
+        query = (
             delete(TTSPreset)
             .where(TTSPreset.name == name)
             .where(TTSPreset.builtin == False)  # Can't delete builtin
         )
+        if workspace_id is not None and hasattr(TTSPreset, "workspace_id"):
+            query = query.where(TTSPreset.workspace_id == workspace_id)
+        result = await self.session.execute(query)
         await self.session.commit()
         await self._invalidate_cache()
         return bool(result.rowcount > 0)  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Closes #379

- Add `workspace_id` filtering to `CloudProviderRepository` (list/get/create/delete) and `PresetRepository` (get_all/get_custom/create/delete)
- Passthrough `workspace_id` in `AsyncCloudProviderManager` and `AsyncPresetManager` (integration.py)
- Replace `user_has_level()` with `workspace_context()` in 7 provider endpoints (`app/routers/llm.py`) and 4 preset endpoints (`app/routers/tts.py`)
- System methods (`get_default_provider`, `get_first_enabled`, `get_provider_with_key`) remain unscoped — they are called without JWT context
- Redis cache for presets only used when no owner/workspace filter (same safe noop as before)

### Pattern applied
Same gate-check pattern as Chat (#376) and Channels (#378):
- `owner_id, ws_id = workspace_context(user, module)` in router
- `_apply_workspace_filter(query, workspace_id)` for SELECT queries
- Manual `WHERE workspace_id = ?` for DELETE queries
- `workspace_id` via `**create_kwargs` for CREATE

### Files changed (5)
| File | Changes |
|------|---------|
| `db/repositories/cloud_provider.py` | `workspace_id` on list/get/create/delete; query-based get/delete |
| `db/repositories/preset.py` | `workspace_id` on get_all/get_custom/create/delete; cache logic updated |
| `db/integration.py` | Passthrough on both managers |
| `app/routers/llm.py` | `workspace_context` on 7 provider endpoints; removed unused `user_has_level` import |
| `app/routers/tts.py` | `workspace_context` on 4 preset endpoints; replaced `user_has_level` import |

## Test plan

- [ ] List providers — returns only workspace-scoped providers
- [ ] Create provider — sets workspace_id from JWT
- [ ] Get/update/delete provider — respects workspace boundary
- [ ] List custom presets — scoped by workspace
- [ ] Create/delete preset — respects workspace boundary
- [ ] System methods (get_default_provider, get_first_enabled) still work without workspace filter
- [ ] Ruff lint + format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)