### PR TITLE
fix: default CC working directory to /opt/ai-secretary

### DIFF
--- a/admin/src/composables/useClaudeCode.ts
+++ b/admin/src/composables/useClaudeCode.ts
@@ -34,7 +34,7 @@ const currentToolBlocks = ref<CcToolBlock[]>([])
 const messages = ref<CcMessage[]>([])
 const currentModel = ref<string | null>(null)
 const error = ref<string | null>(null)
-const workingDir = ref('/root')
+const workingDir = ref('/opt/ai-secretary')
 const projectId = ref<number | null>(null)
 const pendingContextFiles = ref<CcContextFile[]>([])
 

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -1901,7 +1901,7 @@ watch(sessions, (newSessions) => {
         <button
           :class="[
             'w-8 h-8 rounded-lg flex items-center justify-center transition-colors',
-            cc.workingDir.value !== '/root' ? 'bg-green-600/20 text-green-400' : 'text-muted-foreground hover:bg-secondary/50'
+            cc.workingDir.value !== '/opt/ai-secretary' ? 'bg-green-600/20 text-green-400' : 'text-muted-foreground hover:bg-secondary/50'
           ]"
           :title="t('chatView.claudeCode.workDir') + ': ' + cc.workingDir.value"
           @click="showCcDirMenu = !showCcDirMenu"
@@ -2276,7 +2276,7 @@ watch(sessions, (newSessions) => {
             <button
               :class="[
                 'p-2 rounded-lg transition-colors',
-                cc.workingDir.value !== '/root' ? 'bg-green-600/20 text-green-400' : 'hover:bg-secondary text-muted-foreground'
+                cc.workingDir.value !== '/opt/ai-secretary' ? 'bg-green-600/20 text-green-400' : 'hover:bg-secondary text-muted-foreground'
               ]"
               :title="t('chatView.claudeCode.workDir') + ': ' + cc.workingDir.value"
               @click="showCcDirMenu = !showCcDirMenu"

--- a/app/routers/claude_code.py
+++ b/app/routers/claude_code.py
@@ -33,8 +33,8 @@ logger = logging.getLogger(__name__)
 
 CLAUDE_CLI = shutil.which("claude") or "/usr/local/bin/claude"
 _ALLOWED_USERS = {"shaerware", "ivan"}
-_ALLOWED_CWDS = ["/root", "/opt/ai-secretary", "/tmp"]
-_DEFAULT_CWD = "/root"
+_ALLOWED_CWDS = ["/opt/ai-secretary", "/root", "/tmp"]
+_DEFAULT_CWD = "/opt/ai-secretary"
 
 # One active WS per user
 _active_connections: dict[int, WebSocket] = {}


### PR DESCRIPTION
## Summary

- Default Claude Code working directory changed from `/root` to `/opt/ai-secretary`
- CC sessions now start in the project repo — Claude reads CLAUDE.md and project docs automatically
- Dropdown highlight logic updated to match new default
- Built-in directories reordered: `/opt/ai-secretary` first

## Test plan

- [ ] Enable CC → default dir shown as `/opt/ai-secretary`
- [ ] Send message → Claude has access to CLAUDE.md and project files
- [ ] Dropdown button not highlighted when on default dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)