### PR TITLE
feat(rbac): 6c-4 workspace filtering for Knowledge Base & FAQ

### DIFF
--- a/app/routers/faq.py
+++ b/app/routers/faq.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from app.dependencies import get_container
-from auth_manager import User, require_permission
+from auth_manager import User, require_permission, workspace_context
 from db.integration import async_audit_logger, async_faq_manager
 
 
@@ -33,7 +33,8 @@ async def _reload_llm_faq():
 @router.get("")
 async def admin_get_faq(user: User = Depends(require_permission("faq", "view"))):
     """Получить все FAQ записи"""
-    faq = await async_faq_manager.get_all()
+    _owner_id, ws_id = workspace_context(user, "faq")
+    faq = await async_faq_manager.get_all(workspace_id=ws_id)
     return {"faq": faq}
 
 
@@ -42,7 +43,8 @@ async def admin_add_faq(
     request: AdminFAQRequest, user: User = Depends(require_permission("faq", "edit"))
 ):
     """Добавить FAQ запись"""
-    await async_faq_manager.add(request.trigger, request.response)
+    _owner_id, ws_id = workspace_context(user, "faq")
+    await async_faq_manager.add(request.trigger, request.response, workspace_id=ws_id)
 
     # Audit log
     await async_audit_logger.log(
@@ -64,7 +66,10 @@ async def admin_update_faq(
     trigger: str, request: AdminFAQRequest, user: User = Depends(require_permission("faq", "edit"))
 ):
     """Обновить FAQ запись"""
-    result = await async_faq_manager.update(trigger, request.trigger, request.response)
+    _owner_id, ws_id = workspace_context(user, "faq")
+    result = await async_faq_manager.update(
+        trigger, request.trigger, request.response, workspace_id=ws_id
+    )
     if not result:
         raise HTTPException(status_code=404, detail="FAQ entry not found")
 

--- a/app/routers/wiki_rag.py
+++ b/app/routers/wiki_rag.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile
 from pydantic import BaseModel
 
 from app.dependencies import get_container
-from auth_manager import User, require_permission, user_has_level
+from auth_manager import User, require_permission, workspace_context
 from db.integration import (
     async_audit_logger,
     async_knowledge_collection_manager,
@@ -174,7 +174,8 @@ def _get_wiki_rag():
 @router.get("/collections")
 async def list_collections(user: User = Depends(require_permission("wiki", "view"))):
     """List all knowledge collections."""
-    collections = await async_knowledge_collection_manager.get_all()
+    _owner_id, ws_id = workspace_context(user, "wiki")
+    collections = await async_knowledge_collection_manager.get_all(workspace_id=ws_id)
     return {"collections": collections}
 
 
@@ -184,6 +185,7 @@ async def create_collection(
     user: User = Depends(require_permission("wiki", "edit")),
 ):
     """Create a new knowledge collection."""
+    _owner_id, ws_id = workspace_context(user, "wiki")
     slug = request.slug or _slugify(request.name)
 
     # Check for duplicate slug
@@ -203,6 +205,7 @@ async def create_collection(
         slug=slug,
         description=request.description,
         enabled=request.enabled,
+        workspace_id=ws_id,
     )
 
     await async_audit_logger.log(
@@ -405,12 +408,15 @@ async def list_documents(
     user: User = Depends(require_permission("wiki", "view")),
 ):
     """List knowledge base documents. Optionally filter by collection_id."""
+    _owner_id, ws_id = workspace_context(user, "wiki")
     synced = await _sync_disk_to_db()
 
     if collection_id is not None:
-        documents = await async_knowledge_doc_manager.get_by_collection(collection_id)
+        documents = await async_knowledge_doc_manager.get_by_collection(
+            collection_id, workspace_id=ws_id
+        )
     else:
-        documents = await async_knowledge_doc_manager.get_all()
+        documents = await async_knowledge_doc_manager.get_all(workspace_id=ws_id)
 
     return {"documents": documents, "synced": synced}
 
@@ -461,7 +467,7 @@ async def upload_document(
         title = first_header.group(1).strip()
 
     # Create DB record
-    owner_id = None if user_has_level(user, "wiki", "manage") else user.id
+    owner_id, ws_id = workspace_context(user, "wiki")
     doc = await async_knowledge_doc_manager.create(
         filename=filename,
         title=title,
@@ -470,6 +476,7 @@ async def upload_document(
         section_count=sections,
         owner_id=owner_id,
         collection_id=collection_id,
+        workspace_id=ws_id,
     )
 
     # Re-index global + collection

--- a/db/integration.py
+++ b/db/integration.py
@@ -357,17 +357,17 @@ class AsyncChatManager:
 class AsyncFAQManager:
     """Async FAQ manager using database with caching."""
 
-    async def get_all(self) -> Dict[str, str]:
+    async def get_all(self, workspace_id: Optional[int] = None) -> Dict[str, str]:
         """Get all FAQ as question->answer dict."""
         async with AsyncSessionLocal() as session:
             repo = FAQRepository(session)
-            return await repo.get_as_dict()
+            return await repo.get_as_dict(workspace_id=workspace_id)
 
-    async def get_all_entries(self) -> List[dict]:
+    async def get_all_entries(self, workspace_id: Optional[int] = None) -> List[dict]:
         """Get all FAQ entries with full details."""
         async with AsyncSessionLocal() as session:
             repo = FAQRepository(session)
-            return await repo.get_all_entries(enabled_only=False)
+            return await repo.get_all_entries(enabled_only=False, workspace_id=workspace_id)
 
     async def find_answer(self, question: str) -> Optional[str]:
         """Find exact match answer for question."""
@@ -375,13 +375,19 @@ class AsyncFAQManager:
             repo = FAQRepository(session)
             return await repo.find_answer(question)
 
-    async def add(self, question: str, answer: str) -> dict:
+    async def add(self, question: str, answer: str, workspace_id: Optional[int] = None) -> dict:
         """Add new FAQ entry."""
         async with AsyncSessionLocal() as session:
             repo = FAQRepository(session)
-            return await repo.create_entry(question, answer)
+            return await repo.create_entry(question, answer, workspace_id=workspace_id)
 
-    async def update(self, old_question: str, question: str, answer: str) -> Optional[dict]:
+    async def update(
+        self,
+        old_question: str,
+        question: str,
+        answer: str,
+        workspace_id: Optional[int] = None,
+    ) -> Optional[dict]:
         """Update FAQ entry."""
         async with AsyncSessionLocal() as session:
             repo = FAQRepository(session)
@@ -391,7 +397,7 @@ class AsyncFAQManager:
                 existing = await repo.get_by_question(old_question)
                 if existing:
                     await repo.delete_by_question(old_question)
-                return await repo.create_entry(question, answer)
+                return await repo.create_entry(question, answer, workspace_id=workspace_id)
             else:
                 existing = await repo.get_by_question(question)
                 if existing:
@@ -408,11 +414,11 @@ class AsyncFAQManager:
             repo = FAQRepository(session)
             return await repo.delete_by_question(question)
 
-    async def search(self, query: str) -> List[dict]:
+    async def search(self, query: str, workspace_id: Optional[int] = None) -> List[dict]:
         """Search FAQ entries."""
         async with AsyncSessionLocal() as session:
             repo = FAQRepository(session)
-            return await repo.search(query)
+            return await repo.search(query, workspace_id=workspace_id)
 
 
 # ============== Preset Manager ==============
@@ -1349,11 +1355,11 @@ class AsyncUserManager:
 class AsyncKnowledgeDocManager:
     """Async wrapper for KnowledgeDocumentRepository."""
 
-    async def get_all(self) -> List[dict]:
+    async def get_all(self, workspace_id: Optional[int] = None) -> List[dict]:
         """Get all knowledge documents."""
         async with AsyncSessionLocal() as session:
             repo = KnowledgeDocumentRepository(session)
-            return await repo.get_all_documents()
+            return await repo.get_all_documents(workspace_id=workspace_id)
 
     async def get_by_id(self, doc_id: int) -> Optional[dict]:
         """Get document by ID."""
@@ -1369,11 +1375,13 @@ class AsyncKnowledgeDocManager:
             doc = await repo.get_by_filename(filename)
             return doc.to_dict() if doc else None
 
-    async def get_by_collection(self, collection_id: int) -> List[dict]:
+    async def get_by_collection(
+        self, collection_id: int, workspace_id: Optional[int] = None
+    ) -> List[dict]:
         """Get all documents in a specific collection."""
         async with AsyncSessionLocal() as session:
             repo = KnowledgeDocumentRepository(session)
-            return await repo.get_by_collection(collection_id)
+            return await repo.get_by_collection(collection_id, workspace_id=workspace_id)
 
     async def create(
         self,
@@ -1384,6 +1392,7 @@ class AsyncKnowledgeDocManager:
         section_count: int = 0,
         owner_id: Optional[int] = None,
         collection_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> dict:
         """Create a knowledge document record."""
         async with AsyncSessionLocal() as session:
@@ -1396,6 +1405,7 @@ class AsyncKnowledgeDocManager:
                 section_count=section_count,
                 owner_id=owner_id,
                 collection_id=collection_id,
+                workspace_id=workspace_id,
             )
 
     async def update(
@@ -1426,11 +1436,15 @@ class AsyncKnowledgeDocManager:
 class AsyncKnowledgeCollectionManager:
     """Async wrapper for KnowledgeCollectionRepository."""
 
-    async def get_all(self, enabled_only: bool = False) -> List[dict]:
+    async def get_all(
+        self, enabled_only: bool = False, workspace_id: Optional[int] = None
+    ) -> List[dict]:
         """Get all collections."""
         async with AsyncSessionLocal() as session:
             repo = KnowledgeCollectionRepository(session)
-            return await repo.get_all_collections(enabled_only=enabled_only)
+            return await repo.get_all_collections(
+                enabled_only=enabled_only, workspace_id=workspace_id
+            )
 
     async def get_by_id(self, collection_id: int) -> Optional[dict]:
         """Get collection by ID with document count."""
@@ -1486,6 +1500,7 @@ class AsyncKnowledgeCollectionManager:
         description: Optional[str] = None,
         enabled: bool = True,
         base_dir: str = "wiki-pages",
+        workspace_id: Optional[int] = None,
     ) -> dict:
         """Create a collection."""
         async with AsyncSessionLocal() as session:
@@ -1496,6 +1511,7 @@ class AsyncKnowledgeCollectionManager:
                 description=description,
                 enabled=enabled,
                 base_dir=base_dir,
+                workspace_id=workspace_id,
             )
 
     async def update(

--- a/db/repositories/faq.py
+++ b/db/repositories/faq.py
@@ -20,34 +20,41 @@ class FAQRepository(BaseRepository[FAQEntry]):
     def __init__(self, session: AsyncSession):
         super().__init__(session, FAQEntry)
 
-    async def get_all_entries(self, enabled_only: bool = True) -> List[dict]:
-        """Get all FAQ entries."""
+    async def get_all_entries(
+        self, enabled_only: bool = True, workspace_id: Optional[int] = None
+    ) -> List[dict]:
+        """Get all FAQ entries, filtered by workspace."""
         query = select(FAQEntry).order_by(FAQEntry.question)
         if enabled_only:
             query = query.where(FAQEntry.enabled == True)
+        query = self._apply_workspace_filter(query, workspace_id)
 
         result = await self.session.execute(query)
         entries = result.scalars().all()
         return [e.to_dict() for e in entries]
 
-    async def get_as_dict(self) -> Dict[str, str]:
+    async def get_as_dict(self, workspace_id: Optional[int] = None) -> Dict[str, str]:
         """
         Get FAQ as question->answer dict for LLM matching.
-        Uses Redis cache for performance.
+        Uses Redis cache when no workspace filter.
         """
-        # Try cache first
-        cached = await get_cached_faq()
-        if cached:
-            return cached
+        # Try cache first (only when no workspace filter)
+        if workspace_id is None:
+            cached = await get_cached_faq()
+            if cached:
+                return cached
 
         # Fetch from database
-        result = await self.session.execute(select(FAQEntry).where(FAQEntry.enabled == True))
+        query = select(FAQEntry).where(FAQEntry.enabled == True)
+        query = self._apply_workspace_filter(query, workspace_id)
+        result = await self.session.execute(query)
         entries = result.scalars().all()
 
         faq_dict = {e.question: e.answer for e in entries}
 
-        # Cache for 10 minutes
-        await cache_faq(faq_dict, ttl_seconds=600)
+        # Cache for 10 minutes (only when no workspace filter)
+        if workspace_id is None:
+            await cache_faq(faq_dict, ttl_seconds=600)
 
         return faq_dict
 
@@ -84,8 +91,13 @@ class FAQRepository(BaseRepository[FAQEntry]):
         question: str,
         answer: str,
         keywords: Optional[List[str]] = None,
+        workspace_id: Optional[int] = None,
     ) -> dict:
         """Create new FAQ entry."""
+        create_kwargs: dict[str, Any] = {}
+        if workspace_id is not None:
+            create_kwargs["workspace_id"] = workspace_id
+
         entry = FAQEntry(
             question=question.lower().strip(),
             answer=answer,
@@ -94,6 +106,7 @@ class FAQRepository(BaseRepository[FAQEntry]):
             hit_count=0,
             created=datetime.utcnow(),
             updated=datetime.utcnow(),
+            **create_kwargs,
         )
 
         self.session.add(entry)
@@ -175,14 +188,16 @@ class FAQRepository(BaseRepository[FAQEntry]):
         """Export FAQ to legacy dict format."""
         return await self.get_as_dict()
 
-    async def search(self, query: str) -> List[dict]:
+    async def search(self, query: str, workspace_id: Optional[int] = None) -> List[dict]:
         """Search FAQ entries by question or answer content."""
         pattern = f"%{query.lower()}%"
-        result = await self.session.execute(
+        stmt = (
             select(FAQEntry)
             .where((FAQEntry.question.ilike(pattern)) | (FAQEntry.answer.ilike(pattern)))
             .order_by(FAQEntry.hit_count.desc())
         )
+        stmt = self._apply_workspace_filter(stmt, workspace_id)
+        result = await self.session.execute(stmt)
         entries = result.scalars().all()
         return [e.to_dict() for e in entries]
 

--- a/db/repositories/knowledge_collection.py
+++ b/db/repositories/knowledge_collection.py
@@ -2,7 +2,7 @@
 Repository for knowledge base collections.
 """
 
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -34,7 +34,9 @@ class KnowledgeCollectionRepository(BaseRepository[KnowledgeCollection]):
         )
         return result.scalar_one_or_none()
 
-    async def get_all_collections(self, enabled_only: bool = False) -> List[dict]:
+    async def get_all_collections(
+        self, enabled_only: bool = False, workspace_id: Optional[int] = None
+    ) -> List[dict]:
         """Get all collections ordered by name, with document count."""
         stmt = (
             select(
@@ -47,6 +49,8 @@ class KnowledgeCollectionRepository(BaseRepository[KnowledgeCollection]):
         )
         if enabled_only:
             stmt = stmt.where(KnowledgeCollection.enabled.is_(True))
+        if workspace_id is not None and hasattr(KnowledgeCollection, "workspace_id"):
+            stmt = stmt.where(KnowledgeCollection.workspace_id == workspace_id)
 
         result = await self.session.execute(stmt)
         collections = []
@@ -74,14 +78,20 @@ class KnowledgeCollectionRepository(BaseRepository[KnowledgeCollection]):
         description: Optional[str] = None,
         enabled: bool = True,
         base_dir: str = "wiki-pages",
+        workspace_id: Optional[int] = None,
     ) -> dict:
         """Create a new collection."""
+        create_kwargs: dict[str, Any] = {}
+        if workspace_id is not None:
+            create_kwargs["workspace_id"] = workspace_id
+
         col = KnowledgeCollection(
             name=name,
             slug=slug,
             description=description,
             enabled=enabled,
             base_dir=base_dir,
+            **create_kwargs,
         )
         self.session.add(col)
         await self.session.commit()

--- a/db/repositories/knowledge_document.py
+++ b/db/repositories/knowledge_document.py
@@ -2,7 +2,7 @@
 Repository for knowledge base documents.
 """
 
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,20 +24,24 @@ class KnowledgeDocumentRepository(BaseRepository[KnowledgeDocument]):
         )
         return result.scalar_one_or_none()
 
-    async def get_all_documents(self) -> List[dict]:
-        """Get all documents ordered by title."""
-        result = await self.session.execute(
-            select(KnowledgeDocument).order_by(KnowledgeDocument.title)
-        )
+    async def get_all_documents(self, workspace_id: Optional[int] = None) -> List[dict]:
+        """Get all documents ordered by title, filtered by workspace."""
+        query = select(KnowledgeDocument).order_by(KnowledgeDocument.title)
+        query = self._apply_workspace_filter(query, workspace_id)
+        result = await self.session.execute(query)
         return [doc.to_dict() for doc in result.scalars().all()]
 
-    async def get_by_collection(self, collection_id: int) -> List[dict]:
-        """Get all documents in a specific collection."""
-        result = await self.session.execute(
+    async def get_by_collection(
+        self, collection_id: int, workspace_id: Optional[int] = None
+    ) -> List[dict]:
+        """Get all documents in a specific collection, filtered by workspace."""
+        query = (
             select(KnowledgeDocument)
             .where(KnowledgeDocument.collection_id == collection_id)
             .order_by(KnowledgeDocument.title)
         )
+        query = self._apply_workspace_filter(query, workspace_id)
+        result = await self.session.execute(query)
         return [doc.to_dict() for doc in result.scalars().all()]
 
     async def get_filenames_by_collection(self, collection_id: int) -> List[str]:
@@ -58,8 +62,13 @@ class KnowledgeDocumentRepository(BaseRepository[KnowledgeDocument]):
         section_count: int = 0,
         owner_id: Optional[int] = None,
         collection_id: Optional[int] = None,
+        workspace_id: Optional[int] = None,
     ) -> dict:
         """Create a new document record."""
+        create_kwargs: dict[str, Any] = {}
+        if workspace_id is not None:
+            create_kwargs["workspace_id"] = workspace_id
+
         doc = KnowledgeDocument(
             filename=filename,
             title=title,
@@ -68,6 +77,7 @@ class KnowledgeDocumentRepository(BaseRepository[KnowledgeDocument]):
             section_count=section_count,
             owner_id=owner_id,
             collection_id=collection_id,
+            **create_kwargs,
         )
         self.session.add(doc)
         await self.session.commit()


### PR DESCRIPTION
## Summary

Closes #380

- Add `workspace_id` filtering to `FAQRepository` (get_all_entries, get_as_dict, create_entry, search)
- Add `workspace_id` filtering to `KnowledgeDocumentRepository` (get_all_documents, get_by_collection, create_document)
- Add `workspace_id` filtering to `KnowledgeCollectionRepository` (get_all_collections, create_collection)
- Passthrough `workspace_id` in `AsyncFAQManager`, `AsyncKnowledgeDocManager`, `AsyncKnowledgeCollectionManager`
- Add `workspace_context()` to `app/routers/faq.py` (get, add, update endpoints)
- Replace `user_has_level()` with `workspace_context()` in `app/routers/wiki_rag.py` (list collections, create collection, list/upload documents)

### Key decisions

- **FAQ Redis cache**: Skipped when `workspace_id` is set; cached only without filter (same pattern as `PresetRepository`)
- **System callers preserved**: `orchestrator.py` startup, `_reload_llm_faq()`, `finetune_manager.py` all call with `workspace_id=None` (no filter) — unchanged behavior
- **WikiRAGService in-memory indexes**: Untouched — global BM25/embedding indexes remain as-is
- **`_sync_disk_to_db()`**: System helper, no workspace filter — defaults to workspace 1 via DB column default
- **Collections outerjoin**: `get_all_collections()` uses manual `WHERE` instead of `_apply_workspace_filter()` because the query is a grouped outerjoin (not a simple `select(Model)`)

### Pattern applied
Same gate-check pattern as Chat (#376), Channels (#378), AI/LLM (#379):
- `_owner_id, ws_id = workspace_context(user, module)` in router
- `_apply_workspace_filter(query, workspace_id)` for SELECT queries
- `workspace_id` via `**create_kwargs` for CREATE

### Files changed (6)
| File | Changes |
|------|---------|
| `db/repositories/faq.py` | `workspace_id` on get_all_entries, get_as_dict, create_entry, search; cache bypass |
| `db/repositories/knowledge_document.py` | `workspace_id` on get_all_documents, get_by_collection, create_document |
| `db/repositories/knowledge_collection.py` | `workspace_id` on get_all_collections, create_collection |
| `db/integration.py` | Passthrough on 3 managers (FAQ, KnowledgeDoc, KnowledgeCollection) |
| `app/routers/faq.py` | `workspace_context` on get/add/update endpoints |
| `app/routers/wiki_rag.py` | `workspace_context` on list/create collections, list/upload documents; removed `user_has_level` |

## Test plan

- [ ] List FAQ — returns only workspace-scoped entries
- [ ] Create FAQ — sets workspace_id from JWT
- [ ] List collections — scoped by workspace
- [ ] Create collection — sets workspace_id from JWT
- [ ] List/upload documents — scoped by workspace
- [ ] System startup loads all FAQ/collections (no workspace filter)
- [ ] `_reload_llm_faq()` still loads global FAQ dict
- [ ] Ruff lint + format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)