### PR TITLE
fix: add Content-Security-Policy header (#413)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -69,22 +69,6 @@
     <script src="/widget.js?instance=tz-generator" defer></script>
 
     <!-- Force clear old SW caches, then register new SW -->
-    <script>
-      if ('serviceWorker' in navigator) {
-        // Unregister all old service workers first
-        navigator.serviceWorker.getRegistrations().then(regs => {
-          regs.forEach(r => r.unregister());
-        });
-        // Clear all caches
-        if ('caches' in window) {
-          caches.keys().then(names => names.forEach(n => caches.delete(n)));
-        }
-        window.addEventListener('load', () => {
-          navigator.serviceWorker.register('./sw.js')
-            .then(reg => console.log('SW registered:', reg.scope))
-            .catch(err => console.log('SW registration failed:', err));
-        });
-      }
-    </script>
+    <script src="./sw-cleanup.js" defer></script>
   </body>
 </html>

--- a/admin/public/sw-cleanup.js
+++ b/admin/public/sw-cleanup.js
@@ -1,0 +1,27 @@
+// Service Worker: clear old caches + register new SW
+if ("serviceWorker" in navigator) {
+  // Unregister all old service workers first
+  navigator.serviceWorker.getRegistrations().then(function (regs) {
+    regs.forEach(function (r) {
+      r.unregister();
+    });
+  });
+  // Clear all caches
+  if ("caches" in window) {
+    caches.keys().then(function (names) {
+      names.forEach(function (n) {
+        caches.delete(n);
+      });
+    });
+  }
+  window.addEventListener("load", function () {
+    navigator.serviceWorker
+      .register("./sw.js")
+      .then(function (reg) {
+        console.log("SW registered:", reg.scope);
+      })
+      .catch(function (err) {
+        console.log("SW registration failed:", err);
+      });
+  });
+}

--- a/app/security_headers.py
+++ b/app/security_headers.py
@@ -2,6 +2,7 @@
 Security headers middleware.
 
 Adds security headers to all responses:
+- Content-Security-Policy: script-src 'self', style-src 'self' 'unsafe-inline', etc.
 - X-Content-Type-Options: nosniff
 - X-Frame-Options: DENY (or SAMEORIGIN)
 - X-XSS-Protection: 1; mode=block
@@ -11,6 +12,7 @@ Adds security headers to all responses:
 Environment variables:
 - SECURITY_HEADERS_ENABLED: Enable security headers (default: true)
 - X_FRAME_OPTIONS: X-Frame-Options value (default: DENY)
+- CSP_ENABLED: Enable Content-Security-Policy (default: true)
 """
 
 import os
@@ -28,6 +30,21 @@ SECURITY_HEADERS_ENABLED = os.getenv("SECURITY_HEADERS_ENABLED", "true").lower()
     "yes",
 )
 X_FRAME_OPTIONS = os.getenv("X_FRAME_OPTIONS", "DENY")
+CSP_ENABLED = os.getenv("CSP_ENABLED", "true").lower() in ("true", "1", "yes")
+
+# Content-Security-Policy directives
+_CSP_DIRECTIVES = [
+    "default-src 'self'",
+    "script-src 'self'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: https:",
+    "font-src 'self'",
+    "connect-src 'self'",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+    "base-uri 'self'",
+]
+CONTENT_SECURITY_POLICY = "; ".join(_CSP_DIRECTIVES)
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
@@ -41,6 +58,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
 
         if self.enabled:
+            # Content Security Policy — primary XSS protection
+            if CSP_ENABLED:
+                response.headers["Content-Security-Policy"] = CONTENT_SECURITY_POLICY
+
             # Prevent MIME type sniffing
             response.headers["X-Content-Type-Options"] = "nosniff"
 
@@ -66,13 +87,17 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 def get_security_headers_status() -> dict:
     """Get current security headers configuration."""
+    headers: dict[str, str] = {
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": X_FRAME_OPTIONS,
+        "X-XSS-Protection": "1; mode=block",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "Permissions-Policy": "geolocation=()",
+    }
+    if CSP_ENABLED:
+        headers["Content-Security-Policy"] = CONTENT_SECURITY_POLICY
     return {
         "enabled": SECURITY_HEADERS_ENABLED,
-        "headers": {
-            "X-Content-Type-Options": "nosniff",
-            "X-Frame-Options": X_FRAME_OPTIONS,
-            "X-XSS-Protection": "1; mode=block",
-            "Referrer-Policy": "strict-origin-when-cross-origin",
-            "Permissions-Policy": "geolocation=()",
-        },
+        "csp_enabled": CSP_ENABLED,
+        "headers": headers,
     }


### PR DESCRIPTION
## Summary

Closes #413 — защита JWT от XSS через CSP-заголовки.

**CSP header** добавлен в `SecurityHeadersMiddleware`:
```
default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';
img-src 'self' data: https:; font-src 'self'; connect-src 'self';
frame-ancestors 'none'; object-src 'none'; base-uri 'self'
```

**Inline script extracted** — SW-код из `index.html` вынесен в `admin/public/sw-cleanup.js` (иначе `script-src 'self'` его заблокирует).

**Конфигурация:** `CSP_ENABLED=false` env var для отключения CSP отдельно от остальных security headers.

### Что защищает

- `script-src 'self'` — блокирует инъекцию скриптов через XSS (основная защита JWT в localStorage)
- `style-src 'self' 'unsafe-inline'` — Vue `:style` bindings и виджет требуют inline styles
- `frame-ancestors 'none'` — усиленная версия X-Frame-Options (CSP Level 2)
- `object-src 'none'` — блокирует Flash/Java plugins
- `base-uri 'self'` — предотвращает `<base>` tag injection

### Что не затронуто

- DOMPurify + marked — уже правильно используются во всех 9 местах с `v-html`
- Версии библиотек актуальны (DOMPurify 3.3.1, marked 17.0.2)
- Demo mode не затронут (monkey-patch fetch, не скрипты)
- WebSocket / SSE работают через `connect-src 'self'`

## Files changed (3)

| File | Change |
|------|--------|
| `app/security_headers.py` | CSP header + CSP_ENABLED env + status function |
| `admin/index.html` | Replace inline `<script>` with `<script src="./sw-cleanup.js">` |
| `admin/public/sw-cleanup.js` | New: extracted SW cleanup code |

## Test plan

- [ ] `curl -I http://localhost:8002/admin/` — verify `Content-Security-Policy` header present
- [ ] Admin panel loads correctly (no console CSP violations)
- [ ] Chat markdown rendering works (DOMPurify + marked)
- [ ] Dashboard GPU metrics (SSE via `connect-src 'self'`)
- [ ] Claude Code WebSocket works (`connect-src 'self'`)
- [ ] Widget chat works (inline styles via `style-src 'unsafe-inline'`)
- [ ] `CSP_ENABLED=false` — CSP header not sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)