### PR TITLE
fix: npm ci --include=dev to install devDependencies

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -48,7 +48,7 @@ log "Installing bridge dependencies..."
 # Install/update npm deps
 log "Installing npm dependencies..."
 cd "$REPO_DIR/admin"
-npm ci --silent 2>&1 | tee -a "$LOG_FILE"
+npm ci --include=dev 2>&1 | tee -a "$LOG_FILE"
 
 # Ensure .env.production.local exists (base path override)
 if [ ! -f "$REPO_DIR/admin/.env.production.local" ]; then


### PR DESCRIPTION
## Problem

When `NODE_ENV=production` is set, `npm ci` skips devDependencies by default. This causes `vue-tsc` (a devDependency) not to be found during the build step.

Fixes #359

## Solution

Changed `npm ci --silent` to `npm ci --include=dev` in `deploy.sh` line 51.

The `--include=dev` flag explicitly tells npm to install devDependencies regardless of the NODE_ENV setting, ensuring build tools like vue-tsc are available.