### PR TITLE
fix: increase widget button bottom offset to 70px

### DIFF
--- a/web-widget/ai-chat-widget.js
+++ b/web-widget/ai-chat-widget.js
@@ -106,7 +106,7 @@
 
     .ai-chat-button {
       position: fixed !important;
-      bottom: 20px !important;
+      bottom: 70px !important;
       ${settings.position}: 20px !important;
       width: 70px !important;
       height: 70px !important;
@@ -150,7 +150,7 @@
 
     .ai-chat-window {
       position: fixed;
-      bottom: 90px;
+      bottom: 150px;
       ${settings.position}: 20px;
       width: 380px;
       max-width: calc(100vw - 40px);


### PR DESCRIPTION
## Summary
- Widget button `bottom` offset increased from 20px to 70px to avoid overlap with client's site elements
- Chat window position adjusted from 90px to 150px accordingly (70 offset + 70 button + 10 gap)

## NEWS

📐 **Кнопка виджета поднята выше**

Кнопка чат-виджета теперь расположена выше от нижнего края экрана (70px),
чтобы не перекрываться с другими элементами на сайте клиента.

## Test plan
- [ ] Verify widget button is 70px from bottom edge
- [ ] Verify chat window opens above the button without overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)