### PR TITLE
fix: chat widget not hiding on /chat page

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -64,13 +64,18 @@ onUnmounted(() => {
 
 // Hide external chat widget on /chat page, show everywhere else
 // Widget loads async (deferred script + await fetch), so poll until it appears
+// Uses inline style (display:none) instead of CSS class because the widget's
+// own !important rules on .ai-chat-button override class-based hiding
+function setWidgetVisibility(widget: HTMLElement, hide: boolean) {
+  widget.style.display = hide ? 'none' : ''
+}
 let widgetFound = false
 watch(
   () => route.name,
   () => {
     const widget = document.querySelector('.ai-chat-widget') as HTMLElement | null
     if (widget) {
-      widget.classList.toggle('ai-chat-widget-hidden', route.name === 'chat')
+      setWidgetVisibility(widget, route.name === 'chat')
       widgetFound = true
     }
     mobileMenuOpen.value = false
@@ -80,7 +85,7 @@ watch(
 const widgetPoll = setInterval(() => {
   const widget = document.querySelector('.ai-chat-widget') as HTMLElement | null
   if (widget) {
-    widget.classList.toggle('ai-chat-widget-hidden', route.name === 'chat')
+    setWidgetVisibility(widget, route.name === 'chat')
     widgetFound = true
   }
   if (widgetFound) clearInterval(widgetPoll)
@@ -359,15 +364,6 @@ const localeTitle: Record<string, string> = { ru: 'Переключить язы
 .scale-leave-to {
   opacity: 0;
   transform: scale(0.95);
-}
-
-/* Hide chat widget on chat page */
-.ai-chat-widget-hidden,
-.ai-chat-widget-hidden .ai-chat-button,
-.ai-chat-widget-hidden .ai-chat-window {
-  display: none !important;
-  visibility: hidden !important;
-  pointer-events: none !important;
 }
 
 /* Smooth hover effects */


### PR DESCRIPTION
## Summary
- Fixed external chat widget staying permanently visible on the `/chat` page in admin panel
- Root cause: widget's own CSS uses `!important` on `.ai-chat-button` (`display`, `opacity`, `visibility`, `pointer-events`), which overrode the `ai-chat-widget-hidden` class-based hiding
- Fix: use inline `style.display = 'none'` on the root `.ai-chat-widget` element (inline styles always beat stylesheet `!important`)
- Removed now-unused `.ai-chat-widget-hidden` CSS rules

## NEWS

🔧 **Виджет чата больше не перекрывает страницу чата**

Исправлена ошибка, из-за которой виджет чата на странице чата в админке оставался развёрнутым и не скрывался. Теперь виджет корректно прячется при переходе на страницу чата и появляется обратно на других страницах.

## Test plan
- [ ] Open admin panel `/chat` page — widget button should be hidden
- [ ] Navigate to any other page — widget button should reappear
- [ ] Open widget on a non-chat page, navigate to `/chat` — widget should disappear
- [ ] Navigate back from `/chat` — widget should reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)