### PR TITLE
docs: update documentation for Phase 2.1 domain services

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -248,7 +248,7 @@ GET  /admin/legal/consent/stats # Статистика согласий
 - [x] Создать persistent storage (SQLite) — `db/repositories/audit.py`
 - [x] Модель `AuditLog` в `db/models.py`
 - [x] `AuditRepository` с методами: `log()`, `get_logs()`, `get_recent()`
-- [x] `AsyncAuditLogger` wrapper в `db/integration.py`
+- [x] `AuditService` в `modules/monitoring/service.py` (ранее `AsyncAuditLogger` в `db/integration.py`)
 - [x] API эндпоинты: `GET /admin/audit/logs`, `GET /admin/audit/export`
 - [x] Фильтрация по дате, пользователю, типу события
 - [x] Таб "Audit" в админке с таблицей и экспортом (AuditView.vue)
@@ -258,7 +258,7 @@ GET  /admin/legal/consent/stats # Статистика согласий
 ```
 db/models.py                    # AuditLog модель
 db/repositories/audit.py        # AuditRepository
-db/integration.py               # AsyncAuditLogger
+modules/monitoring/service.py   # AuditService (ранее AsyncAuditLogger в db/integration.py)
 admin/src/views/AuditView.vue   # UI
 admin/src/api/audit.ts          # API client
 ```
@@ -584,17 +584,17 @@ models/vosk/              # Директория для моделей
 db/
 ├── __init__.py
 ├── database.py           # SQLite engine
-├── models.py             # 7 ORM models
+├── models.py             # ORM models (imports from modules/*/models.py)
 ├── redis_client.py       # Caching
-├── integration.py        # Backward-compat managers
-└── repositories/
-    ├── base.py
-    ├── chat.py
-    ├── faq.py
-    ├── preset.py
-    ├── config.py
-    ├── telegram.py
-    └── audit.py
+├── integration.py        # Backward-compat facade (aliases + singletons)
+└── repositories/         # Data access layer (25 repositories)
+
+modules/                  # Domain services (31 classes in 15 files)
+├── core/service.py       # DatabaseService, UserService, etc.
+├── chat/service.py       # ChatService, ChatShareService
+├── knowledge/service.py  # FAQService, KnowledgeDocService, etc.
+├── channels/telegram/service.py  # BotInstanceService, TelegramSessionService
+└── ...                   # kanban, llm, monitoring, admin, etc.
 
 scripts/
 ├── migrate_json_to_db.py
@@ -1905,8 +1905,9 @@ pip install zipfile36  # или стандартный zipfile
   db/database.py           # SQLite connection
   db/models.py             # ORM models
   db/redis_client.py       # Redis helpers
-  db/integration.py        # Async managers
+  db/integration.py        # Backward-compat facade (aliases + singletons)
   db/repositories/         # Data access layer
