### PR TITLE
docs: document medium security fixes (#412)

### DIFF
--- a/wiki-pages/API-Reference.md
+++ b/wiki-pages/API-Reference.md
@@ -462,6 +462,31 @@ Content-Type: application/json
 
 Возвращает **409** если зависимость создаёт цикл или целевая задача приватная.
 
+## Legal / Consent (Согласия)
+
+### Публичные эндпоинты (без авторизации)
+
+Вызываются виджетами, Telegram-ботами, внешними клиентами. Пути без `/admin/` (PR #420).
+
+| Метод | Эндпоинт | Описание |
+|-------|----------|----------|
+| GET | `/privacy-policy?lang=ru` | Страница политики конфиденциальности (HTML) |
+| GET | `/terms?lang=ru` | Страница условий использования (HTML) |
+| GET | `/consent-types` | Список типов согласий |
+| POST | `/legal/consents/grant` | Дать согласие (user_id, user_type, consent_type) |
+| POST | `/legal/consents/grant-bulk` | Дать несколько согласий (consent_types[]) |
+| POST | `/legal/consents/grant-required` | Дать все обязательные согласия |
+
+### Защищённые эндпоинты (требуют JWT)
+
+| Метод | Эндпоинт | Доступ | Описание |
+|-------|----------|--------|----------|
+| GET | `/admin/legal/consents/{user_id}` | `settings:manage` | Все согласия пользователя |
+| GET | `/admin/legal/consents/check/{user_id}` | `settings:view` | Проверка обязательных согласий |
+| POST | `/admin/legal/consents/revoke` | `settings:manage` | Отозвать согласие |
+| GET | `/admin/legal/stats` | `settings:manage` | Статистика согласий |
+| POST | `/admin/legal/gdpr/delete` | `settings:manage` | Удаление данных пользователя (GDPR) |
+
 ## URL паттерны
 
 ### CRUD ресурсов
@@ -489,13 +514,22 @@ Content-Type: application/json
 
 | Паттерн | Описание | Пример |
 |---------|----------|--------|
-| `GET /admin/{resource}/stream` | Server-Sent Events | `/admin/chat/stream` |
+| `GET /admin/{resource}/stream` | Server-Sent Events | `/admin/monitor/gpu/stream` |
 
 **Формат SSE:**
 ```
 data: {"message": "chunk"}\n\n
 data: [DONE]\n\n
 ```
+
+Все SSE-эндпоинты требуют JWT-авторизацию (PR #420). Фронтенд использует `fetch + ReadableStream` вместо `EventSource`, чтобы передавать `Authorization: Bearer` заголовок. Эндпоинты:
+
+| Эндпоинт | Доступ | Описание |
+|----------|--------|----------|
+| `GET /admin/monitor/gpu/stream` | `system:view` | GPU-метрики (SSE) |
+| `GET /admin/logs/stream/{logfile}` | `system:view` | Стриминг логов |
+| `GET /admin/finetune/train/log` | `system:view` | Стриминг лога обучения |
+| `POST /admin/chat/stream` | `chat:edit` | Стриминг чата (отдельный flow) |
 
 ### Webhooks
 

--- a/wiki-pages/RBAC.md
+++ b/wiki-pages/RBAC.md
@@ -361,6 +361,15 @@ Frontend:
 | C3 | TTS preset UPDATE без проверки workspace | Добавлен `workspace_context()` в `tts.py`, `workspace_id` в `preset.py:update_preset()` |
 | L3 | `POST /change-password` без rate-limit | Добавлен `@limiter.limit(RATE_LIMIT_AUTH)` |
 
+### Security-фиксы аудита — средние (PR #420, Issue #412)
+
+| # | Проблема | Фикс |
+|---|----------|------|
+| C1 | Consent grant-эндпоинты под `/admin/` без auth, но вызываются виджетами/ботами | Перенесены на публичный путь: `/admin/legal/consents/grant*` → `/legal/consents/grant*`. `GET /admin/legal/consents/check/{user_id}` — добавлен `require_permission("settings", "view")` |
+| H3 | Legacy fallback `admin/admin` при ошибке БД | `except Exception` в `authenticate_user()` теперь возвращает `None`, не падает в фоллбэк. Legacy вход только при `user_count == 0` (пустая БД, первый запуск) |
+| H5 | SSE-эндпоинты без JWT (backend) | Дубликат `GET /admin/monitor/gpu/stream` из `orchestrator.py` удалён (auth-версия в `monitor.py`). Добавлен `require_permission("system", "view")` на `GET /admin/logs/stream/{logfile}` и `GET /admin/finetune/train/log` |
+| H5 | SSE-эндпоинты без JWT (frontend) | `createSSE()`, `useSSE`, `useRealtimeMetrics` переписаны с `EventSource` на `fetch + ReadableStream` — отправляют `Authorization: Bearer` заголовок. Polling fallback тоже с JWT. Auto-reconnect через 3 сек |
+
 ### Внешние контакты — user_identities
 
 Контакты из Telegram, WhatsApp и виджетов автоматически становятся пользователями с привязанными `user_identities` (миграция `0011`, PR #370).
@@ -572,9 +581,10 @@ WebSocket `/ws/claude-code` использует собственный `_ws_aut
 
 | Уровень | Кол-во | Эндпоинты |
 |---------|--------|-----------|
-| `manage` | 4 | GET/PUT terms, GET/PUT privacy |
+| `view` | 1 | GET consents/check/{user_id} (PR #420) |
+| `manage` | 4 | GET consents/{user_id}, POST revoke, GET stats, POST gdpr/delete |
 
-7 публичных эндпоинтов без авторизации: GET/POST consent, GET terms/privacy (public), GET consent/status, GET consent/export.
+7 публичных эндпоинтов без авторизации: GET/POST consent grant/grant-bulk/grant-required (виджеты/боты), GET privacy-policy, GET terms, GET consent-types.
 
 ### auth.py — инфраструктурный роутер
 


### PR DESCRIPTION
## Summary

Documentation update for PR #420 (medium security fixes from issue #412).

- **RBAC.md**: New section documenting C1 (consent path migration), H3 (legacy fallback fix), H5 (SSE auth backend + frontend). Updated legal.py permissions matrix.
- **API-Reference.md**: New Legal/Consent section with public endpoints (`/legal/consents/grant*`) and protected endpoints. SSE streaming section expanded with auth requirements table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)