### PR TITLE
fix: RAG collection selection not saving on widget/WhatsApp

### DIFF
--- a/app/routers/whatsapp.py
+++ b/app/routers/whatsapp.py
@@ -82,6 +82,9 @@ class WhatsAppInstanceUpdateRequest(BaseModel):
     # Rate limiting
     rate_limit_count: Optional[int] = None
     rate_limit_hours: Optional[int] = None
+    # RAG
+    rag_mode: Optional[str] = None
+    knowledge_collection_ids: Optional[List[int]] = None
 
 
 class WhatsAppShareRequest(BaseModel):

--- a/app/routers/widget.py
+++ b/app/routers/widget.py
@@ -89,6 +89,9 @@ class WidgetInstanceUpdateRequest(BaseModel):
     tts_preset: Optional[str] = None
     rate_limit_count: Optional[int] = None
     rate_limit_hours: Optional[int] = None
+    # RAG
+    rag_mode: Optional[str] = None
+    knowledge_collection_ids: Optional[List[int]] = None
 
 
 class WidgetShareRequest(BaseModel):

--- a/db/repositories/whatsapp_instance.py
+++ b/db/repositories/whatsapp_instance.py
@@ -2,6 +2,7 @@
 WhatsApp instance repository for managing WhatsApp bot instances.
 """
 
+import json
 import logging
 import re
 from datetime import datetime
@@ -208,6 +209,7 @@ class WhatsAppInstanceRepository(BaseRepository[WhatsAppInstance]):
             "tts_preset",
             "rate_limit_count",
             "rate_limit_hours",
+            "rag_mode",
         ]
         for field in simple_fields:
             if field in kwargs:
@@ -220,6 +222,9 @@ class WhatsAppInstanceRepository(BaseRepository[WhatsAppInstance]):
             instance.set_blocked_phones(kwargs["blocked_phones"])
         if "llm_params" in kwargs:
             instance.set_llm_params(kwargs["llm_params"])
+        if "knowledge_collection_ids" in kwargs:
+            ids = kwargs["knowledge_collection_ids"]
+            instance.knowledge_collection_ids = json.dumps(ids) if ids else None
 
         instance.updated = datetime.utcnow()
         await self.session.commit()

--- a/db/repositories/widget_instance.py
+++ b/db/repositories/widget_instance.py
@@ -2,6 +2,7 @@
 Widget instance repository for managing website widget instances.
 """
 
+import json
 import logging
 import re
 from datetime import datetime
@@ -206,6 +207,7 @@ class WidgetInstanceRepository(BaseRepository[WidgetInstance]):
             "tts_engine",
             "tts_voice",
             "tts_preset",
+            "rag_mode",
         ]
         for field in simple_fields:
             if field in kwargs:
@@ -216,6 +218,9 @@ class WidgetInstanceRepository(BaseRepository[WidgetInstance]):
             instance.set_allowed_domains(kwargs["allowed_domains"])
         if "llm_params" in kwargs:
             instance.set_llm_params(kwargs["llm_params"])
+        if "knowledge_collection_ids" in kwargs:
+            ids = kwargs["knowledge_collection_ids"]
+            instance.knowledge_collection_ids = json.dumps(ids) if ids else None
 
         instance.updated = datetime.utcnow()
         await self.session.commit()


### PR DESCRIPTION
## Summary
- Added `rag_mode` and `knowledge_collection_ids` to `WidgetInstanceUpdateRequest` and `WhatsAppInstanceUpdateRequest` Pydantic schemas
- Added `rag_mode` to `simple_fields` in both `WidgetInstanceRepository.update_instance()` and `WhatsAppInstanceRepository.update_instance()`
- Added `knowledge_collection_ids` JSON serialization in both repositories' update methods
- Added `import json` to both repository files

**Root cause**: Frontend sent RAG fields but Pydantic schema silently dropped them during validation → data never reached the database. Telegram bot was the only instance type where this worked.

## NEWS

🔧 **Настройки базы знаний теперь сохраняются в виджетах и WhatsApp**

Исправлена ошибка, из-за которой выбор режима RAG и коллекций знаний не сохранялся при редактировании виджетов и WhatsApp-инстансов. Теперь можно привязывать конкретные базы знаний к каждому виджету и боту.

## Test plan
- [ ] Edit widget instance, set RAG mode to "selected", pick a collection → save → reopen → should show selected mode and collection
- [ ] Edit WhatsApp instance same way → should persist
- [ ] Verify existing widget/WhatsApp instances still load correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)