### PR TITLE
fix: skip User row check for internal bot tokens (user_id=0)

### DIFF
--- a/auth_manager.py
+++ b/auth_manager.py
@@ -344,7 +344,8 @@ async def _validate_session(token_payload: TokenPayload) -> Optional[User]:
         return None
     if db_session.revoked_at is not None:
         return None
-    if db_session.user is None or not db_session.user.is_active:
+    # Internal bot tokens use user_id=0 which has no real User row — skip user check
+    if user_id != 0 and (db_session.user is None or not db_session.user.is_active):
         return None
 
     # Valid session — populate cache


### PR DESCRIPTION
## Summary
- Telegram/WhatsApp bots authenticate with `user_id=0` (virtual internal user)
- `_validate_session()` in `auth_manager.py` checks `db_session.user is None` which always fails for `user_id=0` since no `User` row exists with that ID
- This caused **401 Unauthorized** on every bot API call (e.g. `/admin/chat/sessions/{id}/stream`)
- Fix: skip the User existence/active check when `user_id == 0`, while keeping session revocation check intact

## Test plan
- [x] Deployed to production, both Telegram bots started without 401 errors
- [x] Health check passes
- [ ] Send message to Telegram bot and verify response

🤖 Generated with [Claude Code](https://claude.com/claude-code)