### PR TITLE
fix: quick security fixes — upload JWT, preset workspace, rate-limit (#411)

### DIFF
--- a/admin/src/api/client.ts
+++ b/admin/src/api/client.ts
@@ -1,49 +1,46 @@
 // Demo mode interceptor — loaded async but awaited before first API call
 const demoReady: Promise<void> | null =
-  import.meta.env.VITE_DEMO_MODE === 'true'
-    ? import('./demo/index').then(({ setupDemoInterceptor }) => setupDemoInterceptor())
-    : null
+  import.meta.env.VITE_DEMO_MODE === "true"
+    ? import("./demo/index").then(({ setupDemoInterceptor }) => setupDemoInterceptor())
+    : null;
 
 // Base API client
-const BASE_URL = ''
+const BASE_URL = "";
 
 export interface ApiResponse<T> {
-  data?: T
-  error?: string
-  status: 'ok' | 'error'
+  data?: T;
+  error?: string;
+  status: "ok" | "error";
 }
 
 // Get auth headers from localStorage
 export function getAuthHeaders(): Record<string, string> {
-  const token = localStorage.getItem('admin_token')
+  const token = localStorage.getItem("admin_token");
   if (token) {
-    return { 'Authorization': `Bearer ${token}` }
+    return { Authorization: `Bearer ${token}` };
   }
-  return {}
+  return {};
 }
 
-async function request<T>(
-  endpoint: string,
-  options: RequestInit = {}
-): Promise<T> {
-  if (demoReady) await demoReady
-  const url = `${BASE_URL}${endpoint}`
+async function request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+  if (demoReady) await demoReady;
+  const url = `${BASE_URL}${endpoint}`;
 
   const response = await fetch(url, {
     ...options,
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
       ...getAuthHeaders(),
       ...options.headers,
     },
-  })
+  });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ detail: 'Request failed' }))
-    throw new Error(error.detail || `HTTP error ${response.status}`)
+    const error = await response.json().catch(() => ({ detail: "Request failed" }));
+    throw new Error(error.detail || `HTTP error ${response.status}`);
   }
 
-  return response.json()
+  return response.json();
 }
 
 export const api = {
@@ -51,88 +48,90 @@ export const api = {
 
   post: <T>(endpoint: string, data?: unknown) =>
     request<T>(endpoint, {
-      method: 'POST',
+      method: "POST",
       body: data ? JSON.stringify(data) : undefined,
     }),
 
   put: <T>(endpoint: string, data?: unknown) =>
     request<T>(endpoint, {
-      method: 'PUT',
+      method: "PUT",
       body: data ? JSON.stringify(data) : undefined,
     }),
 
   patch: <T>(endpoint: string, data?: unknown) =>
     request<T>(endpoint, {
-      method: 'PATCH',
+      method: "PATCH",
       body: data ? JSON.stringify(data) : undefined,
     }),
 
-  delete: <T>(endpoint: string) =>
-    request<T>(endpoint, { method: 'DELETE' }),
+  delete: <T>(endpoint: string) => request<T>(endpoint, { method: "DELETE" }),
 
   upload: async <T>(endpoint: string, file: File): Promise<T> => {
-    if (demoReady) await demoReady
-    const formData = new FormData()
-    formData.append('file', file)
+    if (demoReady) await demoReady;
+    const formData = new FormData();
+    formData.append("file", file);
 
     const response = await fetch(`${BASE_URL}${endpoint}`, {
-      method: 'POST',
+      method: "POST",
+      headers: getAuthHeaders(),
       body: formData,
-    })
+    });
 
     if (!response.ok) {
-      const error = await response.json().catch(() => ({ detail: 'Upload failed' }))
-      throw new Error(error.detail || `HTTP error ${response.status}`)
+      const error = await response.json().catch(() => ({ detail: "Upload failed" }));
+      throw new Error(error.detail || `HTTP error ${response.status}`);
     }
 
-    return response.json()
+    return response.json();
   },