+  modules/*/service.py     # Domain services (31 classes)
   scripts/migrate_json_to_db.py
   scripts/test_db.py
   scripts/setup_db.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,30 @@ Foundation layer for the ongoing modular decomposition (see issue #489). Purely 
 
 Import from `modules.core`: `EventBus`, `BaseEvent`, `TaskRegistry`, `TaskInfo`, `HealthRegistry`, `HealthStatus`.
 
+### Domain Services (`modules/*/service.py`)
+
+Extracted from the monolithic `db/integration.py` into domain-specific service files (Phase 2 of modular decomposition, issue #492):
+
+| Module | File | Service Classes |
+|--------|------|-----------------|
+| `modules/core/` | `service.py` | `DatabaseService`, `UserService`, `UserSessionService`, `RoleService`, `WorkspaceService`, `ConfigService`, `UserIdentityService` |
+| `modules/chat/` | `service.py` | `ChatService`, `ChatShareService` |
+| `modules/knowledge/` | `service.py` | `FAQService`, `KnowledgeDocService`, `KnowledgeCollectionService`, `GitHubRepoProjectService` |
+| `modules/channels/telegram/` | `service.py` | `BotInstanceService`, `TelegramSessionService` |
+| `modules/channels/whatsapp/` | `service.py` | `WhatsAppInstanceService` |
+| `modules/channels/widget/` | `service.py` | `WidgetInstanceService` |
+| `modules/kanban/` | `service.py` | `KanbanService`, `KanbanProjectService` |
+| `modules/claude_code/` | `service.py` | `ClaudeCodeService`, `ClaudeCodeProjectService` |
+| `modules/llm/` | `service.py` | `CloudProviderService` |
+| `modules/monitoring/` | `service.py` | `AuditService`, `PaymentService` |
+| `modules/admin/` | `service.py` | `ResourceShareService` |
+| `modules/speech/` | `service.py` | `PresetService` |
+| `modules/crm/` | `service.py` | `AmoCRMService` |
+| `modules/ecommerce/` | `service.py` | `WooCommerceService` |
+| `modules/telephony/` | `service.py` | `GSMService` |
+
+**Import pattern**: `from modules.chat.service import ChatService` (direct) or `from db.integration import async_chat_manager` (backward-compatible singleton). Domain `__init__.py` files do NOT re-export services due to circular import with `db/models.py`.
+
 ### Key Components
 
 **`orchestrator.py`** (~4100 lines): FastAPI entry point. Initializes all services as module-level globals, populates `ServiceContainer`, includes all routers. Legacy OpenAI-compatible `/v1/*` endpoints still live here.
@@ -141,11 +165,13 @@ Import from `modules.core`: `EventBus`, `BaseEvent`, `TaskRegistry`, `TaskInfo`,
 
 **Two service layers**: Core AI services at project root (`cloud_llm_service.py`, `vllm_llm_service.py`, `voice_clone_service.py`, `stt_service.py`, etc.). Domain services in `app/services/` (`amocrm_service.py`, `wiki_rag_service.py`, `backup_service.py`, `sales_funnel.py`, etc.).
 
-**Database layer** (`db/`): Async SQLAlchemy + aiosqlite. `db/database.py` creates engine. `db/integration.py` provides backward-compatible manager classes (e.g., `AsyncChatManager`) used as module-level singletons. Repositories in `db/repositories/` inherit from `BaseRepository` with generic CRUD and `_apply_workspace_filter()` for multi-tenant queries.
+**Database layer** (`db/`): Async SQLAlchemy + aiosqlite. `db/database.py` creates engine. Repositories in `db/repositories/` inherit from `BaseRepository` with generic CRUD and `_apply_workspace_filter()` for multi-tenant queries.
 
-**Unit of Work**: Repositories only `flush()` — never `commit()`. Callers own transaction boundaries: managers call `session.commit()`, `get_async_session()` auto-commits on success / rollbacks on exception.
+**Domain services** (`modules/*/service.py`): 31 service classes across 15 files. Each service opens its own `AsyncSessionLocal()` session, calls repository methods, and commits. Naming convention: `XService` (e.g., `ChatService`, `UserService`). Import directly: `from modules.chat.service import ChatService`. Backward-compatible aliases live in `db/integration.py` (facade): `AsyncChatManager = ChatService`, singleton `async_chat_manager = AsyncChatManager()`.
 
-**SQLITE_BUSY retry**: `db/retry.py` `@retry_on_busy()` — exponential backoff (3 retries, 0.1s base). Applied to all write methods in `integration.py` managers.
+**Unit of Work**: Repositories only `flush()` — never `commit()`. Callers own transaction boundaries: service methods call `session.commit()`, `get_async_session()` auto-commits on success / rollbacks on exception.
+
+**SQLITE_BUSY retry**: `db/retry.py` `@retry_on_busy()` — exponential backoff (3 retries, 0.1s base). Applied to write methods in domain service classes (16 methods across 5 services).
 
 **Telegram bots**: Subprocesses managed by `multi_bot_manager.py`. Config pre-fetched from DB, written to `/tmp/bot_config_{id}.json`. Two frameworks: `python-telegram-bot` (legacy) + `aiogram` (new). `LLMRouter` in `telegram_bot/services/llm_router.py` routes through orchestrator chat API.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,12 +124,24 @@ Then create a Pull Request on GitHub with:
 AI_Secretary_System/
 ├── orchestrator.py          # FastAPI entry point
 ├── app/
-│   ├── routers/             # API endpoints (15 routers)
+│   ├── routers/             # API endpoints (28 routers)
 │   ├── dependencies.py      # Dependency injection
 │   ├── rate_limiter.py      # Rate limiting
 │   └── security_headers.py  # Security middleware
+├── modules/                 # Domain modules
+│   ├── core/                # EventBus, TaskRegistry, HealthRegistry + core services
+│   ├── chat/                # ChatService, ChatShareService
+│   ├── knowledge/           # FAQService, KnowledgeDocService, KnowledgeCollectionService
+│   ├── channels/telegram/   # BotInstanceService, TelegramSessionService
+│   ├── channels/whatsapp/   # WhatsAppInstanceService
+│   ├── channels/widget/     # WidgetInstanceService
+│   ├── kanban/              # KanbanService, KanbanProjectService
+│   ├── llm/                 # CloudProviderService
+│   ├── monitoring/          # AuditService, PaymentService
+│   └── ...                  # admin, speech, crm, ecommerce, telephony, claude_code
 ├── db/
-│   ├── models.py            # SQLAlchemy models
+│   ├── models.py            # SQLAlchemy models (imports from modules/*/models.py)
+│   ├── integration.py       # Backward-compatible facade (aliases + singletons)
 │   └── repositories/        # Data access layer
 ├── admin/                   # Vue 3 admin panel
 │   ├── src/views/           # Page components

--- a/SYSTEM_DOCS.md
+++ b/SYSTEM_DOCS.md
@@ -96,7 +96,8 @@ container.backup_service      # BackupService
 - **DB File**: `data/secretary.db`
 - **Redis**: Опциональное кэширование (graceful fallback если недоступен)
 - **Паттерн**: `BaseRepository[Model]` — generic CRUD для всех моделей
-- **Интеграция**: `DatabaseManager` в `db/integration.py` — singleton, backward-compat обёртка
+- **Доменные сервисы**: 31 класс в `modules/*/service.py` (например, `ChatService` в `modules/chat/service.py`)
+- **Фасад**: `db/integration.py` — backward-compatible алиасы и синглтоны (например, `AsyncChatManager = ChatService`, `async_chat_manager = AsyncChatManager()`)
 
 ### Таблицы (35 таблиц)
 
@@ -501,4 +502,4 @@ ORCHESTRATOR_PORT=8002
 Полный список переменных в `.env.example`.
 
 ---
-*Обновлено: 2026-02-12*
+*Обновлено: 2026-03-03*

--- a/wiki-pages/Architecture.md
+++ b/wiki-pages/Architecture.md
@@ -1,0 +1,319 @@
+# Architecture (Архитектура)
+
+Техническая архитектура AI Secretary System: текущее состояние, модульная инфраструктура и план миграции.
+
+## Обзор
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                  Orchestrator (port 8002)                     │
+│  orchestrator.py + app/routers/ (28 роутеров, ~400 endpoints)│
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │        Vue 3 Admin Panel (23 views, PWA)                │  │
+│  │                admin/dist/                              │  │
+│  └────────────────────────────────────────────────────────┘  │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │        modules/core/ (Phase 0)                          │  │
+│  │  EventBus · TaskRegistry · HealthRegistry               │  │
+│  └────────────────────────────────────────────────────────┘  │
+└────────────┬──────────────┬──────────────┬───────────────────┘
+             │              │              │
+     ┌───────┴──┐    ┌──────┴───┐   ┌─────┴─────┐
+     │ LLM      │    │ TTS      │   │ STT       │
+     │ vLLM /   │    │ XTTS v2 /│   │ Vosk /    │
+     │ Cloud    │    │ Piper    │   │ Whisper   │
+     └──────────┘    └──────────┘   └───────────┘
+```
+
+**Пайплайн обработки:** Сообщение пользователя → FAQ-проверка (мгновенный ответ) ИЛИ LLM → TTS → Аудио-ответ
+
+**Профили развёртывания** (`DEPLOYMENT_MODE`): `full` (всё), `cloud` (без GPU/TTS/STT/GSM), `local` (= full).
+
+## Текущее состояние
+
+### Монолит (исторический)
+
+| Компонент | Размер | Что содержит |
+|-----------|--------|-------------|
+| `orchestrator.py` | ~4100 строк | FastAPI entry point, инициализация сервисов, legacy endpoints, background tasks, регистрация 28 роутеров |
+| `db/models.py` | ~200 строк (фасад) | Реэкспорт моделей из `modules/*/models.py` (54 модели) |
+| `db/integration.py` | ~2700 строк | 29 менеджеров — синглтоны на уровне модуля (будет заменён фасадом в Phase 2.2) |
+
+### Что уже хорошо структурировано
+
+| Компонент | Описание |
+|-----------|----------|
+| `app/routers/` | 28 отдельных файлов роутеров |
+| `db/repositories/` | 45 файлов, чистая изоляция, `BaseRepository` с generic CRUD |
+| `telegram_bot/`, `whatsapp_bot/` | Отдельные процессы, общаются через HTTP API |
+| `app/services/` | Доменные сервисы (amoCRM, Wiki RAG, backup и др.) |
+| `app/dependencies.py` | `ServiceContainer` — DI через FastAPI `Depends` |
+
+---
+
+## Модульная инфраструктура (`modules/`)
+
+### Phase 0: Core (`modules/core/`)
+
+> **Статус:** реализовано (PR [#497](https://github.com/ShaerWare/AI_Secretary_System/pull/497), issue [#490](https://github.com/ShaerWare/AI_Secretary_System/issues/490))
+
+Фундамент для модульной декомпозиции. Три компонента, которые используются всеми доменными модулями.
+
+```
+modules/core/
+├── __init__.py      ← реэкспорт EventBus, TaskRegistry, HealthRegistry
+├── events.py        ← EventBus + BaseEvent
+├── tasks.py         ← TaskRegistry + TaskInfo
+└── health.py        ← HealthRegistry + HealthStatus
+```
+
+### Импорт
+
+```python
+from modules.core import EventBus, BaseEvent, TaskRegistry, TaskInfo, HealthRegistry, HealthStatus
+```
+
+---
+
+### EventBus
+
+In-process асинхронная шина событий для развязки межмодульного взаимодействия.
+
+**Принципы:**
+- Обработчики — async callable, выполняются конкурентно через `asyncio.gather`
+- Ошибки обработчиков **логируются**, но **не пробрасываются** к издателю
+- `publish()` ожидает завершения всех обработчиков (не fire-and-forget)
+- Типизированная маршрутизация — обработчик получает только события своего типа
+
+**API:**
+
+| Метод | Описание |
+|-------|----------|
+| `subscribe(event_type, handler)` | Подписка async обработчика на тип события |
+| `publish(event)` | Публикация события всем подписчикам |
+| `clear()` | Удаление всех обработчиков (для тестов) |
+
+**Пример:**
+
+```python
+from dataclasses import dataclass
+from modules.core import EventBus, BaseEvent
+
+@dataclass
+class UserCreated(BaseEvent):
+    user_id: int
+    username: str
+
+bus = EventBus()
+
+async def on_user_created(event: UserCreated):
+    print(f"New user: {event.username} (id={event.user_id})")
+
+bus.subscribe(UserCreated, on_user_created)
+await bus.publish(UserCreated(user_id=42, username="alice"))
+```
+
+---
+
+### TaskRegistry
+
+Реестр именованных фоновых задач с управлением жизненным циклом.
+
+**Два типа задач:**
+- **Периодические** (`interval=N`) — выполняются в цикле: run → sleep N секунд → repeat
+- **Одноразовые** (`interval=None`) — выполняются один раз и завершаются
+
+**Статусы:** `pending` → `running` → `completed` | `failed` | `cancelled`
+
+**API:**
+
+| Метод | Описание |
+|-------|----------|
+| `register(name, coro_fn, *, interval=None, initial_delay=0)` | Регистрация задачи |
+| `start_all()` | Создание `asyncio.Task` для каждой зарегистрированной задачи |
+| `cancel_all(timeout=10.0)` | Отмена всех задач с ожиданием завершения |
+| `list_tasks()` → `list[TaskInfo]` | Информация о всех задачах |
+
+**Поведение при ошибках:**
+- Периодическая задача: ошибка логируется, задача продолжает работать
+- Одноразовая задача: ошибка логируется, статус `failed`
+- `CancelledError`: статус `cancelled`, исключение пробрасывается (корректное завершение)
+
+**Пример:**
+
+```python
+from modules.core import TaskRegistry
+
+registry = TaskRegistry()
+
+async def cleanup_sessions():
+    # удаление просроченных сессий
+    ...
+
+async def send_welcome_email():
+    # одноразовая задача
+    ...
+
+registry.register("session-cleanup", cleanup_sessions, interval=3600)
+registry.register("welcome-email", send_welcome_email, initial_delay=5)
+
+await registry.start_all()   # запуск всех задач
+# ...
+await registry.cancel_all()  # graceful shutdown
+```
+
+---
+
+### HealthRegistry
+
+Реестр модульных health check-ов с агрегацией статусов.
+
+**Логика агрегации:**
+- Все `ok` → общий статус `ok`
+- Хотя бы один `degraded` → общий статус `degraded`
+- Хотя бы один `error` → общий статус `error`
+
+**Защита:** каждый check выполняется с индивидуальным timeout (`asyncio.wait_for`). Таймаут или исключение → `error`.
+
+**API:**
+
+| Метод | Описание |
+|-------|----------|
+| `register(name, check)` | Регистрация async health check |
+| `check_all(timeout=5.0)` → `dict` | Параллельный запуск всех проверок |
+
+**Формат результата `check_all()`:**
+
+```json
+{
+  "status": "ok | degraded | error",
+  "checks": {
+    "database": {"status": "ok", "details": {"tables": 54}},
+    "redis": {"status": "degraded", "details": {"reason": "high latency"}}
+  }
+}
+```
+
+**Пример:**
+
+```python
+from modules.core import HealthRegistry, HealthStatus
+
+registry = HealthRegistry()
+
+async def check_database():
+    # проверка подключения к БД
+    return HealthStatus(status="ok", details={"tables": 54})
+
+async def check_redis():
+    # проверка Redis
+    return HealthStatus(status="ok", details={"connected": True})
+
+registry.register("database", check_database)
+registry.register("redis", check_redis)
+
+result = await registry.check_all(timeout=5.0)
+print(result["status"])  # "ok"
+```
+
+---
+
+### Phase 1: Доменные модели (`modules/*/models.py`)
+
+> **Статус:** реализовано (PR [#499](https://github.com/ShaerWare/AI_Secretary_System/pull/499), issue [#491](https://github.com/ShaerWare/AI_Secretary_System/issues/491))
+
+54 SQLAlchemy модели разнесены из монолитного `db/models.py` по доменным файлам. `db/models.py` стал фасадом-реэкспортом (~200 строк).
+
+```
+modules/
+├── core/models.py           ← User, UserSession, Role, Workspace, SystemConfig, ...
+├── chat/models.py           ← ChatSession, ChatMessage, ChatShare
+├── knowledge/models.py      ← FAQEntry, KnowledgeDocument, KnowledgeCollection
+├── channels/telegram/models.py  ← BotInstance, TelegramSession
+├── channels/whatsapp/models.py  ← WhatsAppInstance
+├── channels/widget/models.py    ← WidgetInstance
+├── kanban/models.py         ← KanbanTask, KanbanTaskDependency, KanbanChecklistItem, ...
+├── monitoring/models.py     ← AuditLog, PaymentLog
+├── llm/models.py            ← CloudLLMProvider, LLMPreset
+├── speech/models.py         ← TTSPreset
+├── crm/models.py            ← AmoCRMConfig, AmoCRMSyncLog
+├── ecommerce/models.py      ← WooCommerceConfig
+├── telephony/models.py      ← GSMCallLog, GSMSMSLog
+├── admin/models.py          ← ResourceShare
+├── claude_code/models.py    ← ClaudeCodeConversation, ClaudeCodeProject
+└── sales/models.py          ← BotAgentPrompt, BotSegment, BotUserProfile, ...
+```
+
+---
+
+### Phase 2.1: Доменные сервисы (`modules/*/service.py`)
+
+> **Статус:** реализовано (PR [#504](https://github.com/ShaerWare/AI_Secretary_System/pull/504), issue [#501](https://github.com/ShaerWare/AI_Secretary_System/issues/501))
+
+31 менеджер-класс извлечён из `db/integration.py` в 15 доменных файлов. Именование: `AsyncXManager` → `XService`. Additive-only — `db/integration.py` пока не изменён.
+
+| Модуль | Файл | Сервисы |
+|--------|------|---------|
+| `modules/core/` | `service.py` | `DatabaseService`, `UserService`, `UserSessionService`, `RoleService`, `WorkspaceService`, `ConfigService`, `UserIdentityService` |
+| `modules/chat/` | `service.py` | `ChatService`, `ChatShareService` |
+| `modules/knowledge/` | `service.py` | `FAQService`, `KnowledgeDocService`, `KnowledgeCollectionService`, `GitHubRepoProjectService` |
+| `modules/channels/telegram/` | `service.py` | `BotInstanceService`, `TelegramSessionService` |
+| `modules/channels/whatsapp/` | `service.py` | `WhatsAppInstanceService` |
+| `modules/channels/widget/` | `service.py` | `WidgetInstanceService` |
+| `modules/kanban/` | `service.py` | `KanbanService`, `KanbanProjectService` |
+| `modules/claude_code/` | `service.py` | `ClaudeCodeService`, `ClaudeCodeProjectService` |
+| `modules/llm/` | `service.py` | `CloudProviderService` |
+| `modules/monitoring/` | `service.py` | `AuditService`, `PaymentService` |
+| `modules/admin/` | `service.py` | `ResourceShareService` |
+| `modules/speech/` | `service.py` | `PresetService` |
+| `modules/crm/` | `service.py` | `AmoCRMService` |
+| `modules/ecommerce/` | `service.py` | `WooCommerceService` |
+| `modules/telephony/` | `service.py` | `GSMService` |
+
+**Импорт:** `from modules.chat.service import ChatService` (прямой) или `from db.integration import async_chat_manager` (backward-compatible синглтон).
+
+**Known limitation:** доменные `__init__.py` не реэкспортируют сервисы из-за циклического импорта `db/models.py` → `modules/X/__init__.py` → `service.py` → `db/repositories` → `db/models.py`. Будет решено в Phase 2.3 ([#503](https://github.com/ShaerWare/AI_Secretary_System/issues/503)).
+
+---
+
+## Тесты
+
+24 unit-теста для core-инфраструктуры:
+
+```bash
+pytest tests/unit/test_event_bus.py tests/unit/test_task_registry.py tests/unit/test_health_registry.py -v
+```
+
+| Файл | Тестов | Что покрывает |
+|------|--------|---------------|
+| `test_event_bus.py` | 8 | publish/subscribe, error isolation, type filtering, clear |
+| `test_task_registry.py` | 8 | periodic/one-shot, cancel, errors, initial_delay, list |
+| `test_health_registry.py` | 8 | aggregation (ok/degraded/error), timeout, exceptions |
+
+---
+
+## План модульной декомпозиции
+
+> Полный план: issue [#489](https://github.com/ShaerWare/AI_Secretary_System/issues/489)
+> Стратегия: **Strangler Fig** — новый код рядом со старым, постепенная миграция импортов, старые файлы → фасады-реэкспорты.
+
+| Фаза | Описание | Issue | Статус |
+|------|----------|-------|--------|
+| **0** | Инфраструктура core (EventBus, TaskRegistry, HealthRegistry) | [#490](https://github.com/ShaerWare/AI_Secretary_System/issues/490) | ✅ Завершена |
+| **1** | Разделение `db/models.py` → доменные модули | [#491](https://github.com/ShaerWare/AI_Secretary_System/issues/491) | ✅ Завершена |
+| **2** | Разделение `db/integration.py` → доменные сервисы | [#492](https://github.com/ShaerWare/AI_Secretary_System/issues/492) | 🔄 Phase 2.1 завершена ([#501](https://github.com/ShaerWare/AI_Secretary_System/issues/501)), 2.2 ([#502](https://github.com/ShaerWare/AI_Secretary_System/issues/502)) и 2.3 ([#503](https://github.com/ShaerWare/AI_Secretary_System/issues/503)) в ожидании |
+| **3** | Перенос роутеров в доменные модули | [#493](https://github.com/ShaerWare/AI_Secretary_System/issues/493) | ⏳ |
+| **4** | Декомпозиция `orchestrator.py` | [#494](https://github.com/ShaerWare/AI_Secretary_System/issues/494) | ⏳ |
+| **5** | Внедрение EventBus-событий | [#495](https://github.com/ShaerWare/AI_Secretary_System/issues/495) | ⏳ |
+| **6** | Протокольные интерфейсы | [#496](https://github.com/ShaerWare/AI_Secretary_System/issues/496) | ⏳ |
+
+### Ключевые ограничения
+
+1. **Alembic-миграции** — `db/models.py` остаётся как фасад-реэкспорт, чтобы не ломать `from db.models import ...` в существующих миграциях
+2. **SQLAlchemy Base** — единый `Base` из `db/database.py` для всех доменных моделей (create_all, relationships, autogenerate)
+3. **Cross-domain FK** — `workspace_id`, `owner_id → User.id` — нормальная зависимость "все зависят от core", FK сохраняются
+4. **Параллельная разработка** — каждую фазу делает одна машина, мелкие PR с чёткими границами
+
+---
+
+← [[Database]] | [[Deployment-Profiles]] →

--- a/wiki-pages/CRM.md
+++ b/wiki-pages/CRM.md
@@ -449,9 +449,9 @@ redis-cli keys "amocrm:*" | xargs redis-cli del
 ```
 app/routers/amocrm.py
   → app/services/amocrm_service.py (AmoCRMService)
