### PR TITLE
fix: remove session.refresh() calls to fix StaticPool concurrency

### DIFF
--- a/db/repositories/amocrm.py
+++ b/db/repositories/amocrm.py
@@ -80,8 +80,8 @@ class AmoCRMConfigRepository(BaseRepository[AmoCRMConfig]):
             config.set_account_info(kwargs["account_info"])
 
         config.updated = datetime.utcnow()
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(config)
         return config.to_dict()
 
     async def clear_tokens(self, workspace_id: Optional[int] = None) -> dict:
@@ -97,7 +97,6 @@ class AmoCRMConfigRepository(BaseRepository[AmoCRMConfig]):
             config.last_sync_at = None
             config.updated = datetime.utcnow()
             await self.session.commit()
-            await self.session.refresh(config)
             return config.to_dict()
         return {}
 
@@ -128,8 +127,8 @@ class AmoCRMSyncLogRepository(BaseRepository[AmoCRMSyncLog]):
             error_message=error_message,
         )
         self.session.add(entry)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(entry)
         return entry.to_dict()
 
     async def get_recent(self, limit: int = 50) -> List[dict]:

--- a/db/repositories/audit.py
+++ b/db/repositories/audit.py
@@ -40,8 +40,8 @@ class AuditRepository(BaseRepository[AuditLog]):
         )
 
         self.session.add(entry)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(entry)
 
         return entry
 

--- a/db/repositories/base.py
+++ b/db/repositories/base.py
@@ -54,14 +54,13 @@ class BaseRepository(Generic[T]):
     async def create(self, entity: T) -> T:
         """Create new entity."""
         self.session.add(entity)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(entity)
         return entity
 
     async def update(self, entity: T) -> T:
         """Update existing entity."""
         await self.session.commit()
-        await self.session.refresh(entity)
         return entity
 
     async def delete(self, entity: T) -> bool:

--- a/db/repositories/bot_ab_test.py
+++ b/db/repositories/bot_ab_test.py
@@ -94,8 +94,8 @@ class BotAbTestRepository(BaseRepository[BotAbTest]):
         if variants:
             test.set_variants(variants)
         self.session.add(test)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(test)
         logger.info(f"Created A/B test: bot_id={bot_id}, key={kwargs.get('test_key')}")
         return test.to_dict()
 
@@ -112,7 +112,6 @@ class BotAbTestRepository(BaseRepository[BotAbTest]):
                 setattr(test, k, v)
         test.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(test)
         logger.info(f"Updated A/B test: id={test_id}")
         return test.to_dict()
 

--- a/db/repositories/bot_agent_prompt.py
+++ b/db/repositories/bot_agent_prompt.py
@@ -44,8 +44,8 @@ class BotAgentPromptRepository(BaseRepository[BotAgentPrompt]):
         """Create a new agent prompt."""
         prompt = BotAgentPrompt(bot_id=bot_id, **kwargs)
         self.session.add(prompt)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(prompt)
         logger.info(f"Created agent prompt: bot_id={bot_id}, key={kwargs.get('prompt_key')}")
         return prompt.to_dict()
 
@@ -59,7 +59,6 @@ class BotAgentPromptRepository(BaseRepository[BotAgentPrompt]):
                 setattr(prompt, k, v)
         prompt.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(prompt)
         logger.info(f"Updated agent prompt: id={prompt_id}")
         return prompt.to_dict()
 

--- a/db/repositories/bot_discovery.py
+++ b/db/repositories/bot_discovery.py
@@ -51,8 +51,8 @@ class BotDiscoveryRepository(BaseRepository[BotDiscoveryResponse]):
             created=datetime.utcnow(),
         )
         self.session.add(response)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(response)
         logger.debug(f"Saved discovery response: bot_id={bot_id}, user_id={user_id}, step={step}")
         return response.to_dict()
 

--- a/db/repositories/bot_event.py
+++ b/db/repositories/bot_event.py
@@ -64,8 +64,8 @@ class BotEventRepository(BaseRepository[BotEvent]):
             created=datetime.utcnow(),
         )
         self.session.add(event)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(event)
         logger.debug(f"Logged event: bot_id={bot_id}, user_id={user_id}, type={event_type}")
         return event.to_dict()
 

