### PR TITLE
fix: wiki embeddings blocking event loop

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -562,7 +562,8 @@ async def _auto_start_bridge_if_needed():
 async def _build_wiki_embeddings(wiki_rag):
     """Background task: build embedding vectors for Wiki RAG sections."""
     try:
-        result = wiki_rag.build_embeddings()
+        # Run sync build_embeddings in a thread to avoid blocking the event loop
+        result = await asyncio.to_thread(wiki_rag.build_embeddings)
         if result.get("status") == "ok":
             total = result.get("total", result.get("cached", 0))
             new = result.get("new", 0)


### PR DESCRIPTION
## Summary

- `build_embeddings()` is synchronous and makes HTTP calls to embedding provider
- When run as background task via `create_task()`, it blocks the event loop after startup, making the server completely unresponsive
- Fix: wrap in `asyncio.to_thread()` to run in a thread pool

## Test plan

- [ ] Server starts and health endpoint responds within 30s
- [ ] Wiki embeddings build works in background without blocking requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)