### PR TITLE
feat(rbac): finalize workspace_id coverage (#382)

### DIFF
--- a/app/routers/amocrm.py
+++ b/app/routers/amocrm.py
@@ -60,13 +60,13 @@ webhook_router = APIRouter(tags=["amocrm-webhook"])
 # ============== Helpers ==============
 
 
-async def _get_valid_token() -> dict:
+async def _get_valid_token(workspace_id: Optional[int] = None) -> dict:
     """Get config with a valid access token; auto-refresh if expired.
 
     Returns full config dict with fresh tokens.
     Raises HTTPException if not connected or refresh fails.
     """
-    config = await async_amocrm_manager.get_config_with_secrets()
+    config = await async_amocrm_manager.get_config_with_secrets(workspace_id=workspace_id)
     if not config or not config.get("access_token"):
         raise HTTPException(status_code=400, detail="amoCRM not connected")
 
@@ -106,6 +106,7 @@ async def _get_valid_token() -> dict:
         new_expires = datetime.utcnow() + timedelta(seconds=expires_in)
 
         await async_amocrm_manager.save_config(
+            workspace_id=workspace_id,
             access_token=tokens["access_token"],
             refresh_token=tokens["refresh_token"],
             token_expires_at=new_expires,
@@ -238,7 +239,8 @@ async def crm_auth_url(
     request: Request, user: User = Depends(require_permission("sales", "manage"))
 ):
     """Build OAuth authorization URL for amoCRM."""
-    config = await async_amocrm_manager.get_config_with_secrets()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await async_amocrm_manager.get_config_with_secrets(workspace_id=ws_id)
     if not config or not config.get("client_id"):
         raise HTTPException(status_code=400, detail="Client ID not configured")
 
@@ -357,7 +359,8 @@ async def crm_disconnect(user: User = Depends(require_permission("sales", "manag
 @router.post("/test")
 async def crm_test_connection(user: User = Depends(require_permission("sales", "edit"))):
     """Test connection by fetching account info."""
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     try:
         account = await get_account_info(config["subdomain"], config["access_token"])
         return {"status": "ok", "account": account}
@@ -368,7 +371,8 @@ async def crm_test_connection(user: User = Depends(require_permission("sales", "
 @router.post("/refresh-token")
 async def crm_force_refresh_token(user: User = Depends(require_permission("sales", "manage"))):
     """Force token refresh."""
-    config = await async_amocrm_manager.get_config_with_secrets()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await async_amocrm_manager.get_config_with_secrets(workspace_id=ws_id)
     if not config or not config.get("refresh_token"):
         raise HTTPException(status_code=400, detail="No refresh token available")
 
@@ -387,6 +391,7 @@ async def crm_force_refresh_token(user: User = Depends(require_permission("sales
     expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
 
     await async_amocrm_manager.save_config(
+        workspace_id=ws_id,
         access_token=tokens["access_token"],
         refresh_token=tokens["refresh_token"],
         token_expires_at=expires_at,
@@ -405,7 +410,8 @@ async def crm_get_contacts(
     user: User = Depends(require_permission("sales", "view")),
 ):
     """List contacts from amoCRM (proxied)."""
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     try:
         data = await get_contacts(config["subdomain"], config["access_token"], page, limit, query)
         return data
@@ -419,7 +425,8 @@ async def crm_create_contact(
     user: User = Depends(require_permission("sales", "edit")),
 ):
     """Create a contact in amoCRM."""
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     try:
         result = await create_contact(
             config["subdomain"],
@@ -451,7 +458,8 @@ async def crm_get_leads(
     user: User = Depends(require_permission("sales", "view")),
 ):
     """List leads from amoCRM (proxied)."""
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     try:
         data = await get_leads(config["subdomain"], config["access_token"], page, limit, query)
         return data
@@ -465,7 +473,8 @@ async def crm_create_lead(
     user: User = Depends(require_permission("sales", "edit")),
 ):
     """Create a lead in amoCRM."""
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     try:
         result = await create_lead(
             config["subdomain"],
@@ -498,7 +507,8 @@ async def crm_add_note_to_lead(
     user: User = Depends(require_permission("sales", "edit")),
 ):
     """Add a note to a lead."""
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     try:
         result = await add_note_to_lead(
             config["subdomain"],
@@ -520,7 +530,8 @@ async def crm_get_leads_by_pipeline(
     user: User = Depends(require_permission("sales", "view")),
 ):
     """Get all leads in a specific pipeline (for kanban board)."""
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     subdomain = _get_subdomain(config)
     cache_key = f"{CacheKey.AMOCRM}:pipeline_leads:{subdomain}:{pipeline_id}"
     cached = await cache_get(cache_key)
@@ -541,7 +552,8 @@ async def crm_get_unsorted_leads(
     user: User = Depends(require_permission("sales", "view")),
 ):
     """Get unsorted (incoming) leads, paginated."""
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     subdomain = _get_subdomain(config)
     cache_key = f"{CacheKey.AMOCRM}:unsorted:{subdomain}:{page}:{limit}"
     cached = await cache_get(cache_key)
@@ -563,7 +575,8 @@ async def crm_get_lead(
     user: User = Depends(require_permission("sales", "view")),
 ):
     """Get single lead detail with contacts."""
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     subdomain = _get_subdomain(config)
     cache_key = f"{CacheKey.AMOCRM}:lead:{subdomain}:{lead_id}"
     cached = await cache_get(cache_key)
@@ -586,7 +599,8 @@ async def crm_update_lead(
     user: User = Depends(require_permission("sales", "edit")),
 ):
     """Update a lead (status, pipeline, name, price)."""
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     update_data = {k: v for k, v in request.model_dump().items() if v is not None}
     if not update_data:
         raise HTTPException(status_code=400, detail="No fields to update")
@@ -623,7 +637,8 @@ async def crm_get_events(
     user: User = Depends(require_permission("sales", "view")),
 ):
     """Get events feed (chat messages, lead changes, etc.)."""
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     try:
         data = await get_events(config["subdomain"], config["access_token"], page, limit, types)
         return data
@@ -640,7 +655,8 @@ async def crm_get_contact_chats(
     user: User = Depends(require_permission("sales", "view")),
 ):
     """Get chats linked to a contact."""
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     try:
         data = await get_contact_chats(config["subdomain"], config["access_token"], contact_id)
         return data
@@ -659,7 +675,8 @@ async def crm_get_chat_history(
     user: User = Depends(require_permission("sales", "view")),
 ):
     """Get chat message history via amojo API."""
-    config = await async_amocrm_manager.get_config_with_secrets()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await async_amocrm_manager.get_config_with_secrets(workspace_id=ws_id)
     if not config:
         raise HTTPException(status_code=400, detail="amoCRM not configured")
 
@@ -686,7 +703,8 @@ async def crm_send_chat_message(
     user: User = Depends(require_permission("sales", "edit")),
 ):
     """Send a chat message via amojo API."""
-    config = await async_amocrm_manager.get_config_with_secrets()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await async_amocrm_manager.get_config_with_secrets(workspace_id=ws_id)
     if not config:
         raise HTTPException(status_code=400, detail="amoCRM not configured")
 
@@ -726,7 +744,8 @@ async def crm_send_chat_message(
 @router.get("/pipelines")
 async def crm_get_pipelines(user: User = Depends(require_permission("sales", "view"))):
     """List pipelines with their statuses."""
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     subdomain = _get_subdomain(config)
     cache_key = f"{CacheKey.AMOCRM}:pipelines:{subdomain}"
     cached = await cache_get(cache_key)
@@ -746,7 +765,8 @@ async def crm_get_pipelines(user: User = Depends(require_permission("sales", "vi
 @router.post("/sync")
 async def crm_sync(user: User = Depends(require_permission("sales", "edit"))):
     """Manual sync — fetch counts from amoCRM and update local stats."""
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     subdomain = config["subdomain"]
     access_token = config["access_token"]
 
@@ -768,6 +788,7 @@ async def crm_sync(user: User = Depends(require_permission("sales", "edit"))):
         pass
 
     await async_amocrm_manager.save_config(
+        workspace_id=ws_id,
         contacts_count=contacts_count,
         leads_count=leads_count,
         last_sync_at=datetime.utcnow(),
@@ -811,7 +832,8 @@ async def crm_dataset_sync(user: User = Depends(require_permission("sales", "edi
     Fetches all pipelines + leads, generates markdown documents,
     writes to data/crm-dataset/, updates knowledge collection + re-indexes.
     """
-    config = await _get_valid_token()
+    _owner_id, ws_id = workspace_context(user, "sales")
+    config = await _get_valid_token(workspace_id=ws_id)
     subdomain = config["subdomain"]
     access_token = config["access_token"]
 

--- a/app/routers/claude_code.py
+++ b/app/routers/claude_code.py
@@ -592,7 +592,8 @@ async def get_session(session_id: str, user=Depends(require_permission("claude_c
     """Get a specific Claude Code session."""
     from db.integration import async_claude_code_manager
 
-    session = await async_claude_code_manager.get_session(session_id)
+    _owner_id, ws_id = workspace_context(user, "claude_code")
+    session = await async_claude_code_manager.get_session(session_id, workspace_id=ws_id)
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
     return {"session": session}
@@ -605,7 +606,8 @@ async def delete_session(
     """Delete a Claude Code session."""
     from db.integration import async_claude_code_manager
 
-    deleted = await async_claude_code_manager.delete_session(session_id)
+    _owner_id, ws_id = workspace_context(user, "claude_code")
+    deleted = await async_claude_code_manager.delete_session(session_id, workspace_id=ws_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Session not found")
     return {"status": "deleted"}

--- a/app/routers/faq.py
+++ b/app/routers/faq.py
@@ -90,7 +90,8 @@ async def admin_update_faq(
 @router.delete("/{trigger}")
 async def admin_delete_faq(trigger: str, user: User = Depends(require_permission("faq", "edit"))):
     """Удалить FAQ запись"""
-    if not await async_faq_manager.delete(trigger):
+    _owner_id, ws_id = workspace_context(user, "faq")
+    if not await async_faq_manager.delete(trigger, workspace_id=ws_id):
         raise HTTPException(status_code=404, detail=f"Trigger not found: {trigger}")
 
     # Audit log

--- a/app/routers/kanban.py
+++ b/app/routers/kanban.py
@@ -123,7 +123,8 @@ async def update_project(
     user: User = Depends(require_permission("kanban", "manage")),
 ):
     """Update a kanban project (admin only)."""
-    existing = await async_kanban_project_manager.get_project(project_id)
+    _owner_id, ws_id = workspace_context(user, "kanban")
+    existing = await async_kanban_project_manager.get_project(project_id, workspace_id=ws_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Project not found")
 
@@ -158,7 +159,8 @@ async def delete_project(
     project_id: int, user: User = Depends(require_permission("kanban", "manage"))
 ):
     """Delete a kanban project (admin only)."""
-    existing = await async_kanban_project_manager.get_project(project_id)
+    _owner_id, ws_id = workspace_context(user, "kanban")
+    existing = await async_kanban_project_manager.get_project(project_id, workspace_id=ws_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Project not found")
 
@@ -175,7 +177,8 @@ async def delete_project(
 @router.post("/projects/{project_id}/sync")
 async def sync_project(project_id: int, user: User = Depends(require_permission("kanban", "edit"))):
     """Trigger full sync of GitHub issues for a project."""
-    existing = await async_kanban_project_manager.get_project(project_id)
+    _owner_id, ws_id = workspace_context(user, "kanban")
+    existing = await async_kanban_project_manager.get_project(project_id, workspace_id=ws_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Project not found")
 
@@ -257,7 +260,8 @@ async def update_task(
     user: User = Depends(require_permission("kanban", "edit")),
 ):
     """Update a task. Non-admin can only edit own tasks."""
-    existing = await async_kanban_manager.get_task(task_id)
+    _owner_id, ws_id = workspace_context(user, "kanban")
+    existing = await async_kanban_manager.get_task(task_id, workspace_id=ws_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Task not found")
 
@@ -304,7 +308,8 @@ async def update_task(
 @router.delete("/tasks/{task_id}")
 async def delete_task(task_id: int, user: User = Depends(require_permission("kanban", "manage"))):
     """Delete a task (admin only)."""
-    existing = await async_kanban_manager.get_task(task_id)
+    _owner_id, ws_id = workspace_context(user, "kanban")
+    existing = await async_kanban_manager.get_task(task_id, workspace_id=ws_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Task not found")
 
@@ -328,8 +333,9 @@ async def reorder_task(
     user: User = Depends(require_permission("kanban", "edit")),
 ):
     """Reorder a task (update status + position)."""
+    _owner_id, ws_id = workspace_context(user, "kanban")
     # Get existing task before reorder (for GitHub push check)
-    existing = await async_kanban_manager.get_task(request.task_id)
+    existing = await async_kanban_manager.get_task(request.task_id, workspace_id=ws_id)
 
     task = await async_kanban_manager.reorder(
         request.task_id, request.new_status, request.new_position
@@ -353,8 +359,9 @@ async def add_dependency(
     request: DependencyCreate, user: User = Depends(require_permission("kanban", "edit"))
 ):
     """Add a dependency between tasks."""
+    _owner_id, ws_id = workspace_context(user, "kanban")
     # Check target task exists and is not private
-    target = await async_kanban_manager.get_task(request.blocker_id)
+    target = await async_kanban_manager.get_task(request.blocker_id, workspace_id=ws_id)
     if not target:
         raise HTTPException(status_code=404, detail="Blocker task not found")
     if (
@@ -364,7 +371,7 @@ async def add_dependency(
     ):
         raise HTTPException(status_code=409, detail="Cannot depend on a private task")
 
-    dependent = await async_kanban_manager.get_task(request.dependent_id)
+    dependent = await async_kanban_manager.get_task(request.dependent_id, workspace_id=ws_id)
     if not dependent:
         raise HTTPException(status_code=404, detail="Dependent task not found")
 
@@ -399,7 +406,8 @@ async def add_checklist_item(
     user: User = Depends(require_permission("kanban", "edit")),
 ):
     """Add a checklist item to a task."""
-    existing = await async_kanban_manager.get_task(task_id)
+    _owner_id, ws_id = workspace_context(user, "kanban")
+    existing = await async_kanban_manager.get_task(task_id, workspace_id=ws_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Task not found")
 

--- a/app/routers/wiki_rag.py
+++ b/app/routers/wiki_rag.py
@@ -224,7 +224,10 @@ async def get_collection(
     collection_id: int, user: User = Depends(require_permission("wiki", "view"))
 ):
     """Get a single knowledge collection."""
-    collection = await async_knowledge_collection_manager.get_by_id(collection_id)
+    _owner_id, ws_id = workspace_context(user, "wiki")
+    collection = await async_knowledge_collection_manager.get_by_id(
+        collection_id, workspace_id=ws_id
+    )
     if not collection:
         raise HTTPException(status_code=404, detail="Коллекция не найдена")
     return {"collection": collection}
@@ -237,7 +240,10 @@ async def update_collection(
     user: User = Depends(require_permission("wiki", "edit")),
 ):
     """Update a knowledge collection."""
-    collection = await async_knowledge_collection_manager.get_by_id(collection_id)
+    _owner_id, ws_id = workspace_context(user, "wiki")
+    collection = await async_knowledge_collection_manager.get_by_id(
+        collection_id, workspace_id=ws_id
+    )
     if not collection:
         raise HTTPException(status_code=404, detail="Коллекция не найдена")
 
@@ -264,7 +270,10 @@ async def delete_collection(
     user: User = Depends(require_permission("wiki", "edit")),
 ):
     """Delete a knowledge collection. Cannot delete 'default'."""
-    collection = await async_knowledge_collection_manager.get_by_id(collection_id)
+    _owner_id, ws_id = workspace_context(user, "wiki")
+    collection = await async_knowledge_collection_manager.get_by_id(
+        collection_id, workspace_id=ws_id
+    )
     if not collection:
         raise HTTPException(status_code=404, detail="Коллекция не найдена")
 
@@ -298,7 +307,10 @@ async def reload_collection_index(
     if not wiki_rag:
         raise HTTPException(status_code=503, detail="Wiki RAG сервис не инициализирован")
 
-    collection = await async_knowledge_collection_manager.get_by_id(collection_id)
+    _owner_id, ws_id = workspace_context(user, "wiki")
+    collection = await async_knowledge_collection_manager.get_by_id(
+        collection_id, workspace_id=ws_id
+    )
     if not collection:
         raise HTTPException(status_code=404, detail="Коллекция не найдена")
 
@@ -504,7 +516,8 @@ async def upload_document(
 @router.get("/documents/{doc_id}")
 async def get_document(doc_id: int, user: User = Depends(require_permission("wiki", "view"))):
     """Get document metadata + content preview."""
-    doc = await async_knowledge_doc_manager.get_by_id(doc_id)
+    _owner_id, ws_id = workspace_context(user, "wiki")
+    doc = await async_knowledge_doc_manager.get_by_id(doc_id, workspace_id=ws_id)
     if not doc:
         raise HTTPException(status_code=404, detail="Документ не найден")
 
@@ -528,7 +541,8 @@ async def update_document(
     user: User = Depends(require_permission("wiki", "edit")),
 ):
     """Update document title and/or content."""
-    doc = await async_knowledge_doc_manager.get_by_id(doc_id)
+    _owner_id, ws_id = workspace_context(user, "wiki")
+    doc = await async_knowledge_doc_manager.get_by_id(doc_id, workspace_id=ws_id)
     if not doc:
         raise HTTPException(status_code=404, detail="Документ не найден")
 
@@ -573,7 +587,8 @@ async def update_document(
 @router.delete("/documents/{doc_id}")
 async def delete_document(doc_id: int, user: User = Depends(require_permission("wiki", "edit"))):
     """Delete document from disk and DB, re-index."""
-    doc = await async_knowledge_doc_manager.get_by_id(doc_id)
+    _owner_id, ws_id = workspace_context(user, "wiki")
+    doc = await async_knowledge_doc_manager.get_by_id(doc_id, workspace_id=ws_id)
     if not doc:
         raise HTTPException(status_code=404, detail="Документ не найден")
 

--- a/db/integration.py
+++ b/db/integration.py
@@ -408,11 +408,11 @@ class AsyncFAQManager:
                     )
             return None
 
-    async def delete(self, question: str) -> bool:
+    async def delete(self, question: str, workspace_id: Optional[int] = None) -> bool:
         """Delete FAQ entry."""
         async with AsyncSessionLocal() as session:
             repo = FAQRepository(session)
-            return await repo.delete_by_question(question)
+            return await repo.delete_by_question(question, workspace_id=workspace_id)
 
     async def search(self, query: str, workspace_id: Optional[int] = None) -> List[dict]:
         """Search FAQ entries."""
@@ -1363,11 +1363,11 @@ class AsyncKnowledgeDocManager:
             repo = KnowledgeDocumentRepository(session)
             return await repo.get_all_documents(workspace_id=workspace_id)
 
-    async def get_by_id(self, doc_id: int) -> Optional[dict]:
-        """Get document by ID."""
+    async def get_by_id(self, doc_id: int, workspace_id: Optional[int] = None) -> Optional[dict]:
+        """Get document by ID, with optional workspace gate-check."""
         async with AsyncSessionLocal() as session:
             repo = KnowledgeDocumentRepository(session)
-            doc = await repo.get_by_id(doc_id)
+            doc = await repo.get_by_id_ws(doc_id, workspace_id)
             return doc.to_dict() if doc else None
 
     async def get_by_filename(self, filename: str) -> Optional[dict]:
@@ -1448,11 +1448,13 @@ class AsyncKnowledgeCollectionManager:
                 enabled_only=enabled_only, workspace_id=workspace_id
             )
 
-    async def get_by_id(self, collection_id: int) -> Optional[dict]:
-        """Get collection by ID with document count."""
+    async def get_by_id(
+        self, collection_id: int, workspace_id: Optional[int] = None
+    ) -> Optional[dict]:
+        """Get collection by ID with document count and optional workspace gate-check."""
         async with AsyncSessionLocal() as session:
             repo = KnowledgeCollectionRepository(session)
-            col = await repo.get_by_id(collection_id)
+            col = await repo.get_by_id_ws(collection_id, workspace_id)
             if not col:
                 return None
             d = col.to_dict()
@@ -1666,10 +1668,12 @@ class AsyncClaudeCodeManager:
                 owner_id=owner_id, limit=limit, workspace_id=workspace_id
             )
 
-    async def get_session(self, session_id: str) -> Optional[dict]:
+    async def get_session(
+        self, session_id: str, workspace_id: Optional[int] = None
+    ) -> Optional[dict]:
         async with AsyncSessionLocal() as session:
             repo = ClaudeCodeRepository(session)
-            return await repo.get_session(session_id)
+            return await repo.get_session(session_id, workspace_id=workspace_id)
 
     async def create_session(
         self,
@@ -1689,10 +1693,10 @@ class AsyncClaudeCodeManager:
             repo = ClaudeCodeRepository(session)
             return await repo.update_session(session_id, **kwargs)
 
-    async def delete_session(self, session_id: str) -> bool:
+    async def delete_session(self, session_id: str, workspace_id: Optional[int] = None) -> bool:
         async with AsyncSessionLocal() as session:
             repo = ClaudeCodeRepository(session)
-            return await repo.delete_session(session_id)
+            return await repo.delete_session(session_id, workspace_id=workspace_id)
 
 
 # ============== User Identity Manager ==============
@@ -1781,10 +1785,10 @@ class AsyncKanbanManager:
             repo = KanbanRepository(session)
             return await repo.get_visible_tasks(current_user, is_admin, workspace_id=workspace_id)
 
-    async def get_task(self, task_id: int) -> Optional[dict]:
+    async def get_task(self, task_id: int, workspace_id: Optional[int] = None) -> Optional[dict]:
         async with AsyncSessionLocal() as session:
             repo = KanbanRepository(session)
-            task = await repo.get_task_with_relations(task_id)
+            task = await repo.get_task_with_relations(task_id, workspace_id=workspace_id)
             return task.to_dict() if task else None
 
     async def create_task(self, **kwargs) -> dict:
@@ -1871,10 +1875,12 @@ class AsyncKanbanProjectManager:
             repo = KanbanProjectRepository(session)
             return await repo.get_all_projects(workspace_id=workspace_id)
 
-    async def get_project(self, project_id: int) -> Optional[dict]:
+    async def get_project(
+        self, project_id: int, workspace_id: Optional[int] = None
+    ) -> Optional[dict]:
         async with AsyncSessionLocal() as session:
             repo = KanbanProjectRepository(session)
-            project = await repo.get_project_with_token(project_id)
+            project = await repo.get_project_with_token(project_id, workspace_id=workspace_id)
             return project.to_dict() if project else None
 
     async def get_project_with_token(self, project_id: int):

--- a/db/repositories/base.py
+++ b/db/repositories/base.py
@@ -33,6 +33,19 @@ class BaseRepository(Generic[T]):
         result: Optional[T] = await self.session.get(self.model, id_value)
         return result
 
+    async def get_by_id_ws(self, id_value: Any, workspace_id: Optional[int] = None) -> Optional[T]:
+        """Get entity by PK with optional workspace filter.
+
+        Gate-check for mutation endpoints: returns None if the entity
+        exists but belongs to a different workspace.
+        """
+        if workspace_id is None:
+            return await self.get_by_id(id_value)
+        query = select(self.model).where(self.model.id == id_value)
+        query = self._apply_workspace_filter(query, workspace_id)
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()
+
     async def get_all(self, limit: int = 1000, offset: int = 0) -> List[T]:
         """Get all entities with pagination."""
         result = await self.session.execute(select(self.model).limit(limit).offset(offset))

--- a/db/repositories/claude_code.py
+++ b/db/repositories/claude_code.py
@@ -29,8 +29,10 @@ class ClaudeCodeRepository(BaseRepository[ClaudeCodeSession]):
         result = await self.session.execute(query)
         return [s.to_dict() for s in result.scalars().all()]
 
-    async def get_session(self, session_id: str) -> Optional[dict]:
-        entity = await self.get_by_id(session_id)
+    async def get_session(
+        self, session_id: str, workspace_id: Optional[int] = None
+    ) -> Optional[dict]:
+        entity = await self.get_by_id_ws(session_id, workspace_id)
         return entity.to_dict() if entity else None
 
     async def create_session(
@@ -67,5 +69,9 @@ class ClaudeCodeRepository(BaseRepository[ClaudeCodeSession]):
         await self.session.refresh(entity)
         return entity.to_dict()
 
-    async def delete_session(self, session_id: str) -> bool:
-        return await self.delete_by_id(session_id)
+    async def delete_session(self, session_id: str, workspace_id: Optional[int] = None) -> bool:
+        entity = await self.get_by_id_ws(session_id, workspace_id)
+        if entity:
+            await self.delete(entity)
+            return True
+        return False

--- a/db/repositories/cloud_provider.py
+++ b/db/repositories/cloud_provider.py
@@ -118,9 +118,9 @@ class CloudProviderRepository(BaseRepository[CloudLLMProvider]):
         if existing:
             provider_id = f"{provider_id}-{int(datetime.utcnow().timestamp())}"
 
-        # If this is set as default, unset others
+        # If this is set as default, unset others in the same workspace
         if kwargs.get("is_default", False):
-            await self._unset_all_defaults()
+            await self._unset_all_defaults(workspace_id=kwargs.get("workspace_id"))
 
         create_kwargs: dict[str, Any] = {}
         if kwargs.get("workspace_id") is not None:
@@ -158,9 +158,10 @@ class CloudProviderRepository(BaseRepository[CloudLLMProvider]):
         if not provider:
             return None
 
-        # If setting as default, unset others
+        # If setting as default, unset others in the same workspace
         if kwargs.get("is_default", False) and not provider.is_default:
-            await self._unset_all_defaults()
+            ws_id = getattr(provider, "workspace_id", None)
+            await self._unset_all_defaults(workspace_id=ws_id)
 
         # Update simple fields
         simple_fields = [
@@ -218,13 +219,14 @@ class CloudProviderRepository(BaseRepository[CloudLLMProvider]):
         return True
 
     async def set_default(self, provider_id: str) -> bool:
-        """Set provider as default."""
+        """Set provider as default (scoped to provider's workspace)."""
         # Check if provider exists and is enabled
         provider = await self.session.get(CloudLLMProvider, provider_id)
         if not provider or not provider.enabled:
             return False
 
-        await self._unset_all_defaults()
+        ws_id = getattr(provider, "workspace_id", None)
+        await self._unset_all_defaults(workspace_id=ws_id)
 
         result = await self.session.execute(
             update(CloudLLMProvider)
@@ -234,13 +236,16 @@ class CloudProviderRepository(BaseRepository[CloudLLMProvider]):
         await self.session.commit()
         return bool(result.rowcount > 0)  # type: ignore[attr-defined]
 
-    async def _unset_all_defaults(self) -> None:
-        """Unset all default flags."""
-        await self.session.execute(
+    async def _unset_all_defaults(self, workspace_id: Optional[int] = None) -> None:
+        """Unset all default flags, scoped to workspace if provided."""
+        stmt = (
             update(CloudLLMProvider)
             .where(CloudLLMProvider.is_default == True)
             .values(is_default=False)
         )
+        if workspace_id is not None and hasattr(CloudLLMProvider, "workspace_id"):
+            stmt = stmt.where(CloudLLMProvider.workspace_id == workspace_id)
+        await self.session.execute(stmt)
 
     async def get_by_type(self, provider_type: str, enabled_only: bool = True) -> List[dict]:
         """Get providers by type."""

--- a/db/repositories/faq.py
+++ b/db/repositories/faq.py
@@ -155,11 +155,12 @@ class FAQRepository(BaseRepository[FAQEntry]):
         await invalidate_faq_cache()
         return bool(result.rowcount > 0)  # type: ignore[attr-defined]
 
-    async def delete_by_question(self, question: str) -> bool:
-        """Delete FAQ entry by question."""
-        result = await self.session.execute(
-            delete(FAQEntry).where(FAQEntry.question == question.lower())
-        )
+    async def delete_by_question(self, question: str, workspace_id: Optional[int] = None) -> bool:
+        """Delete FAQ entry by question, optionally scoped to workspace."""
+        stmt = delete(FAQEntry).where(FAQEntry.question == question.lower())
+        if workspace_id is not None and hasattr(FAQEntry, "workspace_id"):
+            stmt = stmt.where(FAQEntry.workspace_id == workspace_id)
+        result = await self.session.execute(stmt)
         await self.session.commit()
         await invalidate_faq_cache()
         return bool(result.rowcount > 0)  # type: ignore[attr-defined]

--- a/db/repositories/kanban.py
+++ b/db/repositories/kanban.py
@@ -24,11 +24,13 @@ class KanbanRepository(BaseRepository[KanbanTask]):
             selectinload(KanbanTask.dependencies_as_dependent),
         ]
 
-    async def get_task_with_relations(self, task_id: int) -> Optional[KanbanTask]:
+    async def get_task_with_relations(
+        self, task_id: int, workspace_id: Optional[int] = None
+    ) -> Optional[KanbanTask]:
         """Get a single task with all relations loaded."""
-        result = await self.session.execute(
-            select(KanbanTask).where(KanbanTask.id == task_id).options(*self._load_options())
-        )
+        query = select(KanbanTask).where(KanbanTask.id == task_id).options(*self._load_options())
+        query = self._apply_workspace_filter(query, workspace_id)
+        result = await self.session.execute(query)
         return result.scalar_one_or_none()
 
     async def get_visible_tasks(

--- a/db/repositories/kanban_project.py
+++ b/db/repositories/kanban_project.py
@@ -23,8 +23,15 @@ class KanbanProjectRepository(BaseRepository[KanbanProject]):
         result = await self.session.execute(query)
         return [p.to_dict() for p in result.scalars().all()]
 
-    async def get_project_with_token(self, project_id: int) -> Optional[KanbanProject]:
+    async def get_project_with_token(
+        self, project_id: int, workspace_id: Optional[int] = None
+    ) -> Optional[KanbanProject]:
         """Get project ORM object (includes token for sync operations)."""
+        if workspace_id is not None:
+            query = select(KanbanProject).where(KanbanProject.id == project_id)
+            query = self._apply_workspace_filter(query, workspace_id)
+            result = await self.session.execute(query)
+            return result.scalar_one_or_none()
         return await self.session.get(KanbanProject, project_id)
 
     async def get_by_repo(self, owner: str, repo: str) -> Optional[KanbanProject]:


### PR DESCRIPTION
## Summary
- **BaseRepository**: add `get_by_id_ws()` method — workspace-aware PK lookup for mutation gate-checks (returns `None` if entity belongs to different workspace)
- **All 13 resource repos + managers**: close remaining workspace_id gaps found during full-codebase audit — `_unset_all_defaults()` scoped, `delete_by_question()` scoped, mutation lookups (`get_task_with_relations`, `get_project_with_token`, `get_session`, `delete_session`, `get_by_id`) now accept workspace_id
- **All 5 router files**: 26+ endpoints gain workspace gate-checks on ID-based operations — amoCRM `_get_valid_token(workspace_id)` + 19 proxy endpoints, wiki_rag collections/documents, kanban tasks/projects, claude_code sessions, faq delete

12 files changed, 167 insertions(+), 79 deletions(-)

Closes #382

## Test plan
- [ ] Verify login and basic navigation still works
- [ ] Test amoCRM status/config/proxy endpoints return correct workspace data
- [ ] Test kanban task CRUD — create, update, delete, reorder
- [ ] Test wiki_rag collection/document CRUD
- [ ] Test FAQ add/delete
- [ ] Test Claude Code session list/delete
- [ ] Verify `ruff check . && ruff format --check .` passes
- [ ] Verify CI passes (lint-backend + lint-frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)