--- a/db/repositories/bot_followup.py
+++ b/db/repositories/bot_followup.py
@@ -38,8 +38,8 @@ class BotFollowupRuleRepository(BaseRepository[BotFollowupRule]):
         if buttons is not None:
             rule.set_buttons(buttons)
         self.session.add(rule)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(rule)
         logger.info(f"Created follow-up rule: bot_id={bot_id}, name={kwargs.get('name')}")
         return rule.to_dict()
 
@@ -56,7 +56,6 @@ class BotFollowupRuleRepository(BaseRepository[BotFollowupRule]):
                 setattr(rule, k, v)
         rule.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(rule)
         logger.info(f"Updated follow-up rule: id={rule_id}")
         return rule.to_dict()
 
@@ -94,8 +93,8 @@ class BotFollowupQueueRepository(BaseRepository[BotFollowupQueue]):
             created=datetime.utcnow(),
         )
         self.session.add(entry)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(entry)
         logger.info(
             f"Enqueued follow-up: bot_id={bot_id}, user_id={user_id}, "
             f"rule_id={rule_id}, scheduled_at={scheduled_at}"
@@ -130,7 +129,6 @@ class BotFollowupQueueRepository(BaseRepository[BotFollowupQueue]):
         entry.sent_at = datetime.utcnow()
         entry.send_count += 1
         await self.session.commit()
-        await self.session.refresh(entry)
         logger.info(f"Marked follow-up as sent: id={entry_id}")
         return entry.to_dict()
 
@@ -141,7 +139,6 @@ class BotFollowupQueueRepository(BaseRepository[BotFollowupQueue]):
             return None
         entry.status = "cancelled"
         await self.session.commit()
-        await self.session.refresh(entry)
         logger.info(f"Marked follow-up as cancelled: id={entry_id}")
         return entry.to_dict()
 

--- a/db/repositories/bot_github.py
+++ b/db/repositories/bot_github.py
@@ -65,7 +65,6 @@ class BotGithubRepository(BaseRepository[BotGithubConfig]):
                     setattr(config, k, v)
             config.updated = datetime.utcnow()
             await self.session.commit()
-            await self.session.refresh(config)
             logger.info(f"Updated GitHub config: bot_id={bot_id}")
             return config.to_dict()
 
@@ -80,8 +79,8 @@ class BotGithubRepository(BaseRepository[BotGithubConfig]):
         if events is not None:
             config.set_events(events)
         self.session.add(config)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(config)
         logger.info(f"Created GitHub config: bot_id={bot_id}")
         return config.to_dict()
 

--- a/db/repositories/bot_hardware.py
+++ b/db/repositories/bot_hardware.py
@@ -56,8 +56,8 @@ class BotHardwareRepository(BaseRepository[BotHardwareSpec]):
         """Create a new hardware spec entry."""
         spec = BotHardwareSpec(bot_id=bot_id, **kwargs)
         self.session.add(spec)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(spec)
         logger.info(f"Created hardware spec: bot_id={bot_id}, gpu={kwargs.get('gpu_name')}")
         return spec.to_dict()
 
@@ -70,7 +70,6 @@ class BotHardwareRepository(BaseRepository[BotHardwareSpec]):
             if hasattr(spec, k):
                 setattr(spec, k, v)
         await self.session.commit()
-        await self.session.refresh(spec)
         logger.info(f"Updated hardware spec: id={spec_id}")
         return spec.to_dict()
 

--- a/db/repositories/bot_instance.py
+++ b/db/repositories/bot_instance.py
@@ -197,7 +197,6 @@ class BotInstanceRepository(BaseRepository[BotInstance]):
 
         self.session.add(instance)
         await self.session.commit()
-        await self.session.refresh(instance)
 
         logger.info(f"Created bot instance: {instance_id}")
         return instance.to_dict()
@@ -262,7 +261,6 @@ class BotInstanceRepository(BaseRepository[BotInstance]):
 
         instance.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(instance)
 
         logger.info(f"Updated bot instance: {instance_id}")
         data: dict[str, Any] = instance.to_dict()

--- a/db/repositories/bot_quiz.py
+++ b/db/repositories/bot_quiz.py
@@ -48,8 +48,8 @@ class BotQuizRepository(BaseRepository[BotQuizQuestion]):
         if options:
             question.set_options(options)
         self.session.add(question)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(question)
         logger.info(f"Created quiz question: bot_id={bot_id}, key={kwargs.get('question_key')}")
         return question.to_dict()
 
@@ -67,7 +67,6 @@ class BotQuizRepository(BaseRepository[BotQuizQuestion]):
                 setattr(question, k, v)
         question.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(question)
         logger.info(f"Updated quiz question: id={question_id}")
         return question.to_dict()
 

--- a/db/repositories/bot_segment.py
+++ b/db/repositories/bot_segment.py
@@ -83,8 +83,8 @@ class BotSegmentRepository(BaseRepository[BotSegment]):
         if match_rules:
             segment.set_match_rules(match_rules)
         self.session.add(segment)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(segment)
         logger.info(f"Created segment: bot_id={bot_id}, key={kwargs.get('segment_key')}")
         return segment.to_dict()
 
@@ -100,7 +100,6 @@ class BotSegmentRepository(BaseRepository[BotSegment]):
             if hasattr(segment, k):
                 setattr(segment, k, v)
         await self.session.commit()
-        await self.session.refresh(segment)
         logger.info(f"Updated segment: id={segment_id}")
         return segment.to_dict()
 

--- a/db/repositories/bot_subscriber.py
+++ b/db/repositories/bot_subscriber.py
@@ -45,7 +45,6 @@ class BotSubscriberRepository(BaseRepository[BotSubscriber]):
             subscriber.unsubscribed_at = None
             subscriber.subscribed_at = datetime.utcnow()
             await self.session.commit()
-            await self.session.refresh(subscriber)
             logger.info(f"Re-subscribed user: bot_id={bot_id}, user_id={user_id}")
             return subscriber.to_dict()
 
@@ -57,8 +56,8 @@ class BotSubscriberRepository(BaseRepository[BotSubscriber]):
             subscribed_at=datetime.utcnow(),
         )
         self.session.add(subscriber)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(subscriber)
         logger.info(f"Subscribed user: bot_id={bot_id}, user_id={user_id}")
         return subscriber.to_dict()
 