-}
+};
 
 // SSE helper with generic type support
 export function createSSE<T = unknown>(endpoint: string, onMessage: (data: T) => void) {
   // In demo mode, use polling via fetch instead of real EventSource
-  if (import.meta.env.VITE_DEMO_MODE === 'true') {
-    let stopped = false
+  if (import.meta.env.VITE_DEMO_MODE === "true") {
+    let stopped = false;
     const poll = async () => {
-      if (demoReady) await demoReady
+      if (demoReady) await demoReady;
       while (!stopped) {
         try {
-          const res = await fetch(`${BASE_URL}${endpoint}`)
+          const res = await fetch(`${BASE_URL}${endpoint}`);
           if (res.ok) {
-            const data = await res.json()
-            onMessage(data as T)
+            const data = await res.json();
+            onMessage(data as T);
           }
         } catch {
           // ignore
         }
-        await new Promise(r => setTimeout(r, 3000))
+        await new Promise((r) => setTimeout(r, 3000));
       }
-    }
-    poll()
+    };
+    poll();
     return {
-      close: () => { stopped = true },
+      close: () => {
+        stopped = true;
+      },
       eventSource: null as unknown as EventSource,
-    }
+    };
   }
 
-  const eventSource = new EventSource(`${BASE_URL}${endpoint}`)
+  const eventSource = new EventSource(`${BASE_URL}${endpoint}`);
 
   eventSource.onmessage = (event) => {
     try {
-      const data = JSON.parse(event.data) as T
-      onMessage(data)
+      const data = JSON.parse(event.data) as T;
+      onMessage(data);
     } catch {
-      onMessage(event.data as T)
+      onMessage(event.data as T);
     }
-  }
+  };
 
   eventSource.onerror = () => {
-    console.error('SSE error')
-  }
+    console.error("SSE error");
+  };
 
   return {
     close: () => eventSource.close(),
     eventSource,
-  }
+  };
 }

--- a/admin/src/api/stt.ts
+++ b/admin/src/api/stt.ts
@@ -1,58 +1,61 @@
-import { api } from './client'
+import { api, getAuthHeaders } from "./client";
 
 export interface SttStatus {
-  vosk_available: boolean
-  whisper_available: boolean
-  vosk_model: string | null
-  whisper_model: string | null
-  unified_available: boolean
+  vosk_available: boolean;
+  whisper_available: boolean;
+  vosk_model: string | null;
+  whisper_model: string | null;
+  unified_available: boolean;
 }
 
 export interface SttModel {
-  name: string
-  path: string
-  size_mb: number
-  language: string
+  name: string;
+  path: string;
+  size_mb: number;
+  language: string;
 }
 
 export interface TranscribeResult {
-  text: string
-  confidence?: number
-  duration?: number
-  engine: string
+  text: string;
+  confidence?: number;
+  duration?: number;
+  engine: string;
 }
 
 // STT API
 export const sttApi = {
-  getStatus: () =>
-    api.get<SttStatus>('/admin/stt/status'),
+  getStatus: () => api.get<SttStatus>("/admin/stt/status"),
 
-  getModels: () =>
-    api.get<{ models: SttModel[] }>('/admin/stt/models'),
+  getModels: () => api.get<{ models: SttModel[] }>("/admin/stt/models"),
 
-  transcribe: async (audioBlob: Blob, language: string = 'ru', engine: string = 'auto'): Promise<TranscribeResult> => {
-    const formData = new FormData()
-    formData.append('file', audioBlob, 'recording.webm')
-    formData.append('language', language)
-    formData.append('engine', engine)
+  transcribe: async (
+    audioBlob: Blob,
+    language: string = "ru",
+    engine: string = "auto"
+  ): Promise<TranscribeResult> => {
+    const formData = new FormData();
+    formData.append("file", audioBlob, "recording.webm");
+    formData.append("language", language);
+    formData.append("engine", engine);
 
-    const response = await fetch('/admin/stt/transcribe', {
-      method: 'POST',
+    const response = await fetch("/admin/stt/transcribe", {
+      method: "POST",
+      headers: getAuthHeaders(),
       body: formData,
-    })
+    });
 
     if (!response.ok) {
-      throw new Error(`STT failed: ${response.statusText}`)
+      throw new Error(`STT failed: ${response.statusText}`);
     }
 
-    return response.json()
+    return response.json();
   },
 
-  test: (textToSpeak: string = 'Привет, это тест распознавания речи') =>
+  test: (textToSpeak: string = "Привет, это тест распознавания речи") =>
     api.post<{
-      original_text: string
-      recognized_text: string
-      match: boolean
-      duration_seconds: number
-    }>('/admin/stt/test', { text_to_speak: textToSpeak }),
-}
+      original_text: string;
+      recognized_text: string;
+      match: boolean;
+      duration_seconds: number;
+    }>("/admin/stt/test", { text_to_speak: textToSpeak }),
+};

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -98,6 +98,7 @@ async def admin_update_profile(
 
 
 @router.post("/change-password")
+@limiter.limit(RATE_LIMIT_AUTH)
 async def admin_change_password(
     http_request: Request,
     request: ChangePasswordRequest,

--- a/app/routers/tts.py
+++ b/app/routers/tts.py
@@ -371,7 +371,8 @@ async def admin_update_custom_preset(
     user: User = Depends(require_permission("speech", "edit")),
 ):
     """Обновить пользовательский пресет TTS"""
-    result = await async_preset_manager.update(name, request.params)
+    _owner_id, ws_id = workspace_context(user, "speech")
+    result = await async_preset_manager.update(name, request.params, workspace_id=ws_id)
     if not result:
         raise HTTPException(status_code=404, detail=f"Preset not found: {name}")
 

--- a/db/integration.py
+++ b/db/integration.py
@@ -458,11 +458,13 @@ class AsyncPresetManager:
                 name, params, owner_id=owner_id, workspace_id=workspace_id
             )
 
-    async def update(self, name: str, params: dict) -> Optional[dict]:
+    async def update(
+        self, name: str, params: dict, workspace_id: Optional[int] = None
+    ) -> Optional[dict]:
         """Update preset."""
         async with AsyncSessionLocal() as session:
             repo = PresetRepository(session)
-            return await repo.update_preset(name, params)
+            return await repo.update_preset(name, params, workspace_id=workspace_id)
 
     async def delete(self, name: str, workspace_id: Optional[int] = None) -> bool:
         """Delete preset."""

--- a/db/repositories/preset.py
+++ b/db/repositories/preset.py
@@ -120,9 +120,13 @@ class PresetRepository(BaseRepository[TTSPreset]):
         self,
         name: str,
         params: dict,
+        workspace_id: Optional[int] = None,
     ) -> Optional[dict]:
-        """Update existing preset parameters."""
-        result = await self.session.execute(select(TTSPreset).where(TTSPreset.name == name))
+        """Update existing preset parameters, with optional workspace check."""
+        query = select(TTSPreset).where(TTSPreset.name == name)
+        if workspace_id is not None and hasattr(TTSPreset, "workspace_id"):
+            query = query.where(TTSPreset.workspace_id == workspace_id)
+        result = await self.session.execute(query)
         preset = result.scalar_one_or_none()
 
         if not preset:


### PR DESCRIPTION
## Summary

- **C2**: `api.upload()` in `client.ts` now sends `Authorization` header via `getAuthHeaders()` — file uploads (wiki-rag docs, finetune datasets, backup import) were sent without JWT
- **C2+**: `stt.ts` `transcribe()` had the same bug — raw `fetch()` without auth headers (note: `wikiRag.ts` was already fixed separately)
- **C3**: TTS preset `PUT /presets/custom/{name}` now validates `workspace_id` via `workspace_context()` — the `DELETE` endpoint already did this, but `UPDATE` was missing the check
- **L3**: `POST /admin/auth/change-password` now has `@limiter.limit(RATE_LIMIT_AUTH)` — login had rate limiting, password change did not

## Changed files (6)

| File | Change |
|------|--------|
| `admin/src/api/client.ts` | Add `headers: getAuthHeaders()` to `upload()` |
| `admin/src/api/stt.ts` | Import `getAuthHeaders`, add to `transcribe()` fetch |
| `app/routers/auth.py` | Add `@limiter.limit(RATE_LIMIT_AUTH)` to change-password |
| `app/routers/tts.py` | Add `workspace_context()` call in update preset |
| `db/integration.py` | Pass `workspace_id` through `AsyncPresetManager.update()` |
| `db/repositories/preset.py` | Add `workspace_id` filter to `update_preset()` query |

## Test plan

- [ ] Upload a file (wiki-rag document) — verify `Authorization` header is present in request
- [ ] STT transcribe — verify auth header is sent
- [ ] Update TTS preset as non-admin user — verify workspace isolation
- [ ] Rapid `POST /change-password` requests — verify rate limiting kicks in
- [ ] `ruff check . && ruff format --check .`
- [ ] `cd admin && npm run lint:check && npm run build`

Closes #411

🤖 Generated with [Claude Code](https://claude.ai/claude-code)