-    → AsyncAmoCRMManager (db/integration.py)
+    → AmoCRMService (modules/crm/service.py)
       → AmoCRMRepository (db/repositories/amocrm.py)
-        → AmoCRMConfig, AmoCRMToken (db/models.py)
+        → AmoCRMConfig, AmoCRMToken (modules/crm/models.py)
 ```
 
 ### AmoCRMService
@@ -468,9 +468,9 @@ app/routers/amocrm.py
 - `refresh_tokens()` — обновить токены при 401
 - `exchange_code(code)` — обмен `authorization_code` на токены
 
-### AsyncAmoCRMManager
+### AmoCRMService
 
-Менеджер в `db/integration.py` для работы с конфигурацией и токенами в БД:
+Доменный сервис в `modules/crm/service.py` (ранее `AsyncAmoCRMManager` в `db/integration.py`) для работы с конфигурацией и токенами в БД:
 
 - `get_config()` — получить конфигурацию
 - `save_config(config)` — сохранить конфигурацию

--- a/wiki-pages/Cloud-AI-Training.md
+++ b/wiki-pages/Cloud-AI-Training.md
@@ -277,7 +277,7 @@ app/services/wiki_rag_service.py     # TF-IDF поисковый движок
 app/routers/wiki_rag.py              # API-роутер (8 эндпоинтов)
 db/models.py → KnowledgeDocument     # SQLAlchemy модель
 db/repositories/knowledge_document.py # Репозиторий
-db/integration.py → AsyncKnowledgeDocManager  # Обёртка
+modules/knowledge/service.py → KnowledgeDocService  # Доменный сервис (ранее AsyncKnowledgeDocManager в db/integration.py)
 ```
 
 ---

