### PR TITLE
fix(kanban): column header buttons not clickable

### DIFF
--- a/admin/src/components/kanban/KanbanBoard.vue
+++ b/admin/src/components/kanban/KanbanBoard.vue
@@ -192,8 +192,10 @@ const dragScrollLeft = ref(0)
 const dragScrollTop = ref(0)
 const dragMoved = ref(false)
 
-function isCardElement(el: HTMLElement | null): boolean {
+function isInteractiveElement(el: HTMLElement | null): boolean {
   while (el) {
+    const tag = el.tagName
+    if (tag === 'BUTTON' || tag === 'A' || tag === 'INPUT') return true
     if (el.classList?.contains('kanban-card')) return true
     if (el.classList?.contains('kanban-resize-handle')) return true
     if (el === boardContainer.value) return false
@@ -205,7 +207,7 @@ function isCardElement(el: HTMLElement | null): boolean {
 function onBoardPointerDown(e: PointerEvent) {
   // Only enable drag-to-scroll for mouse — touch devices use native scroll
   if (e.pointerType !== 'mouse') return
-  if (isCardElement(e.target as HTMLElement)) return
+  if (isInteractiveElement(e.target as HTMLElement)) return
   const board = boardContainer.value
   if (!board) return
   isDragScrolling.value = true


### PR DESCRIPTION
## Summary

- Fix: `+` buttons in kanban column headers were unresponsive — clicking did nothing
- **Root cause**: drag-to-scroll (`setPointerCapture`) intercepted pointerdown on all non-card elements, including buttons in column headers, preventing click events from firing
- **Fix**: renamed `isCardElement` → `isInteractiveElement`, added checks for `BUTTON`, `A`, `INPUT` tags to skip drag-to-scroll on interactive elements

## Test plan

- [ ] Click `+` in any kanban column header → task creation form opens with correct status
- [ ] Drag-to-scroll on empty board area still works
- [ ] Card drag & drop still works
- [ ] Column collapse button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)