### PR TITLE
fix: close medium security gaps — consent paths, legacy fallback, SSE auth

### DIFF
--- a/admin/src/api/client.ts
+++ b/admin/src/api/client.ts
@@ -86,9 +86,9 @@ export const api = {
   },
 };
 
-// SSE helper with generic type support
+// SSE helper with generic type support (fetch-based to send JWT)
 export function createSSE<T = unknown>(endpoint: string, onMessage: (data: T) => void) {
-  // In demo mode, use polling via fetch instead of real EventSource
+  // In demo mode, use polling via fetch instead of real SSE
   if (import.meta.env.VITE_DEMO_MODE === "true") {
     let stopped = false;
     const poll = async () => {
@@ -115,23 +115,63 @@ export function createSSE<T = unknown>(endpoint: string, onMessage: (data: T) =>
     };
   }
 
-  const eventSource = new EventSource(`${BASE_URL}${endpoint}`);
+  // Real mode: fetch-based SSE with JWT auth
+  const controller = new AbortController();
+  let stopped = false;
 
-  eventSource.onmessage = (event) => {
-    try {
-      const data = JSON.parse(event.data) as T;
-      onMessage(data);
-    } catch {
-      onMessage(event.data as T);
+  const connect = async () => {
+    while (!stopped) {
+      try {
+        const response = await fetch(`${BASE_URL}${endpoint}`, {
+          headers: { ...getAuthHeaders(), Accept: "text/event-stream" },
+          signal: controller.signal,
+        });
+
+        if (!response.ok || !response.body) {
+          throw new Error(`SSE connection failed: ${response.status}`);
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (!stopped) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || "";
+
+          for (const line of lines) {
+            if (line.startsWith("data: ")) {
+              const payload = line.slice(6);
+              try {
+                onMessage(JSON.parse(payload) as T);
+              } catch {
+                onMessage(payload as T);
+              }
+            }
+          }
+        }
+      } catch (e) {
+        if (stopped) return;
+        console.error("SSE error, reconnecting in 3s:", e);
+      }
+
+      if (!stopped) {
+        await new Promise((r) => setTimeout(r, 3000));
+      }
     }
   };
 
-  eventSource.onerror = () => {
-    console.error("SSE error");
-  };
+  connect();
 
   return {
-    close: () => eventSource.close(),
-    eventSource,
+    close: () => {
+      stopped = true;
+      controller.abort();
+    },
+    eventSource: null as unknown as EventSource,
   };
 }

--- a/admin/src/composables/useRealtimeMetrics.ts
+++ b/admin/src/composables/useRealtimeMetrics.ts
@@ -1,143 +1,140 @@
-import { ref, onMounted, onUnmounted, computed } from 'vue'
+import { ref, onMounted, onUnmounted, computed } from "vue";
+import { createSSE, getAuthHeaders } from "@/api/client";
 
 export interface GpuMetrics {
-  memoryPercent: number
-  utilization: number
-  temperature?: number
-  name?: string
+  memoryPercent: number;
+  utilization: number;
+  temperature?: number;
+  name?: string;
 }
 
 export interface MetricsHistory {
   gpu: {
-    memory: number[]
-    utilization: number[]
-  }
+    memory: number[];
+    utilization: number[];
+  };
   requests: {
-    total: number[]
-    latency: number[]
-  }
-  timestamps: string[]
+    total: number[];
+    latency: number[];
+  };
+  timestamps: string[];
 }
 
-const MAX_HISTORY = 60 // 5 minutes at 5s interval
+const MAX_HISTORY = 60; // 5 minutes at 5s interval
 
 export function useRealtimeMetrics(intervalMs = 5000) {
-  const gpuMetrics = ref<GpuMetrics | null>(null)
+  const gpuMetrics = ref<GpuMetrics | null>(null);
   const history = ref<MetricsHistory>({
     gpu: { memory: [], utilization: [] },
     requests: { total: [], latency: [] },
-    timestamps: []
-  })
-  const isConnected = ref(false)
-  const error = ref<string | null>(null)
+    timestamps: [],
+  });
+  const isConnected = ref(false);
+  const error = ref<string | null>(null);
 
