### PR TITLE
fix: increase widget button size to 70px

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -314,9 +314,12 @@ function saveRagToSession() {
   if (ragSaveTimer) clearTimeout(ragSaveTimer)
   ragSaveTimer = setTimeout(() => {
     if (!currentSessionId.value) return
+    // Auto-determine rag_mode from selected collections
+    const hasCollections = selectedCollectionIds.value.length > 0
+    const mode = hasCollections ? 'selected' : 'all'
     chatApi.updateSession(currentSessionId.value, {
-      rag_mode: selectedRagMode.value || 'none',
-      knowledge_collection_ids: selectedRagMode.value === 'selected' ? selectedCollectionIds.value : [],
+      rag_mode: mode,
+      knowledge_collection_ids: hasCollections ? selectedCollectionIds.value : [],
     })
   }, 500)
 }

--- a/web-widget/ai-chat-widget.js
+++ b/web-widget/ai-chat-widget.js
@@ -108,8 +108,8 @@
       position: fixed !important;
       bottom: 20px !important;
       ${settings.position}: 20px !important;
-      width: 60px !important;
-      height: 60px !important;
+      width: 70px !important;
+      height: 70px !important;
       border-radius: 50% !important;
       background: var(--ai-primary) !important;
       border: none !important;


### PR DESCRIPTION
## Summary
- Widget chat button size increased from 60px to 70px for better visibility on mobile
- ChatView RAG save logic fixed: auto-determines `rag_mode` from selected collections instead of stale `selectedRagMode` value

## NEWS

🔘 **Увеличена кнопка чат-виджета**

Кнопка чат-виджета на сайте стала крупнее (70px) — теперь её легче заметить
и нажать, особенно на мобильных устройствах. Также исправлена логика
сохранения настроек базы знаний в чате.

## Test plan
- [ ] Verify widget button renders at 70px on desktop and mobile
- [ ] Verify RAG mode saves correctly when selecting/deselecting collections in ChatView

🤖 Generated with [Claude Code](https://claude.com/claude-code)