### PR TITLE
fix: kanban owner_id FK for RBAC access control (#414)

### DIFF
--- a/admin/src/api/demo/kanban.ts
+++ b/admin/src/api/demo/kanban.ts
@@ -1,169 +1,175 @@
-import type { DemoRoute } from './types'
+import type { DemoRoute } from "./types";
 
 interface MockChecklistItem {
-  id: number
-  task_id: number
-  text: string
-  is_done: boolean
-  position: number
+  id: number;
+  task_id: number;
+  text: string;
+  is_done: boolean;
+  position: number;
 }
 
 interface MockTask {
-  id: number
-  title: string
-  description: string | null
-  status: string
-  is_private: boolean
-  assignee: string | null
-  created_by: string
-  start_date: string | null
-  due_date: string | null
-  position: number
-  tags: string[]
-  project_id: number | null
-  github_issue_number: number | null
-  checklist: MockChecklistItem[]
-  blockers: number[]
-  dependents: number[]
-  created: string
-  updated: string
+  id: number;
+  title: string;
+  description: string | null;
+  status: string;
+  is_private: boolean;
+  assignee: string | null;
+  created_by: string;
+  owner_id: number | null;
+  start_date: string | null;
+  due_date: string | null;
+  position: number;
+  tags: string[];
+  project_id: number | null;
+  github_issue_number: number | null;
+  checklist: MockChecklistItem[];
+  blockers: number[];
+  dependents: number[];
+  created: string;
+  updated: string;
 }
 
 interface MockProject {
-  id: number
-  name: string
-  github_owner: string
-  github_repo: string
-  has_token: boolean
-  webhook_secret_set: boolean
-  label_mapping: Record<string, string>
-  sync_enabled: boolean
-  last_synced: string | null
-  created: string | null
-  updated: string | null
+  id: number;
+  name: string;
+  github_owner: string;
+  github_repo: string;
+  has_token: boolean;
+  webhook_secret_set: boolean;
+  label_mapping: Record<string, string>;
+  sync_enabled: boolean;
+  last_synced: string | null;
+  created: string | null;
+  updated: string | null;
 }
 
-let nextProjectId = 2
+let nextProjectId = 2;
 const projects: MockProject[] = [
   {
     id: 1,
-    name: 'AI Secretary System',
-    github_owner: 'ShaerWare',
-    github_repo: 'AI_Secretary_System',
+    name: "AI Secretary System",
+    github_owner: "ShaerWare",
+    github_repo: "AI_Secretary_System",
     has_token: true,
     webhook_secret_set: true,
     label_mapping: {
-      todo: 'status:todo',
-      in_progress: 'status:in_progress',
-      review: 'status:review',
+      todo: "status:todo",
+      in_progress: "status:in_progress",
+      review: "status:review",
     },
     sync_enabled: true,
-    last_synced: '2026-02-22T10:00:00',
-    created: '2026-02-20T08:00:00',
-    updated: '2026-02-22T10:00:00',
+    last_synced: "2026-02-22T10:00:00",
+    created: "2026-02-20T08:00:00",
+    updated: "2026-02-22T10:00:00",
   },
-]
+];
 