--- a/wiki-pages/Kanban.md
+++ b/wiki-pages/Kanban.md
@@ -242,10 +242,12 @@ python scripts/migrate_kanban.py
 
 ```
 app/routers/kanban.py (10 endpoints)
-  -> db/integration.py (async_kanban_manager)
+  -> modules/kanban/service.py (KanbanService)
     -> db/repositories/kanban.py (KanbanRepository)
-      -> db/models.py (KanbanTask, KanbanTaskDependency, KanbanChecklistItem)
+      -> modules/kanban/models.py (KanbanTask, KanbanTaskDependency, KanbanChecklistItem)
 ```
+
+> **Примечание:** Синглтон `async_kanban_manager` в `db/integration.py` — backward-compatible алиас для `KanbanService`.
 
 Frontend:
 ```

--- a/wiki-pages/RBAC.md
+++ b/wiki-pages/RBAC.md
@@ -522,7 +522,7 @@ Inline-скрипт Service Worker вынесен из `admin/index.html` в `ad
 
 | Канал | Где вызывается | provider | provider_uid |
 |-------|---------------|----------|-------------|
-| Telegram | `AsyncTelegramSessionManager.set_session()` в `db/integration.py` | `telegram` | chat_id |
+| Telegram | `TelegramSessionService.set_session()` в `modules/channels/telegram/service.py` | `telegram` | chat_id |
 | WhatsApp | `handle_text_message()` в `whatsapp_bot/handlers/messages.py` | `whatsapp` | phone (E.164) |
 | Widget | `widget_create_session()` в `orchestrator.py` | `widget` | session_id |
 
