### PR TITLE
fix: news broadcast not working

### DIFF
--- a/scripts/migrate_sales_funnel_enabled.py
+++ b/scripts/migrate_sales_funnel_enabled.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Migration: add sales_funnel_enabled column to bot_instances table.
+
+This column controls whether the Telegram bot runs the sales funnel
+(quiz, segments, follow-ups) and the news broadcast scheduler.
+Default: True (enabled) — matches the SQLAlchemy model default.
+
+Usage:
+    python scripts/migrate_sales_funnel_enabled.py
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+
+DB_PATH = Path(__file__).parent.parent / "data" / "secretary.db"
+
+
+def migrate() -> None:
+    if not DB_PATH.exists():
+        print(f"Database not found: {DB_PATH}")
+        sys.exit(1)
+
+    conn = sqlite3.connect(str(DB_PATH))
+    cursor = conn.cursor()
+
+    # Check if column already exists
+    cursor.execute("PRAGMA table_info(bot_instances)")
+    columns = [row[1] for row in cursor.fetchall()]
+
+    if "sales_funnel_enabled" in columns:
+        print("Column 'sales_funnel_enabled' already exists in bot_instances. Nothing to do.")
+        conn.close()
+        return
+
+    print("Adding 'sales_funnel_enabled' column to bot_instances...")
+    cursor.execute(
+        "ALTER TABLE bot_instances ADD COLUMN sales_funnel_enabled BOOLEAN NOT NULL DEFAULT 1"
+    )
+    conn.commit()
+
+    # Verify
+    cursor.execute("PRAGMA table_info(bot_instances)")
+    columns = [row[1] for row in cursor.fetchall()]
+    assert "sales_funnel_enabled" in columns, "Column was not added!"
+
+    print("Done. Column 'sales_funnel_enabled' added (default=True for all existing bots).")
+    conn.close()
+
+
+if __name__ == "__main__":
+    migrate()

--- a/telegram_bot/sales/database.py
+++ b/telegram_bot/sales/database.py
@@ -375,6 +375,11 @@ class SalesDatabase:
         broadcast_set = {row[0] for row in rows}
         return [n for n in pr_numbers if n not in broadcast_set]
 
+    async def has_any_broadcasts(self) -> bool:
+        """Check if there are any broadcast records at all (for first-run detection)."""
+        cursor = await self._db.execute("SELECT 1 FROM news_broadcasts LIMIT 1")
+        return await cursor.fetchone() is not None
+
     # ── Commit News Cache ──────────────────────────────────────────
 
     async def get_cached_commit_news(self, sha: str) -> str | None:
@@ -432,6 +437,11 @@ class SalesDatabase:
         rows = await cursor.fetchall()
         broadcast_set = {row[0] for row in rows}
         return [s for s in shas if s not in broadcast_set]
+
+    async def has_any_commit_broadcasts(self) -> bool:
+        """Check if there are any commit broadcast records (for first-run detection)."""
+        cursor = await self._db.execute("SELECT 1 FROM commit_news_broadcasts LIMIT 1")
+        return await cursor.fetchone() is not None
 
     async def mark_commit_broadcast(self, sha: str, recipients_count: int) -> None:
         """Mark commit as broadcast."""

--- a/telegram_bot/services/github_news.py
+++ b/telegram_bot/services/github_news.py
@@ -376,8 +376,11 @@ async def check_and_broadcast_news(bot: "Bot", skip_initial: bool = True) -> Non
                     logger.info("All recent PRs in %s already broadcast", repo)
                     continue
 
-                # Check if this is first run (no broadcasts yet)
-                if skip_initial and len(unbroadcast_numbers) == len(pr_numbers):
+                # Check if this is truly first run (no broadcasts in DB at all).
+                # Previous heuristic (all fetched PRs are new) caused false positives
+                # when the bot was offline for weeks and old broadcast records fell out
+                # of the current fetch window.
+                if skip_initial and not await db.has_any_broadcasts():
                     logger.info(
                         "First run: marking %d existing PRs in %s as seen (no broadcast)",
                         len(pr_numbers),
@@ -472,7 +475,7 @@ async def check_and_broadcast_commit_news(bot: "Bot", skip_initial: bool = True)
                     continue
 
                 # First run — mark all as seen without sending
-                if skip_initial and len(unbroadcast_shas) == len(shas):
+                if skip_initial and not await db.has_any_commit_broadcasts():
                     logger.info(
                         "First run: marking %d existing commits in %s as seen (no broadcast)",
                         len(shas),


### PR DESCRIPTION
## Summary
- Added missing migration for `sales_funnel_enabled` column on `bot_instances` table — was defined in model but never migrated to existing DBs
- Fixed false first-run detection in news scheduler: previously checked `len(unbroadcast) == len(fetched)` which falsely triggered after weeks of bot downtime; now checks `db.has_any_broadcasts()` (empty table = true first run)
- Added `has_any_broadcasts()` and `has_any_commit_broadcasts()` methods to `SalesDatabase`

**Root cause**: Bot wasn't running (auto_start=0), and even when started, the scheduler falsely detected "first run" and silently marked all recent PRs as seen without sending.

## NEWS

📢 **Рассылка новостей в Telegram снова работает!**

Исправлена ошибка, из-за которой новости о новых обновлениях проекта не приходили подписчикам в Telegram. Бот теперь корректно отслеживает новые PR с секцией NEWS и автоматически рассылает их подписчикам.

## Test plan
- [ ] Run `python scripts/migrate_sales_funnel_enabled.py` on existing DB
- [ ] Start bot instance with `sales_funnel_enabled=True`
- [ ] Verify scheduler starts: log should show "News broadcast scheduler started"
- [ ] Verify no false first-run: if `news_broadcasts` table has records, scheduler should NOT mark PRs as "seen"
- [ ] Merge a PR with `## NEWS` section and verify broadcast arrives within 60 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)