-  let intervalId: number | null = null
-  let eventSource: EventSource | null = null
+  let intervalId: number | null = null;
+  let sseHandle: { close: () => void } | null = null;
 
   // Try SSE first, fallback to polling
   function connectSSE() {
     try {
-      eventSource = new EventSource('/admin/monitor/gpu/stream')
+      sseHandle = createSSE("/admin/monitor/gpu/stream", (data: unknown) => {
+        updateMetrics(data);
+        isConnected.value = true;
+        error.value = null;
+      });
 
-      eventSource.onopen = () => {
-        isConnected.value = true
-        error.value = null
-      }
-
-      eventSource.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data)
-          updateMetrics(data)
-        } catch (e) {
-          console.error('Failed to parse SSE data:', e)
+      // SSE errors will cause reconnection inside createSSE.
+      // If after 10s we have no data, fall back to polling.
+      setTimeout(() => {
+        if (!gpuMetrics.value && !intervalId) {
+          sseHandle?.close();
+          sseHandle = null;
+          startPolling();
         }
-      }
-
-      eventSource.onerror = () => {
-        isConnected.value = false
-        eventSource?.close()
-        // Fallback to polling
-        startPolling()
-      }
-    } catch (e) {
-      startPolling()
+      }, 10000);
+    } catch {
+      startPolling();
     }
   }
 
   function startPolling() {
-    if (intervalId) return
+    if (intervalId) return;
 
     const poll = async () => {
       try {
-        const response = await fetch('/admin/monitor/gpu')
+        const response = await fetch("/admin/monitor/gpu", {
+          headers: getAuthHeaders(),
+        });
         if (response.ok) {
-          const data = await response.json()
-          updateMetrics(data)
-          isConnected.value = true
-          error.value = null
+          const data = await response.json();
+          updateMetrics(data);
+          isConnected.value = true;
+          error.value = null;
         }
-      } catch (e) {
-        isConnected.value = false
-        error.value = 'Failed to fetch metrics'
+      } catch {
+        isConnected.value = false;
+        error.value = "Failed to fetch metrics";
       }
-    }
+    };
 
-    poll() // Initial fetch
-    intervalId = window.setInterval(poll, intervalMs)
+    poll(); // Initial fetch
+    intervalId = window.setInterval(poll, intervalMs);
   }
 
   function updateMetrics(data: any) {
-    const gpu = data?.gpus?.[0] || data
+    const gpu = data?.gpus?.[0] || data;
 
     if (gpu) {
-      const memPercent = gpu.allocated_gb && gpu.total_memory_gb
-        ? Math.round((gpu.allocated_gb / gpu.total_memory_gb) * 100)
-        : gpu.memory_percent || 0
+      const memPercent =
+        gpu.allocated_gb && gpu.total_memory_gb
+          ? Math.round((gpu.allocated_gb / gpu.total_memory_gb) * 100)
+          : gpu.memory_percent || 0;
 
       gpuMetrics.value = {
         memoryPercent: memPercent,
         utilization: gpu.utilization_percent || gpu.utilization || 0,
         temperature: gpu.temperature_c || gpu.temperature,
-        name: gpu.name
-      }
+        name: gpu.name,
+      };
 
       // Update history
-      history.value.gpu.memory.push(memPercent)
-      history.value.gpu.utilization.push(gpuMetrics.value.utilization)
-      history.value.timestamps.push(new Date().toISOString())
+      history.value.gpu.memory.push(memPercent);
+      history.value.gpu.utilization.push(gpuMetrics.value.utilization);
+      history.value.timestamps.push(new Date().toISOString());
 
       // Trim to max size
       if (history.value.gpu.memory.length > MAX_HISTORY) {
-        history.value.gpu.memory.shift()
-        history.value.gpu.utilization.shift()
-        history.value.timestamps.shift()
+        history.value.gpu.memory.shift();
+        history.value.gpu.utilization.shift();
+        history.value.timestamps.shift();
       }
     }
   }
 
   function disconnect() {
-    if (eventSource) {
-      eventSource.close()
-      eventSource = null
+    if (sseHandle) {
+      sseHandle.close();
+      sseHandle = null;
     }
     if (intervalId) {
-      clearInterval(intervalId)
-      intervalId = null
+      clearInterval(intervalId);
+      intervalId = null;
     }
-    isConnected.value = false
+    isConnected.value = false;
   }
 
   onMounted(() => {
-    connectSSE()
-  })
+    connectSSE();
+  });
 
   onUnmounted(() => {
-    disconnect()
-  })
+    disconnect();
+  });
 
   // Computed sparkline data