@@ -549,7 +549,7 @@ Inline-скрипт Service Worker вынесен из `admin/index.html` в `ad
 **Код:**
 - Модель: `UserIdentity` в `db/models.py`, связь `User.identities` (one-to-many)
 - Репозиторий: `UserIdentityRepository` в `db/repositories/user_identity.py`
-- Менеджер: `AsyncUserIdentityManager` в `db/integration.py` (синглтон `async_user_identity_manager`)
+- Сервис: `UserIdentityService` в `modules/core/service.py` (синглтон `async_user_identity_manager` в `db/integration.py`)
 - `VALID_ROLES` в `user.py`: `("guest", "web", "user", "admin", "contact")`
 
 ## Статус миграции эндпоинтов
@@ -819,7 +819,7 @@ function isVisible(item: { module?: string; minLevel?: string; localOnly?: boole
 
 - **Модели**: `Role`, `RolePermission`, `Workspace`, `WorkspaceMember`, `WorkspaceInvite` в `db/models.py`
 - **Репозитории**: `RoleRepository` в `db/repositories/role.py`, `WorkspaceRepository` в `db/repositories/workspace.py`
-- **Менеджеры**: `AsyncRoleManager`, `AsyncWorkspaceManager` в `db/integration.py`
+- **Сервисы**: `RoleService`, `WorkspaceService` в `modules/core/service.py` (backward-compatible алиасы `AsyncRoleManager`, `AsyncWorkspaceManager` в `db/integration.py`)
 - **Auth-хелперы**: `level_gte()`, `get_user_permissions()`, `require_permission()`, `user_has_level()`, `invalidate_permissions_cache()` в `auth_manager.py`
 - **Кеши**: `PermissionsCache` (role_name → permissions), `MemberRoleCache` ((user_id, workspace_id) → role_name) в `auth_manager.py`
 - **JWT**: `TokenPayload.workspace_id` (default 1), `User.workspace_id` — передаётся в `create_access_token()` и `create_session()`

--- a/wiki-pages/Response-Pipeline.md
+++ b/wiki-pages/Response-Pipeline.md
@@ -56,7 +56,7 @@ retrieve(query, top_k=3, max_chars=2500)
 
 ## 2. FAQ — быстрая проверка
 
-FAQ загружается при старте из БД (`async_faq_manager.get_all()`), перезагружается при изменениях через `/admin/faq`.
+FAQ загружается при старте из БД (`FAQService.get_all()` / синглтон `async_faq_manager`), перезагружается при изменениях через `/admin/faq`.
 
 ### Алгоритм матчинга
 
@@ -88,7 +88,7 @@ _check_faq(user_message):
   │     llm_override (per-request) > widget_instance config > container.llm_service (глобальный)
   │
   ├─ 2. Сохранение user message в БД
-  │     async_chat_manager.add_message(session_id, "user", content)
+  │     ChatService.add_message(session_id, "user", content)
   │
   ├─ 3. Системный промпт
   │     Кастомный (виджет / оверрайд) > llm.get_system_prompt() > _DEFAULT_RAG_PROMPT
@@ -113,7 +113,7 @@ _check_faq(user_message):
   │     user_message → chunk* → assistant_message → [DONE]
   │
   └─ 9. Сохранение ответа в БД
-        async_chat_manager.add_message(session_id, "assistant", full_text)
+        ChatService.add_message(session_id, "assistant", full_text)
 ```
 
 ### Сборка системного промпта (итог)