-let nextId = 10
+let nextId = 10;
 const tasks: MockTask[] = [
   {
     id: 1,
-    title: 'Настроить интеграцию с Telegram',
-    description: 'Подключить бота к Telegram API и настроить вебхуки',
-    status: 'done',
+    title: "Настроить интеграцию с Telegram",
+    description: "Подключить бота к Telegram API и настроить вебхуки",
+    status: "done",
     is_private: false,
-    assignee: 'admin',
-    created_by: 'admin',
-    start_date: '2026-01-10',
-    due_date: '2026-01-20',
+    assignee: "admin",
+    created_by: "admin",
+    owner_id: 1,
+    start_date: "2026-01-10",
+    due_date: "2026-01-20",
     position: 0,
-    tags: ['интеграция', 'telegram'],
+    tags: ["интеграция", "telegram"],
     project_id: null,
     github_issue_number: null,
     checklist: [
-      { id: 1, task_id: 1, text: 'Получить токен бота', is_done: true, position: 0 },
-      { id: 2, task_id: 1, text: 'Настроить вебхук', is_done: true, position: 1 },
+      { id: 1, task_id: 1, text: "Получить токен бота", is_done: true, position: 0 },
+      { id: 2, task_id: 1, text: "Настроить вебхук", is_done: true, position: 1 },
     ],
     blockers: [],
     dependents: [2],
-    created: '2026-01-10T10:00:00',
-    updated: '2026-01-20T15:30:00',
+    created: "2026-01-10T10:00:00",
+    updated: "2026-01-20T15:30:00",
   },
   {
     id: 2,
-    title: 'Тестирование Telegram-бота',
-    description: 'Провести полное тестирование бота в Telegram',
-    status: 'in_progress',
+    title: "Тестирование Telegram-бота",
+    description: "Провести полное тестирование бота в Telegram",
+    status: "in_progress",
     is_private: false,
-    assignee: 'admin',
-    created_by: 'admin',
-    start_date: '2026-01-21',
-    due_date: '2026-02-01',
+    assignee: "admin",
+    created_by: "admin",
+    owner_id: 1,
+    start_date: "2026-01-21",
+    due_date: "2026-02-01",
     position: 0,
-    tags: ['тестирование'],
+    tags: ["тестирование"],
     project_id: null,
     github_issue_number: null,
     checklist: [
-      { id: 3, task_id: 2, text: 'Тест отправки сообщений', is_done: true, position: 0 },
-      { id: 4, task_id: 2, text: 'Тест голосовых сообщений', is_done: false, position: 1 },
+      { id: 3, task_id: 2, text: "Тест отправки сообщений", is_done: true, position: 0 },
+      { id: 4, task_id: 2, text: "Тест голосовых сообщений", is_done: false, position: 1 },
     ],
     blockers: [1],
     dependents: [],
-    created: '2026-01-21T09:00:00',
-    updated: '2026-01-25T12:00:00',
+    created: "2026-01-21T09:00:00",
+    updated: "2026-01-25T12:00:00",
   },
   {
     id: 3,
-    title: 'Добавить FAQ раздел',
-    description: 'Создать базу часто задаваемых вопросов для бота',
-    status: 'todo',
+    title: "Добавить FAQ раздел",
+    description: "Создать базу часто задаваемых вопросов для бота",
+    status: "todo",
     is_private: false,
     assignee: null,
-    created_by: 'admin',
+    created_by: "admin",
+    owner_id: 1,
     start_date: null,
-    due_date: '2026-02-15',
+    due_date: "2026-02-15",
     position: 0,
-    tags: ['контент', 'faq'],
+    tags: ["контент", "faq"],
     project_id: null,
     github_issue_number: null,
     checklist: [],
     blockers: [],
     dependents: [],
-    created: '2026-01-15T14:00:00',
-    updated: '2026-01-15T14:00:00',
+    created: "2026-01-15T14:00:00",
+    updated: "2026-01-15T14:00:00",
   },
   {
     id: 4,
-    title: 'Настроить виджет на сайте',
-    description: 'Установить чат-виджет на основной сайт компании',
-    status: 'review',
+    title: "Настроить виджет на сайте",
+    description: "Установить чат-виджет на основной сайт компании",
+    status: "review",
     is_private: false,
-    assignee: 'admin',
-    created_by: 'admin',
-    start_date: '2026-02-01',
-    due_date: '2026-02-10',
+    assignee: "admin",
+    created_by: "admin",
+    owner_id: 1,
+    start_date: "2026-02-01",
+    due_date: "2026-02-10",
     position: 0,
-    tags: ['виджет', 'сайт'],
+    tags: ["виджет", "сайт"],
     project_id: null,
     github_issue_number: null,
     checklist: [
-      { id: 5, task_id: 4, text: 'Сгенерировать код виджета', is_done: true, position: 0 },
-      { id: 6, task_id: 4, text: 'Встроить на сайт', is_done: true, position: 1 },
-      { id: 7, task_id: 4, text: 'Проверить на мобильных', is_done: false, position: 2 },
+      { id: 5, task_id: 4, text: "Сгенерировать код виджета", is_done: true, position: 0 },
+      { id: 6, task_id: 4, text: "Встроить на сайт", is_done: true, position: 1 },
+      { id: 7, task_id: 4, text: "Проверить на мобильных", is_done: false, position: 2 },
     ],
     blockers: [],
     dependents: [],
-    created: '2026-02-01T08:00:00',
-    updated: '2026-02-08T16:00:00',
+    created: "2026-02-01T08:00:00",
+    updated: "2026-02-08T16:00:00",
   },
   {
     id: 5,
-    title: 'Обновить модель LLM',
+    title: "Обновить модель LLM",
     description: null,
-    status: 'draft',
+    status: "draft",
     is_private: true,
     assignee: null,
-    created_by: 'admin',
+    created_by: "admin",
+    owner_id: 1,
     start_date: null,
     due_date: null,
     position: 0,
@@ -173,205 +179,210 @@ const tasks: MockTask[] = [
     checklist: [],
     blockers: [],
     dependents: [],
-    created: '2026-02-10T11:00:00',
-    updated: '2026-02-10T11:00:00',
+    created: "2026-02-10T11:00:00",
+    updated: "2026-02-10T11:00:00",
   },
   {
     id: 6,
-    title: 'Подготовить документацию',
-    description: 'Написать пользовательскую документацию для админ-панели',
-    status: 'todo',
+    title: "Подготовить документацию",
+    description: "Написать пользовательскую документацию для админ-панели",
+    status: "todo",
     is_private: false,
-    assignee: 'admin',
-    created_by: 'admin',
-    start_date: '2026-02-15',
-    due_date: '2026-03-01',
+    assignee: "admin",
+    created_by: "admin",
+    owner_id: 1,
+    start_date: "2026-02-15",
+    due_date: "2026-03-01",
     position: 1,
-    tags: ['документация'],
+    tags: ["документация"],
     project_id: null,
     github_issue_number: null,
     checklist: [],
     blockers: [],
     dependents: [],
-    created: '2026-02-12T10:00:00',
-    updated: '2026-02-12T10:00:00',
+    created: "2026-02-12T10:00:00",
+    updated: "2026-02-12T10:00:00",
   },
   // GitHub-linked tasks
   {
     id: 7,
-    title: 'Implement multi-project kanban',
-    description: 'Add KanbanProject model and bidirectional GitHub sync',
-    status: 'in_progress',
+    title: "Implement multi-project kanban",
+    description: "Add KanbanProject model and bidirectional GitHub sync",
+    status: "in_progress",
     is_private: false,
-    assignee: 'admin',
-    created_by: 'github',
-    start_date: '2026-02-20',
-    due_date: '2026-02-25',
+    assignee: "admin",
+    created_by: "github",
+    owner_id: null,
+    start_date: "2026-02-20",
+    due_date: "2026-02-25",
     position: 0,
-    tags: ['enhancement'],
+    tags: ["enhancement"],
     project_id: 1,
     github_issue_number: 42,
     checklist: [
-      { id: 8, task_id: 7, text: 'DB models', is_done: true, position: 0 },
-      { id: 9, task_id: 7, text: 'API endpoints', is_done: true, position: 1 },
-      { id: 10, task_id: 7, text: 'Frontend UI', is_done: false, position: 2 },
+      { id: 8, task_id: 7, text: "DB models", is_done: true, position: 0 },
+      { id: 9, task_id: 7, text: "API endpoints", is_done: true, position: 1 },
+      { id: 10, task_id: 7, text: "Frontend UI", is_done: false, position: 2 },
     ],
     blockers: [],
     dependents: [],
-    created: '2026-02-20T09:00:00',
-    updated: '2026-02-22T14:00:00',
+    created: "2026-02-20T09:00:00",
+    updated: "2026-02-22T14:00:00",
   },
   {
     id: 8,
-    title: 'Fix widget loading on mobile',
-    description: 'Widget does not load properly on iOS Safari',
-    status: 'todo',
+    title: "Fix widget loading on mobile",
+    description: "Widget does not load properly on iOS Safari",
+    status: "todo",
     is_private: false,
     assignee: null,
-    created_by: 'github',
+    created_by: "github",
+    owner_id: null,
     start_date: null,
     due_date: null,
     position: 1,
-    tags: ['bug'],
+    tags: ["bug"],
     project_id: 1,
     github_issue_number: 38,
     checklist: [],
     blockers: [],
     dependents: [],
-    created: '2026-02-18T10:00:00',
-    updated: '2026-02-18T10:00:00',
+    created: "2026-02-18T10:00:00",
+    updated: "2026-02-18T10:00:00",
   },
   {
     id: 9,
-    title: 'Add WhatsApp channel support',
-    description: 'Integrate WhatsApp Business API',
-    status: 'done',
+    title: "Add WhatsApp channel support",
+    description: "Integrate WhatsApp Business API",
+    status: "done",
     is_private: false,
-    assignee: 'admin',
-    created_by: 'github',
-    start_date: '2026-02-10',
-    due_date: '2026-02-20',
+    assignee: "admin",
+    created_by: "github",
+    owner_id: null,
+    start_date: "2026-02-10",
+    due_date: "2026-02-20",
     position: 0,
-    tags: ['feature'],
+    tags: ["feature"],
     project_id: 1,
     github_issue_number: 35,
     checklist: [],
     blockers: [],
     dependents: [],
-    created: '2026-02-10T08:00:00',
-    updated: '2026-02-20T16:00:00',
+    created: "2026-02-10T08:00:00",
+    updated: "2026-02-20T16:00:00",
   },
-]
+];
 