@@ -84,7 +83,6 @@ class BotSubscriberRepository(BaseRepository[BotSubscriber]):
         subscriber.subscribed = False
         subscriber.unsubscribed_at = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(subscriber)
         logger.info(f"Unsubscribed user: bot_id={bot_id}, user_id={user_id}")
         return subscriber.to_dict()
 

--- a/db/repositories/bot_testimonial.py
+++ b/db/repositories/bot_testimonial.py
@@ -54,8 +54,8 @@ class BotTestimonialRepository(BaseRepository[BotTestimonial]):
             **kwargs,
         )
         self.session.add(testimonial)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(testimonial)
         logger.info(f"Created testimonial: bot_id={bot_id}, author={kwargs.get('author')}")
         return testimonial.to_dict()
 
@@ -68,7 +68,6 @@ class BotTestimonialRepository(BaseRepository[BotTestimonial]):
             if hasattr(testimonial, k):
                 setattr(testimonial, k, v)
         await self.session.commit()
-        await self.session.refresh(testimonial)
         logger.info(f"Updated testimonial: id={testimonial_id}")
         return testimonial.to_dict()
 

--- a/db/repositories/bot_user_profile.py
+++ b/db/repositories/bot_user_profile.py
@@ -55,7 +55,6 @@ class BotUserProfileRepository(BaseRepository[BotUserProfile]):
             if first_name and profile.first_name != first_name:
                 profile.first_name = first_name
             await self.session.commit()
-            await self.session.refresh(profile)
             return profile.to_dict()
 
         # Create new profile
@@ -70,8 +69,8 @@ class BotUserProfileRepository(BaseRepository[BotUserProfile]):
             updated=datetime.utcnow(),
         )
         self.session.add(profile)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(profile)
         logger.info(f"Created user profile: bot_id={bot_id}, user_id={user_id}")
         return profile.to_dict()
 
@@ -89,7 +88,6 @@ class BotUserProfileRepository(BaseRepository[BotUserProfile]):
         profile.last_activity = datetime.utcnow()
         profile.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(profile)
         logger.debug(f"Updated state to '{state}': bot_id={bot_id}, user_id={user_id}")
         return profile.to_dict()
 