### PR DESCRIPTION
## Summary

- Update all documentation referencing `db/integration.py` and old `AsyncXManager` class names to reflect the new domain service architecture from Phase 2.1 (#504)
- Add Architecture wiki page to `wiki-pages/` (was previously only in the wiki repo)
- GitHub Wiki also updated and synced

### Files updated (10 files)

**Root docs:**
- `CLAUDE.md` — added domain services table, updated database layer description
- `SYSTEM_DOCS.md` — updated db architecture: added domain services, updated facade description
- `CONTRIBUTING.md` — updated project structure tree to include `modules/`
- `BACKLOG.md` — updated `db/` structure, `AsyncAuditLogger` → `AuditService`

**Wiki pages:**
- `Architecture.md` — added Phase 1 (models) and Phase 2.1 (services) sections, updated decomposition plan status
- `CRM.md` — `AsyncAmoCRMManager` → `AmoCRMService` in `modules/crm/service.py`
- `Kanban.md` — `async_kanban_manager` → `KanbanService` in `modules/kanban/service.py`
- `Cloud-AI-Training.md` — `AsyncKnowledgeDocManager` → `KnowledgeDocService`
- `RBAC.md` — updated manager references to domain services (UserIdentityService, RoleService, WorkspaceService, TelegramSessionService)
- `Response-Pipeline.md` — updated `ChatService`/`FAQService` references in pipeline diagram

## Test plan

- [x] All documentation references to `db/integration.py` updated
- [x] GitHub Wiki synced and pushed
- [ ] Visual review of wiki pages on GitHub (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)