### PR TITLE
fix: prevent event loop blocking in collection index loading

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -585,7 +585,8 @@ async def _load_collection_indexes(wiki_rag):
             filenames = await async_knowledge_collection_manager.get_document_filenames(col["id"])
             if filenames:
                 base_dir = Path(col.get("base_dir", "wiki-pages"))
-                wiki_rag.load_collection(col["id"], filenames, base_dir)
+                # Run sync load_collection in a thread to avoid blocking the event loop
+                await asyncio.to_thread(wiki_rag.load_collection, col["id"], filenames, base_dir)
                 loaded += 1
         if loaded:
             logger.info(f"📚 Wiki RAG: загружено {loaded} коллекционных индексов")


### PR DESCRIPTION
## Summary

- Wraps `wiki_rag.load_collection()` in `asyncio.to_thread()` inside `_load_collection_indexes()` background task
- Prevents sync BM25 index building (file I/O + tokenization) from blocking the async event loop
- Fixes server startup hanging after bridge process starts — bridge health check couldn't poll because the event loop was blocked by collection loading (659 WooCommerce docs)
- Same class of bug as PR #450 (embeddings blocking fix)

## Test plan

- [ ] Server starts successfully and reaches "Application startup complete"
- [ ] Health endpoint responds within seconds of startup
- [ ] All 3 knowledge collections load (check logs for "Wiki RAG collection N" messages)
- [ ] Bridge auto-start succeeds (check for "Bridge is healthy" log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)