@@ -110,7 +108,6 @@ class BotUserProfileRepository(BaseRepository[BotUserProfile]):
             profile.path = path
         profile.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(profile)
         logger.info(f"Updated segment to '{segment}': bot_id={bot_id}, user_id={user_id}")
         return profile.to_dict()
 
@@ -127,7 +124,6 @@ class BotUserProfileRepository(BaseRepository[BotUserProfile]):
         profile.set_quiz_answers(answers)
         profile.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(profile)
         return profile.to_dict()
 
     async def set_discovery_data(self, bot_id: str, user_id: int, data: dict) -> Optional[dict]:
@@ -143,7 +139,6 @@ class BotUserProfileRepository(BaseRepository[BotUserProfile]):
         profile.set_discovery_data(data)
         profile.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(profile)
         return profile.to_dict()
 
     async def set_followup_optout(
@@ -161,7 +156,6 @@ class BotUserProfileRepository(BaseRepository[BotUserProfile]):
         profile.followup_optout = optout
         profile.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(profile)
         logger.info(f"Set followup_optout={optout}: bot_id={bot_id}, user_id={user_id}")
         return profile.to_dict()
 

--- a/db/repositories/chat.py
+++ b/db/repositories/chat.py
@@ -151,7 +151,6 @@ class ChatRepository(BaseRepository[ChatSession]):
 
         self.session.add(session)
         await self.session.commit()
-        await self.session.refresh(session)
 
         # Return dict manually to avoid lazy loading issues
         return {
@@ -354,7 +353,6 @@ class ChatRepository(BaseRepository[ChatSession]):
         session.updated = datetime.utcnow()
 
         await self.session.commit()
-        await self.session.refresh(message)
         await invalidate_session_cache(session_id)
 
         return message.to_dict()
@@ -399,7 +397,6 @@ class ChatRepository(BaseRepository[ChatSession]):
             session.updated = datetime.utcnow()
 
         await self.session.commit()
-        await self.session.refresh(new_message)
         await invalidate_session_cache(session_id)
 
         return new_message.to_dict()

--- a/db/repositories/chat_share.py
+++ b/db/repositories/chat_share.py
@@ -62,7 +62,6 @@ class ChatShareRepository(BaseRepository[ChatSessionShare]):
             existing.shared_at = datetime.utcnow()
             existing.branch_message_id = branch_message_id
             await self.session.commit()
-            await self.session.refresh(existing)
             return existing.to_dict()
 
         share = ChatSessionShare(
@@ -74,8 +73,8 @@ class ChatShareRepository(BaseRepository[ChatSessionShare]):
             branch_message_id=branch_message_id,
         )
         self.session.add(share)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(share)
         return share.to_dict()
 
     async def remove_share(self, session_id: str, user_id: int) -> bool:

--- a/db/repositories/claude_code.py
+++ b/db/repositories/claude_code.py
@@ -54,7 +54,6 @@ class ClaudeCodeRepository(BaseRepository[ClaudeCodeSession]):
         entity = ClaudeCodeSession(**create_kwargs)
         self.session.add(entity)
         await self.session.commit()
-        await self.session.refresh(entity)
         return entity.to_dict()
 
     async def update_session(self, session_id: str, **kwargs) -> Optional[dict]:
@@ -66,7 +65,6 @@ class ClaudeCodeRepository(BaseRepository[ClaudeCodeSession]):
                 setattr(entity, key, value)
         entity.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(entity)
         return entity.to_dict()
 
     async def delete_session(self, session_id: str, workspace_id: Optional[int] = None) -> bool:

--- a/db/repositories/cloud_provider.py
+++ b/db/repositories/cloud_provider.py
@@ -147,7 +147,6 @@ class CloudProviderRepository(BaseRepository[CloudLLMProvider]):
 
         self.session.add(provider)
         await self.session.commit()
-        await self.session.refresh(provider)
 
         logger.info(f"Created cloud provider: {provider_id}")
         return provider.to_dict()
@@ -187,7 +186,6 @@ class CloudProviderRepository(BaseRepository[CloudLLMProvider]):
 
         provider.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(provider)
 
         logger.info(f"Updated cloud provider: {provider_id}")
         data: dict[str, Any] = provider.to_dict()

--- a/db/repositories/consent.py
+++ b/db/repositories/consent.py
@@ -79,8 +79,8 @@ class ConsentRepository(BaseRepository[UserConsent]):
             )
             self.session.add(consent)
 
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(consent)
         return consent.to_dict()
 
     async def revoke_consent(self, user_id: str, consent_type: str) -> Optional[dict]:
@@ -99,7 +99,6 @@ class ConsentRepository(BaseRepository[UserConsent]):
             consent.granted = False
             consent.revoked_at = datetime.utcnow()
             await self.session.commit()
-            await self.session.refresh(consent)
             return consent.to_dict()
         return None
 

--- a/db/repositories/faq.py
+++ b/db/repositories/faq.py
@@ -110,8 +110,8 @@ class FAQRepository(BaseRepository[FAQEntry]):
         )
 
         self.session.add(entry)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(entry)
 
         # Invalidate cache
         await invalidate_faq_cache()

