### PR TITLE
feat(rbac): workspace_id filtering for Kanban, Claude Code, amoCRM

### DIFF
--- a/app/routers/amocrm.py
+++ b/app/routers/amocrm.py
@@ -41,7 +41,7 @@ from app.services.crm_dataset_service import (
     build_summary_document,
     clean_crm_files,
 )
-from auth_manager import User, require_permission
+from auth_manager import User, require_permission, workspace_context
 from db.integration import (
     async_amocrm_manager,
     async_audit_logger,
@@ -183,7 +183,8 @@ class SendChatMessageRequest(BaseModel):
 @router.get("/status")
 async def crm_status(user: User = Depends(require_permission("sales", "view"))):
     """Quick status: connected? token expired? last sync."""
-    config = await async_amocrm_manager.get_config()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await async_amocrm_manager.get_config(workspace_id=ws_id)
     if not config:
         return {
             "connected": False,
@@ -205,7 +206,8 @@ async def crm_status(user: User = Depends(require_permission("sales", "view"))):
 @router.get("/config")
 async def crm_get_config(user: User = Depends(require_permission("sales", "view"))):
     """Get amoCRM config (secrets masked)."""
-    config = await async_amocrm_manager.get_config()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await async_amocrm_manager.get_config(workspace_id=ws_id)
     return {"config": config or {}}
 
 
@@ -215,8 +217,9 @@ async def crm_save_config(
     user: User = Depends(require_permission("sales", "manage")),
 ):
     """Save OAuth credentials and sync settings."""
+    _owner_id, ws_id = workspace_context(user, "sales")
     kwargs = {k: v for k, v in request.model_dump().items() if v is not None}
-    config = await async_amocrm_manager.save_config(**kwargs)
+    config = await async_amocrm_manager.save_config(workspace_id=ws_id, **kwargs)
 
     await async_audit_logger.log(
         action="update",
@@ -331,7 +334,8 @@ async def crm_oauth_redirect(
 @router.post("/disconnect")
 async def crm_disconnect(user: User = Depends(require_permission("sales", "manage"))):
     """Clear tokens — disconnect from amoCRM."""
-    await async_amocrm_manager.clear_tokens()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    await async_amocrm_manager.clear_tokens(workspace_id=ws_id)
     await cache_delete_pattern(f"{CacheKey.AMOCRM}:*")
 
     await async_audit_logger.log(

--- a/app/routers/claude_code.py
+++ b/app/routers/claude_code.py
@@ -25,7 +25,7 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 
-from auth_manager import TokenPayload, decode_token, require_permission
+from auth_manager import TokenPayload, decode_token, require_permission, workspace_context
 
 
 router = APIRouter(prefix="/admin/claude-code", tags=["claude-code"])
@@ -455,9 +455,9 @@ async def claude_code_ws(websocket: WebSocket, token: str = ""):
             action = raw.get("action")
 
             if action == "start":
-                await _handle_start(websocket, user_id, raw)
+                await _handle_start(websocket, user_id, raw, payload.workspace_id)
             elif action == "message":
-                await _handle_message(websocket, user_id, raw)
+                await _handle_message(websocket, user_id, raw, payload.workspace_id)
             elif action == "abort":
                 await _handle_abort(user_id)
             else:
@@ -480,7 +480,7 @@ async def claude_code_ws(websocket: WebSocket, token: str = ""):
             shutil.rmtree(ctx_dir, ignore_errors=True)
 
 
-async def _handle_start(ws: WebSocket, user_id: int, raw: dict) -> None:
+async def _handle_start(ws: WebSocket, user_id: int, raw: dict, workspace_id: int = 1) -> None:
     """Handle 'start' action — new session."""
     from db.integration import async_claude_code_manager
 
@@ -499,7 +499,9 @@ async def _handle_start(ws: WebSocket, user_id: int, raw: dict) -> None:
 
     # Create DB session
     title = prompt[:50]
-    db_session = await async_claude_code_manager.create_session(title=title, owner_id=user_id)
+    db_session = await async_claude_code_manager.create_session(
+        title=title, owner_id=user_id, workspace_id=workspace_id
+    )
 
     await _send(ws, {"type": "session_created", "session": db_session})
 
@@ -519,7 +521,7 @@ async def _handle_start(ws: WebSocket, user_id: int, raw: dict) -> None:
         )
 
 
-async def _handle_message(ws: WebSocket, user_id: int, raw: dict) -> None:
+async def _handle_message(ws: WebSocket, user_id: int, raw: dict, workspace_id: int = 1) -> None:
     """Handle 'message' action — continue existing session."""
     from db.integration import async_claude_code_manager
 
@@ -544,7 +546,7 @@ async def _handle_message(ws: WebSocket, user_id: int, raw: dict) -> None:
     if not db_session_id and cli_session_id:
         # Create a follow-up entry
         db_session = await async_claude_code_manager.create_session(
-            title=prompt[:50], owner_id=user_id
+            title=prompt[:50], owner_id=user_id, workspace_id=workspace_id
         )
         db_session_id = db_session["id"]
         await async_claude_code_manager.update_session(db_session_id, cli_session_id=cli_session_id)
@@ -580,7 +582,8 @@ async def list_sessions(user=Depends(require_permission("claude_code", "manage")
     """List Claude Code sessions."""
     from db.integration import async_claude_code_manager
 
-    sessions = await async_claude_code_manager.list_sessions(owner_id=user.id)
+    _owner_id, ws_id = workspace_context(user, "claude_code")
+    sessions = await async_claude_code_manager.list_sessions(owner_id=user.id, workspace_id=ws_id)
     return {"sessions": sessions}
 
 

--- a/app/routers/kanban.py
+++ b/app/routers/kanban.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from auth_manager import User, require_permission, user_has_level
+from auth_manager import User, require_permission, user_has_level, workspace_context
 from db.integration import async_audit_logger, async_kanban_manager, async_kanban_project_manager
 
 
@@ -81,7 +81,8 @@ class ProjectUpdate(BaseModel):
 @router.get("/projects")
 async def get_projects(user: User = Depends(require_permission("kanban", "view"))):
     """Get all kanban projects."""
-    projects = await async_kanban_project_manager.get_all_projects()
+    _owner_id, ws_id = workspace_context(user, "kanban")
+    projects = await async_kanban_project_manager.get_all_projects(workspace_id=ws_id)
     return {"projects": projects}
 
 
@@ -90,11 +91,13 @@ async def create_project(
     request: ProjectCreate, user: User = Depends(require_permission("kanban", "manage"))
 ):
     """Create a new kanban project (admin only)."""
+    _owner_id, ws_id = workspace_context(user, "kanban")
     kwargs = {
         "name": request.name,
         "github_owner": request.github_owner,
         "github_repo": request.github_repo,
         "sync_enabled": request.sync_enabled,
+        "workspace_id": ws_id,
     }
     if request.github_token:
         kwargs["github_token"] = request.github_token
@@ -212,9 +215,10 @@ async def get_tasks(
     project_id: Optional[int] = Query(None),
 ):
     """Get tasks visible to the current user, optionally filtered by project."""
+    _owner_id, ws_id = workspace_context(user, "kanban")
     is_admin = user_has_level(user, "kanban", "manage")
     tasks = await async_kanban_manager.get_visible_tasks_for_project(
-        project_id, user.username, is_admin
+        project_id, user.username, is_admin, workspace_id=ws_id
     )
     return {"tasks": tasks}
 
@@ -224,6 +228,7 @@ async def create_task(
     request: TaskCreate, user: User = Depends(require_permission("kanban", "edit"))
 ):
     """Create a new task (always draft + private)."""
+    _owner_id, ws_id = workspace_context(user, "kanban")
     tags_json = json.dumps(request.tags, ensure_ascii=False) if request.tags else None
     task = await async_kanban_manager.create_task(
         title=request.title,
@@ -233,6 +238,7 @@ async def create_task(
         due_date=request.due_date,
         tags=tags_json,
         created_by=user.username,
+        workspace_id=ws_id,
     )
     await async_audit_logger.log(
         action="create",

--- a/db/integration.py
+++ b/db/integration.py
@@ -1064,17 +1064,19 @@ class AsyncPaymentManager:
 class AsyncAmoCRMManager:
     """Async wrapper for amoCRM config and sync log repositories."""
 
-    async def get_config(self) -> Optional[dict]:
+    async def get_config(self, workspace_id: Optional[int] = None) -> Optional[dict]:
         """Get amoCRM config (secrets masked)."""
         async with AsyncSessionLocal() as session:
             repo = AmoCRMConfigRepository(session)
-            return await repo.get_config()
+            return await repo.get_config(workspace_id=workspace_id)
 
-    async def get_config_with_secrets(self) -> Optional[Dict[str, Any]]:
+    async def get_config_with_secrets(
+        self, workspace_id: Optional[int] = None
+    ) -> Optional[Dict[str, Any]]:
         """Get raw config model for internal use (tokens, secrets)."""
         async with AsyncSessionLocal() as session:
             repo = AmoCRMConfigRepository(session)
-            model = await repo.get_config_with_secrets()
+            model = await repo.get_config_with_secrets(workspace_id=workspace_id)
             if not model:
                 return None
             result = model.to_dict(include_secrets=True)
@@ -1085,17 +1087,17 @@ class AsyncAmoCRMManager:
             )
             return result
 
-    async def save_config(self, **kwargs: Any) -> dict:
+    async def save_config(self, workspace_id: Optional[int] = None, **kwargs: Any) -> dict:
         """Create or update amoCRM config."""
         async with AsyncSessionLocal() as session:
             repo = AmoCRMConfigRepository(session)
-            return await repo.save_config(**kwargs)
+            return await repo.save_config(workspace_id=workspace_id, **kwargs)
 
-    async def clear_tokens(self) -> dict:
+    async def clear_tokens(self, workspace_id: Optional[int] = None) -> dict:
         """Clear OAuth tokens (disconnect)."""
         async with AsyncSessionLocal() as session:
             repo = AmoCRMConfigRepository(session)
-            return await repo.clear_tokens()
+            return await repo.clear_tokens(workspace_id=workspace_id)
 
     async def log_sync(self, **kwargs: Any) -> dict:
         """Log a sync event."""
@@ -1652,10 +1654,17 @@ class AsyncChatShareManager:
 class AsyncClaudeCodeManager:
     """Manager for Claude Code session CRUD."""
 
-    async def list_sessions(self, owner_id: Optional[int] = None, limit: int = 50) -> List[dict]:
+    async def list_sessions(
+        self,
+        owner_id: Optional[int] = None,
+        limit: int = 50,
+        workspace_id: Optional[int] = None,
+    ) -> List[dict]:
         async with AsyncSessionLocal() as session:
             repo = ClaudeCodeRepository(session)
-            return await repo.list_sessions(owner_id=owner_id, limit=limit)
+            return await repo.list_sessions(
+                owner_id=owner_id, limit=limit, workspace_id=workspace_id
+            )
 
     async def get_session(self, session_id: str) -> Optional[dict]:
         async with AsyncSessionLocal() as session:
@@ -1667,10 +1676,13 @@ class AsyncClaudeCodeManager:
         title: str,
         owner_id: int,
         working_directory: str = "/opt/ai-secretary",
+        workspace_id: Optional[int] = None,
     ) -> dict:
         async with AsyncSessionLocal() as session:
             repo = ClaudeCodeRepository(session)
-            return await repo.create_session(title, owner_id, working_directory)
+            return await repo.create_session(
+                title, owner_id, working_directory, workspace_id=workspace_id
+            )
 
     async def update_session(self, session_id: str, **kwargs) -> Optional[dict]:
         async with AsyncSessionLocal() as session:
@@ -1759,10 +1771,15 @@ async_claude_code_manager = AsyncClaudeCodeManager()
 class AsyncKanbanManager:
     """Async kanban task manager."""
 
-    async def get_visible_tasks(self, current_user: str, is_admin: bool) -> list:
+    async def get_visible_tasks(
+        self,
+        current_user: str,
+        is_admin: bool,
+        workspace_id: Optional[int] = None,
+    ) -> list:
         async with AsyncSessionLocal() as session:
             repo = KanbanRepository(session)
-            return await repo.get_visible_tasks(current_user, is_admin)
+            return await repo.get_visible_tasks(current_user, is_admin, workspace_id=workspace_id)
 
     async def get_task(self, task_id: int) -> Optional[dict]:
         async with AsyncSessionLocal() as session:
@@ -1816,11 +1833,17 @@ class AsyncKanbanManager:
             return await repo.delete_checklist_item(item_id)
 
     async def get_visible_tasks_for_project(
-        self, project_id, current_user: str, is_admin: bool
+        self,
+        project_id,
+        current_user: str,
+        is_admin: bool,
+        workspace_id: Optional[int] = None,
     ) -> list:
         async with AsyncSessionLocal() as session:
             repo = KanbanRepository(session)
-            return await repo.get_visible_tasks_for_project(project_id, current_user, is_admin)
+            return await repo.get_visible_tasks_for_project(
+                project_id, current_user, is_admin, workspace_id=workspace_id
+            )
 
     async def find_by_github_issue(self, project_id: int, issue_number: int):
         async with AsyncSessionLocal() as session:
@@ -1843,10 +1866,10 @@ async_kanban_manager = AsyncKanbanManager()
 class AsyncKanbanProjectManager:
     """Async kanban project manager."""
 
-    async def get_all_projects(self) -> list:
+    async def get_all_projects(self, workspace_id: Optional[int] = None) -> list:
         async with AsyncSessionLocal() as session:
             repo = KanbanProjectRepository(session)
-            return await repo.get_all_projects()
+            return await repo.get_all_projects(workspace_id=workspace_id)
 
     async def get_project(self, project_id: int) -> Optional[dict]:
         async with AsyncSessionLocal() as session:

--- a/db/repositories/amocrm.py
+++ b/db/repositories/amocrm.py
@@ -21,20 +21,35 @@ class AmoCRMConfigRepository(BaseRepository[AmoCRMConfig]):
     def __init__(self, session: AsyncSession):
         super().__init__(session, AmoCRMConfig)
 
-    async def get_config(self) -> Optional[dict]:
-        """Get the singleton config row (id=1), masked secrets."""
-        config = await self.session.get(AmoCRMConfig, 1)
-        return config.to_dict() if config else None
-
-    async def get_config_with_secrets(self) -> Optional[AmoCRMConfig]:
-        """Get raw model for internal use (tokens, secrets)."""
+    async def _get_config_entity(
+        self, workspace_id: Optional[int] = None
+    ) -> Optional[AmoCRMConfig]:
+        """Get config entity, optionally filtered by workspace_id."""
+        if workspace_id is not None:
+            query = select(AmoCRMConfig).where(AmoCRMConfig.workspace_id == workspace_id)
+            result = await self.session.execute(query)
+            return result.scalar_one_or_none()
         return await self.session.get(AmoCRMConfig, 1)
 
-    async def save_config(self, **kwargs: Any) -> dict:
-        """Create or update the singleton config."""
-        config = await self.session.get(AmoCRMConfig, 1)
+    async def get_config(self, workspace_id: Optional[int] = None) -> Optional[dict]:
+        """Get config row, masked secrets."""
+        config = await self._get_config_entity(workspace_id)
+        return config.to_dict() if config else None
+
+    async def get_config_with_secrets(
+        self, workspace_id: Optional[int] = None
+    ) -> Optional[AmoCRMConfig]:
+        """Get raw model for internal use (tokens, secrets)."""
+        return await self._get_config_entity(workspace_id)
+
+    async def save_config(self, workspace_id: Optional[int] = None, **kwargs: Any) -> dict:
+        """Create or update config."""
+        config = await self._get_config_entity(workspace_id)
         if not config:
-            config = AmoCRMConfig(id=1)
+            create_kwargs: dict = {"id": 1}
+            if workspace_id is not None:
+                create_kwargs["workspace_id"] = workspace_id
+            config = AmoCRMConfig(**create_kwargs)
             self.session.add(config)
 
         simple_fields = [
@@ -69,9 +84,9 @@ class AmoCRMConfigRepository(BaseRepository[AmoCRMConfig]):
         await self.session.refresh(config)
         return config.to_dict()
 
-    async def clear_tokens(self) -> dict:
+    async def clear_tokens(self, workspace_id: Optional[int] = None) -> dict:
         """Clear OAuth tokens (disconnect)."""
-        config = await self.session.get(AmoCRMConfig, 1)
+        config = await self._get_config_entity(workspace_id)
         if config:
             config.access_token = None
             config.refresh_token = None

--- a/db/repositories/claude_code.py
+++ b/db/repositories/claude_code.py
@@ -15,8 +15,14 @@ class ClaudeCodeRepository(BaseRepository[ClaudeCodeSession]):
     def __init__(self, session: AsyncSession):
         super().__init__(session, ClaudeCodeSession)
 
-    async def list_sessions(self, owner_id: Optional[int] = None, limit: int = 50) -> List[dict]:
+    async def list_sessions(
+        self,
+        owner_id: Optional[int] = None,
+        limit: int = 50,
+        workspace_id: Optional[int] = None,
+    ) -> List[dict]:
         query = select(ClaudeCodeSession).order_by(ClaudeCodeSession.updated.desc())
+        query = self._apply_workspace_filter(query, workspace_id)
         if owner_id is not None:
             query = query.where(ClaudeCodeSession.owner_id == owner_id)
         query = query.limit(limit)
@@ -32,14 +38,18 @@ class ClaudeCodeRepository(BaseRepository[ClaudeCodeSession]):
         title: str,
         owner_id: int,
         working_directory: str = "/opt/ai-secretary",
+        workspace_id: Optional[int] = None,
     ) -> dict:
         session_id = f"cc-{uuid.uuid4().hex[:12]}"
-        entity = ClaudeCodeSession(
+        create_kwargs: dict = dict(
             id=session_id,
             title=title[:50] if title else "New session",
             owner_id=owner_id,
             working_directory=working_directory,
         )
+        if workspace_id is not None:
+            create_kwargs["workspace_id"] = workspace_id
+        entity = ClaudeCodeSession(**create_kwargs)
         self.session.add(entity)
         await self.session.commit()
         await self.session.refresh(entity)

--- a/db/repositories/kanban.py
+++ b/db/repositories/kanban.py
@@ -31,16 +31,27 @@ class KanbanRepository(BaseRepository[KanbanTask]):
         )
         return result.scalar_one_or_none()
 
-    async def get_visible_tasks(self, current_user: str, is_admin: bool) -> List[dict]:
+    async def get_visible_tasks(
+        self,
+        current_user: str,
+        is_admin: bool,
+        workspace_id: Optional[int] = None,
+    ) -> List[dict]:
         """Get tasks visible to the user (local tasks only, project_id IS NULL).
 
         Admin sees all tasks.
         Others see their own tasks + non-draft public tasks.
         """
-        return await self.get_visible_tasks_for_project(None, current_user, is_admin)
+        return await self.get_visible_tasks_for_project(
+            None, current_user, is_admin, workspace_id=workspace_id
+        )
 
     async def get_visible_tasks_for_project(
-        self, project_id: Optional[int], current_user: str, is_admin: bool
+        self,
+        project_id: Optional[int],
+        current_user: str,
+        is_admin: bool,
+        workspace_id: Optional[int] = None,
     ) -> List[dict]:
         """Get tasks visible to the user, filtered by project.
 
@@ -48,6 +59,7 @@ class KanbanRepository(BaseRepository[KanbanTask]):
         project_id=N -> tasks for that project
         """
         stmt = select(KanbanTask).options(*self._load_options())
+        stmt = self._apply_workspace_filter(stmt, workspace_id)
 
         if project_id is None:
             stmt = stmt.where(KanbanTask.project_id.is_(None))
@@ -74,9 +86,10 @@ class KanbanRepository(BaseRepository[KanbanTask]):
         start_date: Optional[str] = None,
         due_date: Optional[str] = None,
         tags: Optional[str] = None,
+        workspace_id: Optional[int] = None,
     ) -> dict:
         """Create a new task (always draft + private)."""
-        task = KanbanTask(
+        create_kwargs: dict = dict(
             title=title,
             description=description,
             status="draft",
@@ -87,6 +100,9 @@ class KanbanRepository(BaseRepository[KanbanTask]):
             due_date=due_date,
             tags=tags,
         )
+        if workspace_id is not None:
+            create_kwargs["workspace_id"] = workspace_id
+        task = KanbanTask(**create_kwargs)
         self.session.add(task)
         await self.session.commit()
         task = await self.get_task_with_relations(task.id)

--- a/db/repositories/kanban_project.py
+++ b/db/repositories/kanban_project.py
@@ -16,9 +16,11 @@ class KanbanProjectRepository(BaseRepository[KanbanProject]):
     def __init__(self, session: AsyncSession):
         super().__init__(session, KanbanProject)
 
-    async def get_all_projects(self) -> List[dict]:
+    async def get_all_projects(self, workspace_id: Optional[int] = None) -> List[dict]:
         """Get all projects (safe dict, no token exposed)."""
-        result = await self.session.execute(select(KanbanProject).order_by(KanbanProject.name))
+        query = select(KanbanProject).order_by(KanbanProject.name)
+        query = self._apply_workspace_filter(query, workspace_id)
+        result = await self.session.execute(query)
         return [p.to_dict() for p in result.scalars().all()]
 
     async def get_project_with_token(self, project_id: int) -> Optional[KanbanProject]:


### PR DESCRIPTION
## Summary

Closes #381 — Sub-task 6c-5 of workspace-aware queries (#365).

- **Kanban** (`kanban_tasks`, `kanban_projects`): `workspace_id` filtering on `get_visible_tasks_for_project()`, `get_all_projects()`, and `create_task()`/`create_project()`. `user_has_level` kept for admin visibility logic alongside `workspace_context`.
- **Claude Code** (`claude_code_sessions`): `workspace_id` on `list_sessions()` and `create_session()`. WebSocket handler passes `payload.workspace_id` from JWT.
- **amoCRM** (`amocrm_config`): Converted singleton `session.get(id=1)` to workspace-scoped query via `_get_config_entity()`. Endpoints without JWT (OAuth redirect, webhooks) remain unscoped.
- **Audit** tables excluded (no `workspace_id` column — out of scope).

8 files changed, +131/−52. Safe noop: `workspace_id=None` means no filter, all existing data has `workspace_id=1`.

## Test plan

- [ ] Verify kanban task/project list and create respect workspace_id
- [ ] Verify Claude Code session list scoped by workspace
- [ ] Verify amoCRM config CRUD workspace isolation
- [ ] Verify system callers (OAuth, webhooks, GitHub sync) still work with workspace_id=None

🤖 Generated with [Claude Code](https://claude.com/claude-code)