### PR TITLE
fix(deploy): include devDependencies in npm ci and increase health check timeout

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -48,7 +48,7 @@ log "Installing bridge dependencies..."
 # Install/update npm deps
 log "Installing npm dependencies..."
 cd "$REPO_DIR/admin"
-npm ci --silent 2>&1 | tee -a "$LOG_FILE"
+npm ci --include=dev 2>&1 | tee -a "$LOG_FILE"
 
 # Ensure .env.production.local exists (base path override)
 if [ ! -f "$REPO_DIR/admin/.env.production.local" ]; then
@@ -76,8 +76,8 @@ rsync -a --delete "$REPO_DIR/admin/dist/" /var/www/admin-ai-sekretar24/
 log "Restarting orchestrator..."
 systemctl restart ai-secretary 2>&1 | tee -a "$LOG_FILE"
 
-# Wait and verify
-sleep 5
+# Wait and verify (20s to allow orchestrator full startup)
+sleep 20
 if curl -sf http://localhost:8002/health > /dev/null 2>&1; then
     log "=== Deploy completed successfully ==="
 else


### PR DESCRIPTION
## Summary
This PR fixes issue #359 where `npm ci --silent` fails to install devDependencies when `NODE_ENV=production` is set in the environment.

## Changes
1. **npm ci --include=dev**: Explicitly include devDependencies to ensure `vue-tsc` and other build tools are installed
2. **Health check timeout**: Increased from 5s to 20s to give the orchestrator sufficient startup time

## Problem
When `NODE_ENV=production` is set, `npm ci` skips devDependencies. Since `vue-tsc` is listed in devDependencies but is required for the build step (`npm run build`), the deploy fails with:

```
sh: 1: vue-tsc: not found
```

## Solution
Using `npm ci --include=dev` ensures devDependencies are always installed regardless of NODE_ENV.

Fixes #359