-  const memorySparkline = computed(() => history.value.gpu.memory.slice(-20))
-  const utilizationSparkline = computed(() => history.value.gpu.utilization.slice(-20))
+  const memorySparkline = computed(() => history.value.gpu.memory.slice(-20));
+  const utilizationSparkline = computed(() => history.value.gpu.utilization.slice(-20));
 
   return {
     gpuMetrics,
@@ -146,6 +143,6 @@ export function useRealtimeMetrics(intervalMs = 5000) {
     error,
     memorySparkline,
     utilizationSparkline,
-    disconnect
-  }
+    disconnect,
+  };
 }

--- a/admin/src/composables/useSSE.ts
+++ b/admin/src/composables/useSSE.ts
@@ -1,61 +1,91 @@
-import { ref, onUnmounted, type Ref, shallowRef } from 'vue'
+import { ref, onUnmounted, type Ref, shallowRef } from "vue";
+import { getAuthHeaders } from "@/api/client";
 
 export function useSSE<T = unknown>(url: string) {
-  const data: Ref<T[]> = shallowRef([])
-  const lastData: Ref<T | null> = shallowRef(null)
-  const isConnected = ref(false)
-  const error = ref<string | null>(null)
-  let eventSource: EventSource | null = null
+  const data: Ref<T[]> = shallowRef([]);
+  const lastData: Ref<T | null> = shallowRef(null);
+  const isConnected = ref(false);
+  const error = ref<string | null>(null);
+  let controller: AbortController | null = null;
+  let stopped = false;
 
-  function connect() {
-    if (eventSource) {
-      return
-    }
+  async function connect() {
+    if (controller) return;
+    stopped = false;
 
-    eventSource = new EventSource(url)
-
-    eventSource.onopen = () => {
-      isConnected.value = true
-      error.value = null
-    }
-
-    eventSource.onmessage = (event) => {
+    while (!stopped) {
+      controller = new AbortController();
       try {
-        const parsed = JSON.parse(event.data) as T
-        const newData = [...data.value, parsed]
-        // Keep last 1000 items
-        data.value = newData.length > 1000 ? newData.slice(-500) : newData
-        lastData.value = parsed
-      } catch {
-        // If not JSON, store as string
-        const newData = [...data.value, event.data as T]
-        data.value = newData.length > 1000 ? newData.slice(-500) : newData
-        lastData.value = event.data as T
-      }
-    }
+        const response = await fetch(url, {
+          headers: { ...getAuthHeaders(), Accept: "text/event-stream" },
+          signal: controller.signal,
+        });
 
-    eventSource.onerror = () => {
-      isConnected.value = false
-      error.value = 'Connection lost'
+        if (!response.ok || !response.body) {
+          throw new Error(`SSE connection failed: ${response.status}`);
+        }
+
+        isConnected.value = true;
+        error.value = null;
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (!stopped) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || "";
+
+          for (const line of lines) {
+            if (line.startsWith("data: ")) {
+              const payload = line.slice(6);
+              try {
+                const parsed = JSON.parse(payload) as T;
+                const newData = [...data.value, parsed];
+                data.value = newData.length > 1000 ? newData.slice(-500) : newData;
+                lastData.value = parsed;
+              } catch {
+                const newData = [...data.value, payload as T];
+                data.value = newData.length > 1000 ? newData.slice(-500) : newData;
+                lastData.value = payload as T;
+              }
+            }
+          }
+        }
+      } catch (e) {
+        if (stopped) return;
+        isConnected.value = false;
+        error.value = "Connection lost";
+      }
+
+      controller = null;
+      if (!stopped) {
+        await new Promise((r) => setTimeout(r, 3000));
+      }
     }
   }
 
   function disconnect() {
-    if (eventSource) {
-      eventSource.close()
-      eventSource = null
-      isConnected.value = false
+    stopped = true;
+    if (controller) {
+      controller.abort();
+      controller = null;
     }
+    isConnected.value = false;
   }
 
   function clear() {
-    data.value = []
-    lastData.value = null
+    data.value = [];
+    lastData.value = null;
   }
 
   onUnmounted(() => {
-    disconnect()
-  })
+    disconnect();
+  });
 
   return {
     data,
@@ -65,5 +95,5 @@ export function useSSE<T = unknown>(url: string) {
     connect,
     disconnect,
     clear,
-  }
+  };
 }

