### PR TITLE
fix: add HTTP 402 to model fallback statuses

### DIFF
--- a/cloud_llm_service.py
+++ b/cloud_llm_service.py
@@ -233,7 +233,8 @@ class OpenAICompatibleProvider(BaseLLMProvider):
         )
 
     # HTTP status codes that trigger model fallback
-    _RETRIABLE_STATUSES = {404, 429, 500, 502, 503}
+    # 402 = Payment Required (OpenRouter: model too expensive for account tier)
+    _RETRIABLE_STATUSES = {402, 404, 429, 500, 502, 503}
 
     @staticmethod
     def _ensure_no_proxy_for_localhost():
@@ -331,6 +332,7 @@ class OpenAICompatibleProvider(BaseLLMProvider):
                     continue
                 error_messages = {
                     401: "Invalid API key",
+                    402: "Insufficient credits - top up account or use free models",
                     403: "Access denied - check API key permissions",
                     404: f"Model '{model}' not found - check model name",
                     429: "Rate limit exceeded - wait or upgrade plan",


### PR DESCRIPTION
## Summary

- Add HTTP 402 (Payment Required) to `_RETRIABLE_STATUSES` in `OpenAICompatibleProvider`
- OpenRouter returns 402 for paid models on free-tier accounts; fallback chain now reaches free models (qwen3, hermes-405b, gemma-3)
- Add 402 error message to user-facing error map

## Test plan

- [ ] Set backend to OpenRouter Секретарь provider (free-tier key)
- [ ] Send chat message → paid models return 402 → fallback chain reaches free models → response received

🤖 Generated with [Claude Code](https://claude.com/claude-code)