-let nextChecklistId = 12
+let nextChecklistId = 12;
 
 export const kanbanRoutes: DemoRoute[] = [
   // GET /admin/kanban/projects
   {
-    method: 'GET',
+    method: "GET",
     pattern: /^\/admin\/kanban\/projects$/,
     handler: () => ({ projects }),
   },
   // POST /admin/kanban/projects
   {
-    method: 'POST',
+    method: "POST",
     pattern: /^\/admin\/kanban\/projects$/,
     handler: ({ body }) => {
-      const b = body as Record<string, unknown>
+      const b = body as Record<string, unknown>;
       const project: MockProject = {
         id: nextProjectId++,
-        name: (b.name as string) || 'New Project',
-        github_owner: (b.github_owner as string) || '',
-        github_repo: (b.github_repo as string) || '',
+        name: (b.name as string) || "New Project",
+        github_owner: (b.github_owner as string) || "",
+        github_repo: (b.github_repo as string) || "",
         has_token: !!(b.github_token as string),
         webhook_secret_set: !!(b.webhook_secret as string),
         label_mapping: (b.label_mapping as Record<string, string>) || {
-          todo: 'status:todo',
-          in_progress: 'status:in_progress',
-          review: 'status:review',
+          todo: "status:todo",
+          in_progress: "status:in_progress",
+          review: "status:review",
         },
         sync_enabled: (b.sync_enabled as boolean) ?? true,
         last_synced: null,
         created: new Date().toISOString(),
         updated: new Date().toISOString(),
-      }
-      projects.push(project)
-      return { project }
+      };
+      projects.push(project);
+      return { project };
     },
   },
   // PATCH /admin/kanban/projects/:id
   {
-    method: 'PATCH',
+    method: "PATCH",
     pattern: /^\/admin\/kanban\/projects\/(\d+)$/,
     handler: ({ matches, body }) => {
-      const id = Number(matches[1])
-      const project = projects.find((p) => p.id === id)
-      if (!project) throw new Error('Project not found')
-      const b = body as Record<string, unknown>
-      if (b.name !== undefined) project.name = b.name as string
-      if (b.github_owner !== undefined) project.github_owner = b.github_owner as string
-      if (b.github_repo !== undefined) project.github_repo = b.github_repo as string
-      if (b.github_token !== undefined) project.has_token = !!(b.github_token as string)
+      const id = Number(matches[1]);
+      const project = projects.find((p) => p.id === id);
+      if (!project) throw new Error("Project not found");
+      const b = body as Record<string, unknown>;
+      if (b.name !== undefined) project.name = b.name as string;
+      if (b.github_owner !== undefined) project.github_owner = b.github_owner as string;
+      if (b.github_repo !== undefined) project.github_repo = b.github_repo as string;
+      if (b.github_token !== undefined) project.has_token = !!(b.github_token as string);
       if (b.webhook_secret !== undefined)
-        project.webhook_secret_set = !!(b.webhook_secret as string)
+        project.webhook_secret_set = !!(b.webhook_secret as string);
       if (b.label_mapping !== undefined)
-        project.label_mapping = b.label_mapping as Record<string, string>
-      if (b.sync_enabled !== undefined) project.sync_enabled = b.sync_enabled as boolean
-      project.updated = new Date().toISOString()
-      return { project }
+        project.label_mapping = b.label_mapping as Record<string, string>;
+      if (b.sync_enabled !== undefined) project.sync_enabled = b.sync_enabled as boolean;
+      project.updated = new Date().toISOString();
+      return { project };
     },
   },
   // DELETE /admin/kanban/projects/:id
   {
-    method: 'DELETE',
+    method: "DELETE",
     pattern: /^\/admin\/kanban\/projects\/(\d+)$/,
     handler: ({ matches }) => {
-      const id = Number(matches[1])
-      const idx = projects.findIndex((p) => p.id === id)
-      if (idx === -1) throw new Error('Project not found')
-      projects.splice(idx, 1)
-      return { status: 'deleted' }
+      const id = Number(matches[1]);
+      const idx = projects.findIndex((p) => p.id === id);
+      if (idx === -1) throw new Error("Project not found");
+      projects.splice(idx, 1);
+      return { status: "deleted" };
     },
   },
   // POST /admin/kanban/projects/:id/sync
   {
-    method: 'POST',
+    method: "POST",
     pattern: /^\/admin\/kanban\/projects\/(\d+)\/sync$/,
     handler: ({ matches }) => {
-      const id = Number(matches[1])
-      const project = projects.find((p) => p.id === id)
-      if (!project) throw new Error('Project not found')
-      project.last_synced = new Date().toISOString()
-      return { created: 0, updated: 3, total: 3 }
+      const id = Number(matches[1]);
+      const project = projects.find((p) => p.id === id);
+      if (!project) throw new Error("Project not found");
+      project.last_synced = new Date().toISOString();
+      return { created: 0, updated: 3, total: 3 };
     },
   },
   // GET /admin/kanban/tasks
   {
-    method: 'GET',
+    method: "GET",
     pattern: /^\/admin\/kanban\/tasks$/,
     handler: ({ searchParams }) => {
-      const projectIdStr = searchParams.get('project_id')
+      const projectIdStr = searchParams.get("project_id");
       if (projectIdStr !== null) {
-        const projectId = Number(projectIdStr)
-        return { tasks: tasks.filter((t) => t.project_id === projectId) }
+        const projectId = Number(projectIdStr);
+        return { tasks: tasks.filter((t) => t.project_id === projectId) };
       }
-      return { tasks: tasks.filter((t) => t.project_id === null) }
+      return { tasks: tasks.filter((t) => t.project_id === null) };
     },
   },
   // POST /admin/kanban/tasks
   {
-    method: 'POST',
+    method: "POST",
     pattern: /^\/admin\/kanban\/tasks$/,
     handler: ({ body }) => {
-      const b = body as Record<string, unknown>
+      const b = body as Record<string, unknown>;
       const task: MockTask = {
         id: nextId++,
-        title: (b.title as string) || 'Новая задача',
+        title: (b.title as string) || "Новая задача",
         description: (b.description as string) || null,
-        status: 'draft',
+        status: "draft",
         is_private: true,
         assignee: (b.assignee as string) || null,
-        created_by: 'admin',
+        created_by: "admin",
+        owner_id: 1,
         start_date: (b.start_date as string) || null,
         due_date: (b.due_date as string) || null,
         position: tasks.length,
@@ -383,140 +394,140 @@ export const kanbanRoutes: DemoRoute[] = [
         dependents: [],
         created: new Date().toISOString(),
         updated: new Date().toISOString(),
-      }
-      tasks.push(task)
-      return { task }
+      };
+      tasks.push(task);
+      return { task };
     },
   },
   // PATCH /admin/kanban/tasks/:id
   {
-    method: 'PATCH',
+    method: "PATCH",
     pattern: /^\/admin\/kanban\/tasks\/(\d+)$/,
     handler: ({ matches, body }) => {
-      const id = Number(matches[1])
-      const task = tasks.find((t) => t.id === id)
-      if (!task) throw new Error('Task not found')
-      const b = body as Record<string, unknown>
-      if (b.title !== undefined) task.title = b.title as string
-      if (b.description !== undefined) task.description = b.description as string | null
+      const id = Number(matches[1]);
+      const task = tasks.find((t) => t.id === id);
+      if (!task) throw new Error("Task not found");
+      const b = body as Record<string, unknown>;
+      if (b.title !== undefined) task.title = b.title as string;
+      if (b.description !== undefined) task.description = b.description as string | null;
       if (b.status !== undefined) {
-        task.status = b.status as string
-        if (task.status !== 'draft') task.is_private = false
+        task.status = b.status as string;
+        if (task.status !== "draft") task.is_private = false;
       }
-      if (b.assignee !== undefined) task.assignee = b.assignee as string | null
-      if (b.start_date !== undefined) task.start_date = b.start_date as string | null
-      if (b.due_date !== undefined) task.due_date = b.due_date as string | null
-      if (b.tags !== undefined) task.tags = b.tags as string[]
-      if (b.is_private !== undefined) task.is_private = b.is_private as boolean
-      task.updated = new Date().toISOString()
-      return { task }
+      if (b.assignee !== undefined) task.assignee = b.assignee as string | null;
+      if (b.start_date !== undefined) task.start_date = b.start_date as string | null;
+      if (b.due_date !== undefined) task.due_date = b.due_date as string | null;
+      if (b.tags !== undefined) task.tags = b.tags as string[];
+      if (b.is_private !== undefined) task.is_private = b.is_private as boolean;
+      task.updated = new Date().toISOString();
+      return { task };
     },
   },
   // DELETE /admin/kanban/tasks/:id
   {
-    method: 'DELETE',
+    method: "DELETE",
     pattern: /^\/admin\/kanban\/tasks\/(\d+)$/,
     handler: ({ matches }) => {
-      const id = Number(matches[1])
-      const idx = tasks.findIndex((t) => t.id === id)
-      if (idx === -1) throw new Error('Task not found')
-      tasks.splice(idx, 1)
-      return { status: 'ok' }
+      const id = Number(matches[1]);
+      const idx = tasks.findIndex((t) => t.id === id);
+      if (idx === -1) throw new Error("Task not found");
+      tasks.splice(idx, 1);
+      return { status: "ok" };
     },
   },
   // POST /admin/kanban/reorder
   {
-    method: 'POST',
+    method: "POST",
     pattern: /^\/admin\/kanban\/reorder$/,
     handler: ({ body }) => {
-      const b = body as Record<string, unknown>
-      const task = tasks.find((t) => t.id === (b.task_id as number))
-      if (!task) throw new Error('Task not found')
-      task.status = b.new_status as string
-      task.position = b.new_position as number
-      if (task.status !== 'draft') task.is_private = false
-      task.updated = new Date().toISOString()
-      return { task }
+      const b = body as Record<string, unknown>;
+      const task = tasks.find((t) => t.id === (b.task_id as number));
+      if (!task) throw new Error("Task not found");
+      task.status = b.new_status as string;
+      task.position = b.new_position as number;
+      if (task.status !== "draft") task.is_private = false;
+      task.updated = new Date().toISOString();
+      return { task };
     },
   },
   // POST /admin/kanban/dependencies
   {
-    method: 'POST',
+    method: "POST",
     pattern: /^\/admin\/kanban\/dependencies$/,
     handler: ({ body }) => {
-      const b = body as Record<string, unknown>
-      const blocker = tasks.find((t) => t.id === (b.blocker_id as number))
-      const dependent = tasks.find((t) => t.id === (b.dependent_id as number))
-      if (!blocker || !dependent) throw new Error('Task not found')
-      if (!blocker.dependents.includes(dependent.id)) blocker.dependents.push(dependent.id)
-      if (!dependent.blockers.includes(blocker.id)) dependent.blockers.push(blocker.id)
-      return { status: 'ok' }
+      const b = body as Record<string, unknown>;
+      const blocker = tasks.find((t) => t.id === (b.blocker_id as number));
+      const dependent = tasks.find((t) => t.id === (b.dependent_id as number));
+      if (!blocker || !dependent) throw new Error("Task not found");
+      if (!blocker.dependents.includes(dependent.id)) blocker.dependents.push(dependent.id);
+      if (!dependent.blockers.includes(blocker.id)) dependent.blockers.push(blocker.id);
+      return { status: "ok" };
     },
   },
   // DELETE /admin/kanban/dependencies
   {
-    method: 'DELETE',
+    method: "DELETE",
     pattern: /^\/admin\/kanban\/dependencies$/,
     handler: ({ searchParams }) => {
-      const blockerId = Number(searchParams.get('blocker_id'))
-      const dependentId = Number(searchParams.get('dependent_id'))
-      const blocker = tasks.find((t) => t.id === blockerId)
-      const dependent = tasks.find((t) => t.id === dependentId)
-      if (blocker) blocker.dependents = blocker.dependents.filter((d) => d !== dependentId)
-      if (dependent) dependent.blockers = dependent.blockers.filter((b) => b !== blockerId)
-      return { status: 'ok' }
+      const blockerId = Number(searchParams.get("blocker_id"));
+      const dependentId = Number(searchParams.get("dependent_id"));
+      const blocker = tasks.find((t) => t.id === blockerId);
+      const dependent = tasks.find((t) => t.id === dependentId);
+      if (blocker) blocker.dependents = blocker.dependents.filter((d) => d !== dependentId);
+      if (dependent) dependent.blockers = dependent.blockers.filter((b) => b !== blockerId);
+      return { status: "ok" };
     },
   },
   // POST /admin/kanban/tasks/:id/checklist
   {
-    method: 'POST',
+    method: "POST",
     pattern: /^\/admin\/kanban\/tasks\/(\d+)\/checklist$/,
     handler: ({ matches, body }) => {
-      const taskId = Number(matches[1])
-      const task = tasks.find((t) => t.id === taskId)
-      if (!task) throw new Error('Task not found')
-      const b = body as Record<string, unknown>
+      const taskId = Number(matches[1]);
+      const task = tasks.find((t) => t.id === taskId);
+      if (!task) throw new Error("Task not found");
+      const b = body as Record<string, unknown>;
       const item = {
         id: nextChecklistId++,
         task_id: taskId,
-        text: (b.text as string) || '',
+        text: (b.text as string) || "",
         is_done: false,
         position: (b.position as number) || 0,
-      }
-      task.checklist.push(item)
-      return { item }
+      };
+      task.checklist.push(item);
+      return { item };
     },
   },
   // PATCH /admin/kanban/checklist/:id/toggle
   {
-    method: 'PATCH',
+    method: "PATCH",
     pattern: /^\/admin\/kanban\/checklist\/(\d+)\/toggle$/,
     handler: ({ matches }) => {
-      const itemId = Number(matches[1])
+      const itemId = Number(matches[1]);
       for (const task of tasks) {
-        const item = task.checklist.find((c) => c.id === itemId)
+        const item = task.checklist.find((c) => c.id === itemId);
         if (item) {
-          item.is_done = !item.is_done
-          return { item }
+          item.is_done = !item.is_done;
+          return { item };
         }
       }
-      throw new Error('Checklist item not found')
+      throw new Error("Checklist item not found");
     },
   },
   // DELETE /admin/kanban/checklist/:id
   {
-    method: 'DELETE',
+    method: "DELETE",
     pattern: /^\/admin\/kanban\/checklist\/(\d+)$/,
     handler: ({ matches }) => {
-      const itemId = Number(matches[1])
+      const itemId = Number(matches[1]);
       for (const task of tasks) {
-        const idx = task.checklist.findIndex((c) => c.id === itemId)
+        const idx = task.checklist.findIndex((c) => c.id === itemId);
         if (idx !== -1) {
-          task.checklist.splice(idx, 1)
-          return { status: 'ok' }
+          task.checklist.splice(idx, 1);
+          return { status: "ok" };
         }
       }
-      throw new Error('Checklist item not found')
+      throw new Error("Checklist item not found");
     },
   },
