### PR TITLE
docs: RBAC 8-1 workspace members documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,7 @@ Frontend: `auth.ts` store fetches deployment mode via `GET /admin/deployment-mod
 
 **Chat session sharing**: `ChatSessionShare` model (`chat_session_shares` table) enables sharing chat sessions between users. `ChatShareDialog.vue` component in frontend.
 
-**Other routers**: `audit.py` (audit log viewer/export/cleanup), `usage.py` (usage statistics/analytics), `legal.py` (legal compliance, migration: `scripts/migrate_legal_compliance.py`), `wiki_rag.py` (Wiki RAG stats/search/reload + Knowledge Base CRUD + collections management), `github_webhook.py` (GitHub CI/CD webhook handler).
+**Other routers**: `audit.py` (audit log viewer/export/cleanup), `usage.py` (usage statistics/analytics), `legal.py` (legal compliance, migration: `scripts/migrate_legal_compliance.py`), `wiki_rag.py` (Wiki RAG stats/search/reload + Knowledge Base CRUD + collections management), `github_webhook.py` (GitHub CI/CD webhook handler), `workspace.py` (workspace info + member management: list, role change, remove).
 
 ## Code Patterns
 
@@ -308,6 +308,7 @@ Frontend: `auth.ts` store fetches deployment mode via `GET /admin/deployment-mod
 - **User identities:** `user_identities` table links external contacts (Telegram/WhatsApp/Widget) to `users` rows. Contact-only users have `username=NULL, password_hash=NULL, role=contact` and cannot log in. Identity tracked via `find_or_create` on first message (Telegram `set_session`, WhatsApp `handle_text_message`, Widget `widget_create_session`). `AsyncUserIdentityManager` in `db/integration.py`.
 - Frontend uses `GET /admin/auth/permissions` → `hasModule()`/`canView()`/`canEdit()`/`canManage()`
 - CLI: `python scripts/manage_users.py create <user> <pass> --role web` (also populates `workspace_members`)
+- **Workspace members management:** `app/routers/workspace.py` (prefix `/admin/workspace`) — 4 endpoints: GET info, GET members, PUT member role, DELETE member. Business rules: cannot change own role or owner's role, cannot remove self or owner. After role change: `_member_role_cache.invalidate_user()`. After remove: `revoke_all_user_sessions()`. Admin UI: `UsersView.vue` at `/admin/#/users` (module `users`, minLevel `view`).
 
 **Adding i18n translations:**
 1. Edit `admin/src/plugins/i18n.ts` — add keys to all three message objects: `ru`, `en`, and `kk` (Kazakh)

--- a/wiki-pages/API-Reference.md
+++ b/wiki-pages/API-Reference.md
@@ -579,6 +579,15 @@ Workspace — контейнер всех ресурсов. Default workspace (i
 
 > **Статус:** workspace_id колонки добавлены на 13 таблиц, фильтрация полностью реализована. Модули с workspace-фильтрацией: **Chat** (PR #385), **Channels** — Telegram, WhatsApp, Widget (PR #387), **AI/LLM** — Cloud LLM Providers, TTS Presets (PR #389), **Knowledge/FAQ** — Knowledge Documents, Collections, FAQ Entries (PR #391), **System/Kanban/amoCRM** — Kanban Tasks & Projects, Claude Code Sessions, amoCRM Config (PR #393), **Финализация** — gate-check на мутациях всех модулей (PR #395). Audit excluded (no workspace_id).
 
+#### Управление участниками (PR #406)
+
+| Метод | Путь | Доступ | Описание |
+|-------|------|--------|----------|
+| `GET` | `/admin/workspace` | `users:view` | Информация о workspace (name, slug, owner_id, member_count, created_at) |
+| `GET` | `/admin/workspace/members` | `users:view` | Список участников с user details (username, display_name, email, is_active, last_login) |
+| `PUT` | `/admin/workspace/members/{user_id}/role` | `users:manage` | Смена роли. Body: `{"role_name": "operator"}`. Нельзя менять себе и owner |
+| `DELETE` | `/admin/workspace/members/{user_id}` | `users:manage` | Удаление участника. Нельзя удалить себя и owner. Ревокация сессий удалённого |
+
 ### Совместный доступ к чатам
 
 Чат-сессии (admin source) могут быть расшарены другим пользователям с уровнями доступа `read` или `write`.

--- a/wiki-pages/RBAC.md
+++ b/wiki-pages/RBAC.md
@@ -288,6 +288,36 @@ Content-Type: application/json
 
 Bot-scoped таблицы (`telegram_sessions`, `bot_agent_prompts`, `bot_quiz_questions` и др.) **не** содержат `workspace_id` — они фильтруются через `bot_instances.workspace_id`.
 
+### Этап 8: Инвайт-система + UI workspace (#330)
+
+**8-1: Управление участниками workspace** (PR #406, Issue #398) — ✅ Done
+
+Backend — новый роутер `app/routers/workspace.py` (prefix `/admin/workspace`):
+
+| Метод | Путь | Доступ | Описание |
+|-------|------|--------|----------|
+| GET | `/admin/workspace` | users:view | Информация о текущем workspace |
+| GET | `/admin/workspace/members` | users:view | Список участников с данными пользователя |
+| PUT | `/admin/workspace/members/{user_id}/role` | users:manage | Смена роли участника |
+| DELETE | `/admin/workspace/members/{user_id}` | users:manage | Удаление участника |
+
+Бизнес-правила:
+- Нельзя менять роль себе и owner
+- Нельзя удалить себя и owner
+- Валидация `role_name` через `async_role_manager.get_by_name()`
+- Инвалидация `MemberRoleCache` после смены роли
+- `revoke_all_user_sessions()` после удаления участника
+- Audit log на все мутации
+
+Frontend — `UsersView.vue` (`/admin/#/users`):
+- Карточка workspace (название, количество участников, дата создания)
+- Таблица участников: имя, логин, роль (dropdown для manage), дата входа, статус (active/inactive)
+- Crown-бейдж на владельце, dropdown и remove disabled для self и owner
+- Demo-мок: `admin/src/api/demo/workspace.ts`
+- i18n: ru/en/kk (секция `users`)
+
+**8-2: Инвайт-система** (Issue #399) — в ожидании
+
 ### Внешние контакты — user_identities
 
 Контакты из Telegram, WhatsApp и виджетов автоматически становятся пользователями с привязанными `user_identities` (миграция `0011`, PR #370).


### PR DESCRIPTION
## Summary

- **RBAC.md**: Added Stage 8 section with 8-1 (workspace members management) — endpoints table, business rules, frontend details, 8-2 status
- **API-Reference.md**: Added workspace members API endpoints table (4 endpoints with access levels)
- **CLAUDE.md**: Added workspace.py to Other routers, workspace members management description

## Test plan

- [ ] Documentation is accurate and matches PR #406 implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)