--- a/db/repositories/gsm.py
+++ b/db/repositories/gsm.py
@@ -61,7 +61,6 @@ class GSMCallLogRepository(BaseRepository[GSMCallLog]):
                 call.duration_seconds = int((ended_at - call.answered_at).total_seconds())
 
         await self.session.commit()
-        await self.session.refresh(call)
         return call
 
     async def get_recent_calls(

--- a/db/repositories/kanban.py
+++ b/db/repositories/kanban.py
@@ -207,8 +207,8 @@ class KanbanRepository(BaseRepository[KanbanTask]):
         """Add a checklist item to a task."""
         item = KanbanChecklistItem(task_id=task_id, text=text, position=position)
         self.session.add(item)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(item)
         return item.to_dict()
 
     async def toggle_checklist_item(self, item_id: int) -> Optional[dict]:
@@ -218,7 +218,6 @@ class KanbanRepository(BaseRepository[KanbanTask]):
             return None
         item.is_done = not item.is_done
         await self.session.commit()
-        await self.session.refresh(item)
         return item.to_dict()
 
     async def delete_checklist_item(self, item_id: int) -> bool:

--- a/db/repositories/kanban_project.py
+++ b/db/repositories/kanban_project.py
@@ -48,8 +48,8 @@ class KanbanProjectRepository(BaseRepository[KanbanProject]):
         """Create a new project."""
         project = KanbanProject(**kwargs)
         self.session.add(project)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(project)
         return project.to_dict()
 
     async def update_project(self, project_id: int, **kwargs) -> Optional[dict]:
@@ -61,7 +61,6 @@ class KanbanProjectRepository(BaseRepository[KanbanProject]):
             if hasattr(project, key):
                 setattr(project, key, value)
         await self.session.commit()
-        await self.session.refresh(project)
         return project.to_dict()
 
     async def update_last_synced(self, project_id: int) -> None:

--- a/db/repositories/knowledge_collection.py
+++ b/db/repositories/knowledge_collection.py
@@ -94,8 +94,8 @@ class KnowledgeCollectionRepository(BaseRepository[KnowledgeCollection]):
             **create_kwargs,
         )
         self.session.add(col)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(col)
         d = col.to_dict()
         d["document_count"] = 0
         return d
@@ -123,7 +123,6 @@ class KnowledgeCollectionRepository(BaseRepository[KnowledgeCollection]):
             col.enabled = enabled
 
         await self.session.commit()
-        await self.session.refresh(col)
         d = col.to_dict()
         # Count documents
         result = await self.session.execute(

--- a/db/repositories/knowledge_document.py
+++ b/db/repositories/knowledge_document.py
@@ -80,8 +80,8 @@ class KnowledgeDocumentRepository(BaseRepository[KnowledgeDocument]):
             **create_kwargs,
         )
         self.session.add(doc)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(doc)
         return doc.to_dict()
 
     async def update_document(
@@ -107,7 +107,6 @@ class KnowledgeDocumentRepository(BaseRepository[KnowledgeDocument]):
             doc.collection_id = collection_id
 
         await self.session.commit()
-        await self.session.refresh(doc)
         return doc.to_dict()
 
     async def delete_document(self, doc_id: int) -> bool:

--- a/db/repositories/llm_preset.py
+++ b/db/repositories/llm_preset.py
@@ -66,7 +66,6 @@ class LLMPresetRepository(BaseRepository[LLMPreset]):
             preset.repetition_penalty = repetition_penalty
 
         await self.session.commit()
-        await self.session.refresh(preset)
         return preset
 
     async def update_prompt(self, preset_id: str, system_prompt: str) -> Optional[LLMPreset]:
@@ -77,7 +76,6 @@ class LLMPresetRepository(BaseRepository[LLMPreset]):
 
         preset.system_prompt = system_prompt
         await self.session.commit()
-        await self.session.refresh(preset)
         return preset
 
     async def ensure_defaults(self) -> int:

--- a/db/repositories/payment.py
+++ b/db/repositories/payment.py
@@ -47,8 +47,8 @@ class PaymentRepository(BaseRepository[PaymentLog]):
             status="completed",
         )
         self.session.add(entry)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(entry)
         logger.info(f"Payment logged: bot={bot_id}, user={user_id}, {amount} {currency}")
         return entry.to_dict()
 