-]
+];

--- a/admin/src/api/kanban.ts
+++ b/admin/src/api/kanban.ts
@@ -1,115 +1,114 @@
-import { api } from './client'
+import { api } from "./client";
 
 export interface KanbanProject {
-  id: number
-  name: string
-  github_owner: string
-  github_repo: string
-  has_token: boolean
-  webhook_secret_set: boolean
-  label_mapping: Record<string, string>
-  sync_enabled: boolean
-  last_synced: string | null
-  created: string | null
-  updated: string | null
+  id: number;
+  name: string;
+  github_owner: string;
+  github_repo: string;
+  has_token: boolean;
+  webhook_secret_set: boolean;
+  label_mapping: Record<string, string>;
+  sync_enabled: boolean;
+  last_synced: string | null;
+  created: string | null;
+  updated: string | null;
 }
 
 export interface KanbanTask {
-  id: number
-  title: string
-  description: string | null
-  status: string
-  is_private: boolean
-  assignee: string | null
-  created_by: string
-  start_date: string | null
-  due_date: string | null
-  position: number
-  tags: string[]
-  project_id: number | null
-  github_issue_number: number | null
-  checklist: ChecklistItem[]
-  blockers: number[]
-  dependents: number[]
-  created: string | null
-  updated: string | null
+  id: number;
+  title: string;
+  description: string | null;
+  status: string;
+  is_private: boolean;
+  assignee: string | null;
+  created_by: string;
+  owner_id: number | null;
+  start_date: string | null;
+  due_date: string | null;
+  position: number;
+  tags: string[];
+  project_id: number | null;
+  github_issue_number: number | null;
+  checklist: ChecklistItem[];
+  blockers: number[];
+  dependents: number[];
+  created: string | null;
+  updated: string | null;
 }
 
 export interface ChecklistItem {
-  id: number
-  task_id: number
-  text: string
-  is_done: boolean
-  position: number
+  id: number;
+  task_id: number;
+  text: string;
+  is_done: boolean;
+  position: number;
 }
 
 export interface TaskCreateData {
-  title: string
-  description?: string
-  status?: string
-  assignee?: string
-  start_date?: string
-  due_date?: string
-  tags?: string[]
+  title: string;
+  description?: string;
+  status?: string;
+  assignee?: string;
+  start_date?: string;
+  due_date?: string;
+  tags?: string[];
 }
 
 export interface TaskUpdateData {
-  title?: string
-  description?: string
-  status?: string
-  assignee?: string
-  start_date?: string
-  due_date?: string
-  tags?: string[]
-  is_private?: boolean
+  title?: string;
+  description?: string;
+  status?: string;
+  assignee?: string;
+  start_date?: string;
+  due_date?: string;
+  tags?: string[];
+  is_private?: boolean;
 }
 
 export interface ProjectCreateData {
-  name: string
-  github_owner: string
-  github_repo: string
-  github_token?: string
-  webhook_secret?: string
-  label_mapping?: Record<string, string>
-  sync_enabled?: boolean
+  name: string;
+  github_owner: string;
+  github_repo: string;
+  github_token?: string;
+  webhook_secret?: string;
+  label_mapping?: Record<string, string>;
+  sync_enabled?: boolean;
 }
 
 export interface ProjectUpdateData {
-  name?: string
-  github_owner?: string
-  github_repo?: string
-  github_token?: string
-  webhook_secret?: string
-  label_mapping?: Record<string, string>
-  sync_enabled?: boolean
+  name?: string;
+  github_owner?: string;
+  github_repo?: string;
+  github_token?: string;
+  webhook_secret?: string;
+  label_mapping?: Record<string, string>;
+  sync_enabled?: boolean;
 }
 
 export const kanbanApi = {
   // Projects
-  getProjects: () => api.get<{ projects: KanbanProject[] }>('/admin/kanban/projects'),
+  getProjects: () => api.get<{ projects: KanbanProject[] }>("/admin/kanban/projects"),
 
   createProject: (data: ProjectCreateData) =>
-    api.post<{ project: KanbanProject }>('/admin/kanban/projects', data),
+    api.post<{ project: KanbanProject }>("/admin/kanban/projects", data),
 
   updateProject: (id: number, data: ProjectUpdateData) =>
     api.patch<{ project: KanbanProject }>(`/admin/kanban/projects/${id}`, data),
 
-  deleteProject: (id: number) =>
-    api.delete<{ status: string }>(`/admin/kanban/projects/${id}`),
+  deleteProject: (id: number) => api.delete<{ status: string }>(`/admin/kanban/projects/${id}`),
 
   syncProject: (id: number) =>
     api.post<{ created: number; updated: number; total: number }>(
-      `/admin/kanban/projects/${id}/sync`,
+      `/admin/kanban/projects/${id}/sync`
     ),
 
   // Tasks
   getTasks: (projectId?: number | null) => {
-    const params = projectId != null ? `?project_id=${projectId}` : ''
-    return api.get<{ tasks: KanbanTask[] }>(`/admin/kanban/tasks${params}`)
+    const params = projectId != null ? `?project_id=${projectId}` : "";
+    return api.get<{ tasks: KanbanTask[] }>(`/admin/kanban/tasks${params}`);
   },
 
-  createTask: (data: TaskCreateData) =>
-    api.post<{ task: KanbanTask }>('/admin/kanban/tasks', data),
+  createTask: (data: TaskCreateData) => api.post<{ task: KanbanTask }>("/admin/kanban/tasks", data),
 
   updateTask: (id: number, data: TaskUpdateData) =>
     api.patch<{ task: KanbanTask }>(`/admin/kanban/tasks/${id}`, data),
@@ -117,21 +116,21 @@ export const kanbanApi = {
   deleteTask: (id: number) => api.delete<{ status: string }>(`/admin/kanban/tasks/${id}`),
 
   reorder: (taskId: number, newStatus: string, newPosition: number) =>
-    api.post<{ task: KanbanTask }>('/admin/kanban/reorder', {
+    api.post<{ task: KanbanTask }>("/admin/kanban/reorder", {
       task_id: taskId,
       new_status: newStatus,
       new_position: newPosition,
     }),
 
   addDependency: (blockerId: number, dependentId: number) =>
-    api.post<{ status: string }>('/admin/kanban/dependencies', {
+    api.post<{ status: string }>("/admin/kanban/dependencies", {
       blocker_id: blockerId,
       dependent_id: dependentId,
     }),
 
   removeDependency: (blockerId: number, dependentId: number) =>
     api.delete<{ status: string }>(
-      `/admin/kanban/dependencies?blocker_id=${blockerId}&dependent_id=${dependentId}`,
+      `/admin/kanban/dependencies?blocker_id=${blockerId}&dependent_id=${dependentId}`
     ),
 
   addChecklistItem: (taskId: number, text: string, position: number = 0) =>
@@ -145,4 +144,4 @@ export const kanbanApi = {
 
   deleteChecklistItem: (itemId: number) =>
     api.delete<{ status: string }>(`/admin/kanban/checklist/${itemId}`),
-}
+};

--- a/alembic/versions/20260225_0013_add_kanban_task_owner_id.py
+++ b/alembic/versions/20260225_0013_add_kanban_task_owner_id.py
@@ -1,0 +1,48 @@
+"""Add owner_id FK to kanban_tasks, backfill from created_by.
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-02-25
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0013"
+down_revision: Union[str, None] = "0012"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add owner_id column (nullable — GitHub-synced tasks have no local owner)
+    with op.batch_alter_table("kanban_tasks") as batch_op:
+        batch_op.add_column(sa.Column("owner_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_kanban_tasks_owner_id", "users", ["owner_id"], ["id"], ondelete="SET NULL"
+        )
+        batch_op.create_index("ix_kanban_tasks_owner_id", ["owner_id"])
+
+    # Backfill owner_id from created_by → users.username
+    op.execute(
+        """
+        UPDATE kanban_tasks SET owner_id = (
+            SELECT id FROM users WHERE users.username = kanban_tasks.created_by
+        )
+        WHERE EXISTS (
+            SELECT 1 FROM users WHERE users.username = kanban_tasks.created_by
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("kanban_tasks") as batch_op:
+        batch_op.drop_index("ix_kanban_tasks_owner_id")
+        batch_op.drop_constraint("fk_kanban_tasks_owner_id", type_="foreignkey")
+        batch_op.drop_column("owner_id")

--- a/app/routers/kanban.py
+++ b/app/routers/kanban.py
@@ -222,7 +222,7 @@ async def get_tasks(
     _owner_id, ws_id = workspace_context(user, "kanban")
     is_admin = user_has_level(user, "kanban", "manage")
     tasks = await async_kanban_manager.get_visible_tasks_for_project(
-        project_id, user.username, is_admin, workspace_id=ws_id
+        project_id, user.id, is_admin, workspace_id=ws_id
     )
     return {"tasks": tasks}
 
@@ -245,6 +245,7 @@ async def create_task(
         due_date=request.due_date,
         tags=tags_json,
         created_by=user.username,
+        owner_id=user.id,
         workspace_id=ws_id,
     )
     await async_audit_logger.log(
@@ -269,7 +270,7 @@ async def update_task(
     if not existing:
         raise HTTPException(status_code=404, detail="Task not found")
 
-    if not user_has_level(user, "kanban", "manage") and existing["created_by"] != user.username:
+    if not user_has_level(user, "kanban", "manage") and existing.get("owner_id") != user.id:
         raise HTTPException(status_code=403, detail="Can only edit own tasks")
 
     update_data = {}
@@ -370,7 +371,7 @@ async def add_dependency(
         raise HTTPException(status_code=404, detail="Blocker task not found")
     if (
         target["is_private"]
-        and target["created_by"] != user.username
+        and target.get("owner_id") != user.id
         and not user_has_level(user, "kanban", "manage")
     ):
         raise HTTPException(status_code=409, detail="Cannot depend on a private task")

--- a/db/integration.py
+++ b/db/integration.py
@@ -1815,13 +1815,15 @@ class AsyncKanbanManager:
 
     async def get_visible_tasks(
         self,
-        current_user: str,
+        current_user_id: int,
         is_admin: bool,
         workspace_id: Optional[int] = None,
     ) -> list:
         async with AsyncSessionLocal() as session:
             repo = KanbanRepository(session)
-            return await repo.get_visible_tasks(current_user, is_admin, workspace_id=workspace_id)
+            return await repo.get_visible_tasks(
+                current_user_id, is_admin, workspace_id=workspace_id
+            )
 
     async def get_task(self, task_id: int, workspace_id: Optional[int] = None) -> Optional[dict]:
         async with AsyncSessionLocal() as session:
@@ -1877,14 +1879,14 @@ class AsyncKanbanManager:
     async def get_visible_tasks_for_project(
         self,
         project_id,
-        current_user: str,
+        current_user_id: int,
         is_admin: bool,
         workspace_id: Optional[int] = None,
     ) -> list:
         async with AsyncSessionLocal() as session:
             repo = KanbanRepository(session)
             return await repo.get_visible_tasks_for_project(
-                project_id, current_user, is_admin, workspace_id=workspace_id
+                project_id, current_user_id, is_admin, workspace_id=workspace_id
             )
 
     async def find_by_github_issue(self, project_id: int, issue_number: int):

--- a/db/models.py
+++ b/db/models.py
@@ -3297,6 +3297,9 @@ class KanbanTask(Base):
     is_private: Mapped[bool] = mapped_column(Boolean, default=True, server_default="1")
     assignee: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     created_by: Mapped[str] = mapped_column(String(100), index=True)
+    owner_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     start_date: Mapped[Optional[str]] = mapped_column(String(10), nullable=True)
     due_date: Mapped[Optional[str]] = mapped_column(String(10), nullable=True)
     position: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
@@ -3349,6 +3352,7 @@ class KanbanTask(Base):
             "is_private": self.is_private,
             "assignee": self.assignee,
             "created_by": self.created_by,
+            "owner_id": self.owner_id,
             "start_date": self.start_date,
             "due_date": self.due_date,
             "position": self.position,

--- a/db/repositories/kanban.py
+++ b/db/repositories/kanban.py
@@ -35,7 +35,7 @@ class KanbanRepository(BaseRepository[KanbanTask]):
 
     async def get_visible_tasks(
         self,
-        current_user: str,
+        current_user_id: int,
         is_admin: bool,
         workspace_id: Optional[int] = None,
     ) -> List[dict]:
@@ -45,13 +45,13 @@ class KanbanRepository(BaseRepository[KanbanTask]):
         Others see their own tasks + non-draft public tasks.
         """
         return await self.get_visible_tasks_for_project(
-            None, current_user, is_admin, workspace_id=workspace_id
+            None, current_user_id, is_admin, workspace_id=workspace_id
         )
 
     async def get_visible_tasks_for_project(
         self,
         project_id: Optional[int],
-        current_user: str,
+        current_user_id: int,
         is_admin: bool,
         workspace_id: Optional[int] = None,
     ) -> List[dict]:
@@ -70,7 +70,7 @@ class KanbanRepository(BaseRepository[KanbanTask]):
 
         if not is_admin:
             stmt = stmt.where(
-                (KanbanTask.created_by == current_user)
+                (KanbanTask.owner_id == current_user_id)
                 | ((KanbanTask.is_private == False) & (KanbanTask.status != "draft"))
             )
 
@@ -83,6 +83,7 @@ class KanbanRepository(BaseRepository[KanbanTask]):
         self,
         title: str,
         created_by: str,
+        owner_id: Optional[int] = None,
         description: Optional[str] = None,
         status: str = "todo",
         assignee: Optional[str] = None,
@@ -99,6 +100,7 @@ class KanbanRepository(BaseRepository[KanbanTask]):
             is_private=True,
             assignee=assignee,
             created_by=created_by,
+            owner_id=owner_id,
             start_date=start_date,
             due_date=due_date,
             tags=tags,


### PR DESCRIPTION
## Summary

- Added `owner_id` (int FK → `users.id`) column to `kanban_tasks` alongside existing `created_by` (string)
- Visibility filter now uses `owner_id == user.id` instead of `created_by == username` for proper RBAC
- Ownership checks on update/dependency endpoints use `owner_id` instead of string comparison
- GitHub-synced tasks retain `created_by` from GitHub username, get `owner_id=NULL` (no local user)
- Alembic migration `0013` adds column + index + FK, backfills from `created_by → users.username`

## Files changed (7)

| File | Change |
|------|--------|
| `alembic/versions/20260225_0013_*.py` | New migration: add column, FK, index, backfill |
| `db/models.py` | `owner_id` column + `to_dict()` |
| `db/repositories/kanban.py` | `current_user: str` → `current_user_id: int`, `owner_id` in create |
| `db/integration.py` | Manager signatures updated |
| `app/routers/kanban.py` | Pass `owner_id=user.id`, ownership checks via `owner_id` |
| `admin/src/api/kanban.ts` | `owner_id: number \| null` in interface |
| `admin/src/api/demo/kanban.ts` | `owner_id` in mock interface + all mock data |

## Test plan

- [ ] `alembic upgrade head` runs without errors
- [ ] Existing tasks get `owner_id` backfilled from `created_by`
- [ ] New task creation sets `owner_id` from JWT user
- [ ] Non-admin user can only see own tasks (by `owner_id`) + public non-draft tasks
- [ ] Non-admin user cannot edit tasks with different `owner_id`
- [ ] GitHub-synced tasks have `owner_id=NULL`, `created_by` = GitHub username
- [ ] Demo mode shows `owner_id` in mock data

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)