--- a/app/routers/legal.py
+++ b/app/routers/legal.py
@@ -94,8 +94,8 @@ async def admin_get_user_consents(
         return {"consents": consents, "user_id": user_id}
 
 
-@router.post("/admin/legal/consents/grant")
-async def admin_grant_consent(
+@router.post("/legal/consents/grant")
+async def grant_consent(
     request: ConsentRequest,
     req: Request,
 ):
@@ -126,8 +126,8 @@ async def admin_grant_consent(
         return {"consent": consent}
 
 
-@router.post("/admin/legal/consents/grant-bulk")
-async def admin_grant_bulk_consents(
+@router.post("/legal/consents/grant-bulk")
+async def grant_bulk_consents(
     request: ConsentBulkRequest,
     req: Request,
 ):
@@ -161,8 +161,8 @@ async def admin_grant_bulk_consents(
         return {"consents": granted}
 
 
-@router.post("/admin/legal/consents/grant-required")
-async def admin_grant_required_consents(
+@router.post("/legal/consents/grant-required")
+async def grant_required_consents(
     request: ConsentRequest,
     req: Request,
 ):
@@ -204,8 +204,11 @@ async def admin_revoke_consent(
 
 
 @router.get("/admin/legal/consents/check/{user_id}")
-async def admin_check_consents(user_id: str):
-    """Check if user has granted all required consents."""
+async def admin_check_consents(
+    user_id: str,
+    user: User = Depends(require_permission("settings", "view")),
+):
+    """Check if user has granted all required consents (admin only)."""
     async with AsyncSessionLocal() as session:
         repo = ConsentRepository(session)
         result = await repo.check_required_consents(user_id)

--- a/auth_manager.py
+++ b/auth_manager.py
@@ -297,9 +297,11 @@ async def authenticate_user(username: str, password: str) -> Optional[User]:
             return None
 
     except Exception as e:
-        logger.warning(f"DB auth failed, trying legacy: {e}")
+        # DB error — do NOT fall through to legacy fallback (security: H3)
+        logger.error(f"DB auth error (not falling back to legacy): {e}")
+        return None
 
-    # Fallback: legacy env-var admin (when no users in DB or DB unavailable)
+    # Fallback: legacy env-var admin ONLY when no users in DB (first run)
     if username == _LEGACY_USERNAME and _verify_legacy_password(password, _LEGACY_PASSWORD_HASH):
         return User(id=0, username=username, role="admin")
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -76,6 +76,7 @@ from auth_manager import (
     create_session,
     get_auth_status,
     get_current_user,
+    require_permission,
 )
 
 # Cloud LLM service for multi-provider support
@@ -2319,7 +2320,10 @@ async def admin_read_log(
 
 
 @app.get("/admin/logs/stream/{logfile}")
-async def admin_stream_log(logfile: str):
+async def admin_stream_log(
+    logfile: str,
+    user: User = Depends(require_permission("system", "view")),
+):
     """SSE streaming логов"""
     manager = get_service_manager()
 
@@ -3064,7 +3068,9 @@ async def admin_get_training_status():
 
 
 @app.get("/admin/finetune/train/log")
-async def admin_stream_training_log():
+async def admin_stream_training_log(
+    user: User = Depends(require_permission("system", "view")),
+):
     """SSE streaming лога обучения"""
     manager = get_finetune_manager()
 
@@ -3308,42 +3314,6 @@ async def admin_get_gpu_stats():
             logger.warning(f"Error getting GPU {i} stats: {e}")
 
     return {"available": True, "gpus": gpus}
-
-
-@app.get("/admin/monitor/gpu/stream")
-async def admin_stream_gpu_stats():
-    """SSE streaming статистики GPU"""
-    import torch
-
-    async def generate():
-        while True:
-            if torch.cuda.is_available():
-                gpus = []
-                for i in range(torch.cuda.device_count()):
-                    try:
-                        allocated = torch.cuda.memory_allocated(i) / (1024**3)
-                        reserved = torch.cuda.memory_reserved(i) / (1024**3)
-                        gpus.append(
-                            {
-                                "id": i,
-                                "allocated_gb": round(allocated, 2),
-                                "reserved_gb": round(reserved, 2),
-                            }
-                        )
-                    except Exception:
-                        pass
-
-                yield f"data: {json.dumps({'gpus': gpus, 'timestamp': datetime.now().isoformat()})}\n\n"
-            else:
-                yield f"data: {json.dumps({'available': False})}\n\n"
-
-            await asyncio.sleep(5)
-
-    return StreamingResponse(
-        generate(),
-        media_type="text/event-stream",
-        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
-    )
 
 
 @app.get("/admin/monitor/health")


### PR DESCRIPTION
## Summary

Closes #412 (medium security fixes from audit #315).

**C1 — Consent endpoints:**
- Move 3 grant endpoints from `/admin/legal/consents/grant*` → `/legal/consents/grant*` (public, called by widgets/bots without JWT)
- Add `require_permission("settings", "view")` to `GET /admin/legal/consents/check/{user_id}`

**H3 — Legacy fallback:**
- DB errors in `authenticate_user()` now return `None` instead of falling through to legacy `admin/admin` check
- Legacy fallback only activates when `user_count == 0` (first run, empty DB)

**H5 — SSE auth (backend):**
- Delete duplicate `/admin/monitor/gpu/stream` from `orchestrator.py` (auth version exists in `app/routers/monitor.py:83`)
- Add `require_permission("system", "view")` to `/admin/logs/stream/{logfile}` and `/admin/finetune/train/log`

**H5 — SSE auth (frontend):**
- Rewrite `createSSE()` in `client.ts` from `EventSource` to `fetch + ReadableStream` (sends JWT `Authorization` header)
- Rewrite `useSSE` composable with same fetch-based approach
- Rewrite `useRealtimeMetrics` to use `createSSE()` instead of raw `EventSource`; polling fallback also sends JWT via `getAuthHeaders()`
- All SSE connections auto-reconnect after 3s on error

## Files changed (6)

| File | Change |
|------|--------|
| `auth_manager.py` | H3: except → return None |
| `app/routers/legal.py` | C1: 3 paths `/admin/` → `/`, auth on check |
| `orchestrator.py` | H5: delete GPU dup, auth on 2 SSE |
| `admin/src/api/client.ts` | H5: createSSE → fetch+ReadableStream |
| `admin/src/composables/useSSE.ts` | H5: EventSource → fetch+ReadableStream |
| `admin/src/composables/useRealtimeMetrics.ts` | H5: EventSource → createSSE, auth polling |

## Test plan

- [ ] `POST /legal/consents/grant` without token → 200 (public)
- [ ] `GET /admin/legal/consents/check/test` without token → 401
- [ ] Login with valid credentials → 200 (normal DB auth)
- [ ] `GET /admin/logs/stream/orchestrator.log` without token → 401
- [ ] `GET /admin/finetune/train/log` without token → 401
- [ ] `GET /admin/monitor/gpu/stream` without token → 401
- [ ] Dashboard GPU metrics widget works with auth (SSE or polling fallback)
- [ ] Monitoring tab log streaming works

🤖 Generated with [Claude Code](https://claude.com/claude-code)