### PR TITLE
fix: GitHub repos sync — proxy bypass, unique filenames, .md dedup

### DIFF
--- a/app/routers/github_repos.py
+++ b/app/routers/github_repos.py
@@ -154,8 +154,9 @@ async def create_project(
             )
 
         # Summary doc
+        summary_fname = f"{data.github_owner}-{data.github_repo}--_summary.md"
         await async_knowledge_doc_manager.create(
-            filename="_summary.md",
+            filename=summary_fname,
             title=f"GitHub: {data.github_owner}/{data.github_repo}",
             source_type="github",
             file_size_bytes=len(summary.encode("utf-8")),
@@ -392,8 +393,9 @@ async def sync_project(
                     collection_id=collection_id,
                 )
 
+            summary_filename = f"{project_orm.github_owner}-{project_orm.github_repo}--_summary.md"
             await async_knowledge_doc_manager.create(
-                filename="_summary.md",
+                filename=summary_filename,
                 title=f"GitHub: {project_orm.github_owner}/{project_orm.github_repo}",
                 source_type="github",
                 file_size_bytes=len(summary.encode("utf-8")),

--- a/app/services/github_repo_sync_service.py
+++ b/app/services/github_repo_sync_service.py
@@ -5,6 +5,7 @@ Pure functions: no DB access. Handles git clone/pull, file filtering, and markdo
 
 import fnmatch
 import logging
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -106,6 +107,14 @@ LANG_MAP = {
 }
 
 
+def _clean_env() -> dict[str, str]:
+    """Return os.environ copy with proxy vars stripped (xray proxy breaks git)."""
+    env = os.environ.copy()
+    for key in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy", "ALL_PROXY"):
+        env.pop(key, None)
+    return env
+
+
 def get_repo_dir(owner: str, repo: str) -> Path:
     """Get the local directory for a cloned repo."""
     return GITHUB_REPOS_DIR / f"{owner}-{repo}"
@@ -146,6 +155,7 @@ def clone_repo(
         capture_output=True,
         text=True,
         timeout=300,
+        env=_clean_env(),
     )
     if result.returncode != 0:
         stderr = result.stderr.strip()
@@ -181,6 +191,7 @@ def pull_repo(
         capture_output=True,
         text=True,
         timeout=300,
+        env=_clean_env(),
     )
     if result.returncode != 0:
         stderr = result.stderr.strip()
@@ -192,7 +203,7 @@ def pull_repo(
 
     # Reset to FETCH_HEAD
     reset_cmd = ["git", "-C", str(target), "reset", "--hard", "FETCH_HEAD"]
-    subprocess.run(reset_cmd, capture_output=True, text=True, timeout=60)
+    subprocess.run(reset_cmd, capture_output=True, text=True, timeout=60, env=_clean_env())
 
     return get_head_sha(target)
 
@@ -305,8 +316,10 @@ def build_repo_documents(
 
         title, content = convert_file_to_markdown(filepath, repo_dir)
         rel_path = filepath.relative_to(repo_dir)
-        # Sanitize filename for RAG: replace / with --
-        safe_name = str(rel_path).replace("/", "--") + ".md"
+        # Sanitize filename for RAG: prefix with owner-repo, replace / with --
+        safe_name = f"{owner}-{repo}--{str(rel_path).replace('/', '--')}"
+        if not safe_name.endswith(".md"):
+            safe_name += ".md"
 
         documents.append((safe_name, title, content, file_size))
 


### PR DESCRIPTION
## Summary

- Strip proxy env vars (`HTTP_PROXY`/`HTTPS_PROXY`) from `subprocess.run` for git operations — xray proxy was intercepting GitHub API calls causing `ConnectionRefused` on port 10809
- Prefix `knowledge_documents.filename` with `{owner}-{repo}--` to avoid global UNIQUE constraint conflicts between repos sharing identical filenames (e.g. `README.md`)
- Skip adding `.md` suffix when filename already ends with `.md` (was producing `README.md.md`)

## NEWS

🔧 **Синхронизация GitHub-репозиториев починена**

Исправлены три бага, мешавших подключить GitHub-репозитории в базу знаний: прокси блокировал git-операции, одинаковые имена файлов (README.md) из разных репо конфликтовали в БД, а .md файлы получали двойное расширение. Теперь все репозитории синхронизируются корректно.

## Test plan

- [ ] Sync all 3 GitHub repos via admin panel (Finetune → Cloud AI → GitHub repos)
- [ ] Verify no `.md.md` filenames in knowledge_documents table
- [ ] Verify repos with same filenames (README.md) don't conflict
- [ ] Verify sync works when xray proxy is active (Gemini backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)