### PR TITLE
feat: move Tasks shortcut next to Chat in sidebar

### DIFF
--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -11,6 +11,7 @@ import {
   Languages,
   PanelLeftClose,
   MessageCircle,
+  ClipboardList,
   Maximize2
 } from 'lucide-vue-next'
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
@@ -172,8 +173,8 @@ const localeTitle: Record<string, string> = { ru: 'Переключить язы
             </button>
           </div>
 
-          <!-- Chat shortcut -->
-          <div v-if="sidebarOpen || isMobile" class="p-2">
+          <!-- Top shortcuts (Chat + Tasks) -->
+          <div v-if="sidebarOpen || isMobile" class="p-2 space-y-1">
             <router-link
               to="/chat"
               class="flex items-center gap-2 w-full px-3 py-2 text-sm rounded-lg transition-colors"
@@ -183,14 +184,32 @@ const localeTitle: Record<string, string> = { ru: 'Переключить язы
               <MessageCircle class="w-4 h-4" />
               <span class="flex-1 text-left">{{ t('nav.chat') }}</span>
             </router-link>
+            <router-link
+              v-if="authStore.canView('kanban')"
+              to="/kanban"
+              class="flex items-center gap-2 w-full px-3 py-2 text-sm rounded-lg transition-colors"
+              :class="route.path === '/kanban' ? 'bg-primary/10 text-primary' : 'text-muted-foreground bg-secondary/50 hover:bg-secondary'"
+              @click="isMobile && (mobileMenuOpen = false)"
+            >
+              <ClipboardList class="w-4 h-4" />
+              <span class="flex-1 text-left">{{ t('nav.kanban') }}</span>
+            </router-link>
           </div>
-          <div v-else class="p-2">
+          <div v-else class="p-2 space-y-1">
             <router-link
               to="/chat"
               class="flex items-center justify-center w-full p-2 rounded-lg transition-colors"
               :class="route.path === '/chat' ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:bg-secondary/50'"
             >
               <MessageCircle class="w-5 h-5" />
+            </router-link>
+            <router-link
+              v-if="authStore.canView('kanban')"
+              to="/kanban"
+              class="flex items-center justify-center w-full p-2 rounded-lg transition-colors"
+              :class="route.path === '/kanban' ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:bg-secondary/50'"
+            >
+              <ClipboardList class="w-5 h-5" />
             </router-link>
           </div>
 

--- a/admin/src/components/AccordionNav.vue
+++ b/admin/src/components/AccordionNav.vue
@@ -23,7 +23,6 @@ import {
   Users,
   Settings,
   Info,
-  ClipboardList,
   UserCog
 } from 'lucide-vue-next'
 import { markRaw } from 'vue'
@@ -90,7 +89,6 @@ const allNavGroups = computed(() => [
       { path: '/sales', nameKey: 'nav.sales', icon: ShoppingCart, module: 'sales' },
       { path: '/crm', nameKey: 'nav.crm', icon: Users, module: 'sales' },
       { path: '/woocommerce', nameKey: 'nav.woocommerce', icon: ShoppingBag, module: 'sales' },
-      { path: '/kanban', nameKey: 'nav.kanban', icon: ClipboardList, module: 'kanban' },
     ]
   },
   {


### PR DESCRIPTION
## Summary

- Move Kanban/Tasks from Business accordion group to top-level sidebar shortcuts
- Tasks now appears directly below Chat for quick one-click access
- RBAC check preserved (`canView('kanban')`) — hidden for users without permission
- Works in both expanded (icon + label) and collapsed (icon only) sidebar modes

## Test plan

- [ ] Verify "Задачи" appears below "Чат" in expanded sidebar
- [ ] Verify ClipboardList icon appears below MessageCircle in collapsed sidebar
- [ ] Verify Tasks is no longer in the Business accordion group
- [ ] Verify active state highlights correctly when on /kanban
- [ ] Verify guest users (no kanban permission) don't see the Tasks shortcut
- [ ] Mobile: verify Tasks shortcut closes mobile menu on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)