--- a/db/repositories/preset.py
+++ b/db/repositories/preset.py
@@ -110,8 +110,8 @@ class PresetRepository(BaseRepository[TTSPreset]):
         )
 
         self.session.add(preset)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(preset)
         await self._invalidate_cache()
 
         return preset.to_dict()

--- a/db/repositories/resource_share.py
+++ b/db/repositories/resource_share.py
@@ -54,7 +54,6 @@ class ResourceShareRepository(BaseRepository[ResourceShare]):
             existing.shared_by = shared_by
             existing.shared_at = datetime.utcnow()
             await self.session.commit()
-            await self.session.refresh(existing)
             return existing.to_dict()
 
         share = ResourceShare(
@@ -66,8 +65,8 @@ class ResourceShareRepository(BaseRepository[ResourceShare]):
             shared_at=datetime.utcnow(),
         )
         self.session.add(share)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(share)
         return share.to_dict()
 
     async def remove_share(self, resource_type: str, resource_id: str, user_id: int) -> bool:

--- a/db/repositories/role.py
+++ b/db/repositories/role.py
@@ -57,8 +57,8 @@ class RoleRepository(BaseRepository[Role]):
                 RolePermission(module=module, level=level) for module, level in permissions.items()
             ]
         self.session.add(role)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(role)
         return role
 
     async def update_role(

--- a/db/repositories/usage.py
+++ b/db/repositories/usage.py
@@ -39,8 +39,8 @@ class UsageRepository(BaseRepository[UsageLog]):
             details=json.dumps(details, ensure_ascii=False) if details else None,
         )
         self.session.add(entry)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(entry)
         return entry.to_dict()
 
     async def get_usage(
@@ -252,8 +252,8 @@ class UsageLimitsRepository(BaseRepository[UsageLimits]):
             )
             self.session.add(limit)
 
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(limit)
         return limit.to_dict()
 
     async def delete_limit(self, service_type: str, limit_type: str) -> bool:

--- a/db/repositories/user.py
+++ b/db/repositories/user.py
@@ -76,8 +76,8 @@ class UserRepository(BaseRepository[User]):
             is_active=True,
         )
         self.session.add(user)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(user)
         return user.to_dict()
 
     async def update_password(self, user_id: int, new_password: str) -> bool:
@@ -105,7 +105,6 @@ class UserRepository(BaseRepository[User]):
             user.display_name = display_name
         user.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(user)
         return user.to_dict()
 
     async def set_role(self, user_id: int, role: str) -> bool:
@@ -146,8 +145,8 @@ class UserRepository(BaseRepository[User]):
             is_active=True,
         )
         self.session.add(user)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(user)
         return user.to_dict()
 
     async def list_users(

--- a/db/repositories/user_identity.py
+++ b/db/repositories/user_identity.py
@@ -79,7 +79,6 @@ class UserIdentityRepository(BaseRepository[UserIdentity]):
         )
         self.session.add(identity)
         await self.session.commit()
-        await self.session.refresh(user)
         return user.to_dict()
 
     async def get_identities_for_user(self, user_id: int) -> List[dict]:
@@ -107,8 +106,8 @@ class UserIdentityRepository(BaseRepository[UserIdentity]):
             last_seen=datetime.utcnow(),
         )
         self.session.add(identity)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(identity)
         return identity.to_dict()
 
     async def update_last_seen(self, provider: str, provider_uid: str) -> bool:

--- a/db/repositories/user_session.py
+++ b/db/repositories/user_session.py
@@ -36,8 +36,8 @@ class UserSessionRepository(BaseRepository[UserSession]):
             workspace_id=workspace_id,
         )
         self.session.add(user_session)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(user_session)
         return user_session.to_dict()
 
     async def get_by_jti(self, jti: str) -> Optional[UserSession]:

--- a/db/repositories/whatsapp_instance.py
+++ b/db/repositories/whatsapp_instance.py
@@ -179,7 +179,6 @@ class WhatsAppInstanceRepository(BaseRepository[WhatsAppInstance]):
 
         self.session.add(instance)
         await self.session.commit()
-        await self.session.refresh(instance)
 
         logger.info(f"Created WhatsApp instance: {instance_id}")
         return instance.to_dict()
@@ -228,7 +227,6 @@ class WhatsAppInstanceRepository(BaseRepository[WhatsAppInstance]):
 
         instance.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(instance)
 
         logger.info(f"Updated WhatsApp instance: {instance_id}")
         data: dict[str, Any] = instance.to_dict()

--- a/db/repositories/widget_instance.py
+++ b/db/repositories/widget_instance.py
@@ -176,7 +176,6 @@ class WidgetInstanceRepository(BaseRepository[WidgetInstance]):
 
         self.session.add(instance)
         await self.session.commit()
-        await self.session.refresh(instance)
 
         logger.info(f"Created widget instance: {instance_id}")
         return instance.to_dict()
@@ -224,7 +223,6 @@ class WidgetInstanceRepository(BaseRepository[WidgetInstance]):
 
         instance.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(instance)
 
         logger.info(f"Updated widget instance: {instance_id}")
         data: dict[str, Any] = instance.to_dict()

--- a/db/repositories/woocommerce.py
+++ b/db/repositories/woocommerce.py
@@ -47,8 +47,8 @@ class WooCommerceConfigRepository(BaseRepository[WooCommerceConfig]):
                 setattr(config, field, kwargs[field])
 
         config.updated = datetime.utcnow()
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(config)
         return config.to_dict()
 
     async def clear_credentials(self) -> dict:
@@ -61,5 +61,4 @@ class WooCommerceConfigRepository(BaseRepository[WooCommerceConfig]):
         config.is_connected = False
         config.updated = datetime.utcnow()
         await self.session.commit()
-        await self.session.refresh(config)
         return config.to_dict()

--- a/db/repositories/workspace.py
+++ b/db/repositories/workspace.py
@@ -58,8 +58,8 @@ class WorkspaceRepository(BaseRepository[Workspace]):
         """Create the default workspace (id=1)."""
         ws = Workspace(name=name, slug=slug)
         self.session.add(ws)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(ws)
         return ws.to_dict()
 
     # ============== Members Management ==============
@@ -160,8 +160,8 @@ class WorkspaceRepository(BaseRepository[Workspace]):
             ),
         )
         self.session.add(invite)
+        await self.session.flush()
         await self.session.commit()
-        await self.session.refresh(invite)
         return invite.to_dict()
 
     async def list_invites(self, workspace_id: int) -> List[dict]:


### PR DESCRIPTION
## Summary

- Removed all 84 `session.refresh()` calls across 40 repository files in `db/repositories/`
- Root cause: SQLite async uses `StaticPool` (single connection) — concurrent `refresh()` calls race and fail with `InvalidRequestError: Could not refresh instance`
- `expire_on_commit=False` is already set, so all Python-set attributes remain accessible after commit without refresh
- Creates with autoincrement PK: replaced `commit()+refresh()` with `flush()+commit()` (flush populates PK via `lastrowid`)
- Creates with string PK: removed `refresh()` entirely (PK set in Python)
- Updates: removed `refresh()` entirely (attributes already in memory)

## NEWS

🔧 **Исправлена критическая ошибка с зависанием чата**

Чат и другие операции переставали отвечать из-за конкурентного доступа к базе данных. Ошибка «Could not refresh instance» возникала при одновременной работе нескольких операций. Теперь все обращения к БД работают стабильно без лишних запросов.

## Test plan

- [ ] Docker rebuild: `docker compose up -d --build`
- [ ] Check logs: `docker logs ai-secretary 2>&1 | grep "Could not refresh"` — should be 0
- [ ] Test chat: send a message in admin panel, verify AI responds
- [ ] Test login: logout/login — verify UserSession created without errors
- [ ] Test kanban: update a task — verify AuditLog writes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)