### PR TITLE
refactor: Phase 3.1 — migrate singletons to domain services

### DIFF
--- a/db/integration.py
+++ b/db/integration.py
@@ -1,21 +1,39 @@
+# ruff: noqa: F401
 """Database integration — facade re-export for backward compatibility.
 
-All service classes now live in modules/*/service.py.
-This file re-exports them under old names and creates module-level singletons
-so that existing consumers (routers, orchestrator, bots) keep working.
+All service classes and singletons now live in modules/*/service.py.
+This file re-exports them under old names so that existing consumers
+(routers, orchestrator, bots) keep working.
 """
 
 from modules.admin.service import ResourceShareService as AsyncResourceShareManager
+from modules.admin.service import resource_share_service as async_resource_share_manager
 from modules.channels.telegram.service import BotInstanceService as AsyncBotInstanceManager
-from modules.channels.telegram.service import TelegramSessionService as AsyncTelegramSessionManager
+from modules.channels.telegram.service import (
+    TelegramSessionService as AsyncTelegramSessionManager,
+)
+from modules.channels.telegram.service import bot_instance_service as async_bot_instance_manager
+from modules.channels.telegram.service import telegram_session_service as async_telegram_manager
 from modules.channels.whatsapp.service import (
     WhatsAppInstanceService as AsyncWhatsAppInstanceManager,
 )
+from modules.channels.whatsapp.service import (
+    whatsapp_instance_service as async_whatsapp_instance_manager,
+)
 from modules.channels.widget.service import WidgetInstanceService as AsyncWidgetInstanceManager
+from modules.channels.widget.service import (
+    widget_instance_service as async_widget_instance_manager,
+)
 from modules.chat.service import ChatService as AsyncChatManager
 from modules.chat.service import ChatShareService as AsyncChatShareManager
+from modules.chat.service import chat_service as async_chat_manager
+from modules.chat.service import chat_share_service as async_chat_share_manager
 from modules.claude_code.service import ClaudeCodeProjectService as AsyncClaudeCodeProjectManager
 from modules.claude_code.service import ClaudeCodeService as AsyncClaudeCodeManager
+from modules.claude_code.service import (
+    claude_code_project_service as async_claude_code_project_manager,
+)
+from modules.claude_code.service import claude_code_service as async_claude_code_manager
 from modules.core.service import ConfigService as AsyncConfigManager
 from modules.core.service import DatabaseService as DatabaseManager
 from modules.core.service import RoleService as AsyncRoleManager
@@ -23,55 +41,44 @@ from modules.core.service import UserIdentityService as AsyncUserIdentityManager
 from modules.core.service import UserService as AsyncUserManager
 from modules.core.service import UserSessionService as AsyncUserSessionManager
 from modules.core.service import WorkspaceService as AsyncWorkspaceManager
+from modules.core.service import config_service as async_config_manager
+from modules.core.service import database_service as db_manager
+from modules.core.service import role_service as async_role_manager
+from modules.core.service import user_identity_service as async_user_identity_manager
+from modules.core.service import user_service as async_user_manager
+from modules.core.service import user_session_service as async_session_manager
+from modules.core.service import workspace_service as async_workspace_manager
 from modules.crm.service import AmoCRMService as AsyncAmoCRMManager
+from modules.crm.service import amocrm_service as async_amocrm_manager
 from modules.ecommerce.service import WooCommerceService as AsyncWooCommerceManager
+from modules.ecommerce.service import woocommerce_service as async_woocommerce_manager
 from modules.kanban.service import KanbanProjectService as AsyncKanbanProjectManager
 from modules.kanban.service import KanbanService as AsyncKanbanManager
+from modules.kanban.service import kanban_project_service as async_kanban_project_manager
+from modules.kanban.service import kanban_service as async_kanban_manager
 from modules.knowledge.service import FAQService as AsyncFAQManager
 from modules.knowledge.service import GitHubRepoProjectService as AsyncGitHubRepoProjectManager
 from modules.knowledge.service import KnowledgeCollectionService as AsyncKnowledgeCollectionManager
 from modules.knowledge.service import KnowledgeDocService as AsyncKnowledgeDocManager
+from modules.knowledge.service import faq_service as async_faq_manager
+from modules.knowledge.service import (
+    github_repo_project_service as async_github_repo_project_manager,
+)
+from modules.knowledge.service import (
+    knowledge_collection_service as async_knowledge_collection_manager,
+)
+from modules.knowledge.service import knowledge_doc_service as async_knowledge_doc_manager
 from modules.llm.service import CloudProviderService as AsyncCloudProviderManager
+from modules.llm.service import cloud_provider_service as async_cloud_provider_manager
 from modules.monitoring.service import AuditService as AsyncAuditLogger
 from modules.monitoring.service import PaymentService as AsyncPaymentManager
+from modules.monitoring.service import audit_service as async_audit_logger
+from modules.monitoring.service import payment_service as async_payment_manager
 from modules.speech.service import PresetService as AsyncPresetManager
+from modules.speech.service import preset_service as async_preset_manager
 from modules.telephony.service import GSMService as AsyncGSMManager
+from modules.telephony.service import gsm_service as async_gsm_manager
 
-
-# ---------------------------------------------------------------------------
-# Singletons (same names as before)
-# ---------------------------------------------------------------------------
-
-db_manager = DatabaseManager()
-
-async_chat_manager = AsyncChatManager()
-async_faq_manager = AsyncFAQManager()
-async_preset_manager = AsyncPresetManager()
-async_config_manager = AsyncConfigManager()
-async_telegram_manager = AsyncTelegramSessionManager()
-async_audit_logger = AsyncAuditLogger()
-async_bot_instance_manager = AsyncBotInstanceManager()
-async_widget_instance_manager = AsyncWidgetInstanceManager()
-async_whatsapp_instance_manager = AsyncWhatsAppInstanceManager()
-async_cloud_provider_manager = AsyncCloudProviderManager()
-async_payment_manager = AsyncPaymentManager()
-async_amocrm_manager = AsyncAmoCRMManager()
-async_woocommerce_manager = AsyncWooCommerceManager()
-async_github_repo_project_manager = AsyncGitHubRepoProjectManager()
-async_gsm_manager = AsyncGSMManager()
-async_user_manager = AsyncUserManager()
-async_user_identity_manager = AsyncUserIdentityManager()
-async_knowledge_doc_manager = AsyncKnowledgeDocManager()
-async_knowledge_collection_manager = AsyncKnowledgeCollectionManager()
-async_chat_share_manager = AsyncChatShareManager()
-async_resource_share_manager = AsyncResourceShareManager()
-async_claude_code_manager = AsyncClaudeCodeManager()
-async_claude_code_project_manager = AsyncClaudeCodeProjectManager()
-async_kanban_manager = AsyncKanbanManager()
-async_kanban_project_manager = AsyncKanbanProjectManager()
-async_role_manager = AsyncRoleManager()
-async_workspace_manager = AsyncWorkspaceManager()
-async_session_manager = AsyncUserSessionManager()
 
 # ---------------------------------------------------------------------------
 # Lifecycle functions

--- a/modules/admin/service.py
+++ b/modules/admin/service.py
@@ -113,3 +113,7 @@ class ResourceShareService:
                 and u.get("role") != "guest"
                 and u["id"] != exclude_user_id
             ]
+
+
+# Singleton
+resource_share_service = ResourceShareService()

--- a/modules/channels/telegram/service.py
+++ b/modules/channels/telegram/service.py
@@ -216,3 +216,8 @@ class TelegramSessionService:
         async with AsyncSessionLocal() as session:
             repo = TelegramRepository(session)
             return await repo.get_session_count_by_bot()
+
+
+# Singletons
+bot_instance_service = BotInstanceService()
+telegram_session_service = TelegramSessionService()

--- a/modules/channels/whatsapp/service.py
+++ b/modules/channels/whatsapp/service.py
@@ -115,3 +115,7 @@ class WhatsAppInstanceService:
         async with AsyncSessionLocal() as session:
             repo = WhatsAppInstanceRepository(session)
             return await repo.get_instance_count()
+
+
+# Singleton
+whatsapp_instance_service = WhatsAppInstanceService()

--- a/modules/channels/widget/service.py
+++ b/modules/channels/widget/service.py
@@ -103,3 +103,7 @@ class WidgetInstanceService:
             result = await repo.import_from_legacy_config(config, instance_id)
             await session.commit()
             return result
+
+
+# Singleton
+widget_instance_service = WidgetInstanceService()

--- a/modules/chat/service.py
+++ b/modules/chat/service.py
@@ -387,3 +387,8 @@ class ChatShareService:
                 and u.get("role") != "guest"
                 and u["id"] != exclude_user_id
             ]
+
+
+# Singletons
+chat_service = ChatService()
+chat_share_service = ChatShareService()

--- a/modules/claude_code/service.py
+++ b/modules/claude_code/service.py
@@ -141,3 +141,8 @@ class ClaudeCodeProjectService:
             result = await repo.delete_project(project_id, owner_id, workspace_id=workspace_id)
             await session.commit()
             return result
+
+
+# Singletons
+claude_code_service = ClaudeCodeService()
+claude_code_project_service = ClaudeCodeProjectService()

--- a/modules/core/service.py
+++ b/modules/core/service.py
@@ -561,3 +561,13 @@ class UserIdentityService:
             result = await repo.update_last_seen(provider, provider_uid)
             await session.commit()
             return result
+
+
+# Singletons
+database_service = DatabaseService()
+user_service = UserService()
+user_session_service = UserSessionService()
+role_service = RoleService()
+workspace_service = WorkspaceService()
+config_service = ConfigService()
+user_identity_service = UserIdentityService()

--- a/modules/crm/service.py
+++ b/modules/crm/service.py
@@ -65,3 +65,7 @@ class AmoCRMService:
         async with AsyncSessionLocal() as session:
             repo = AmoCRMSyncLogRepository(session)
             return await repo.get_recent(limit)
+
+
+# Singleton
+amocrm_service = AmoCRMService()

--- a/modules/ecommerce/service.py
+++ b/modules/ecommerce/service.py
@@ -43,3 +43,7 @@ class WooCommerceService:
             result = await repo.clear_credentials()
             await session.commit()
             return result
+
+
+# Singleton
+woocommerce_service = WooCommerceService()

--- a/modules/kanban/service.py
+++ b/modules/kanban/service.py
@@ -191,3 +191,8 @@ class KanbanProjectService:
             repo = KanbanProjectRepository(session)
             await repo.update_last_synced(project_id)
             await session.commit()
+
+
+# Singletons
+kanban_service = KanbanService()
+kanban_project_service = KanbanProjectService()

--- a/modules/knowledge/service.py
+++ b/modules/knowledge/service.py
@@ -360,3 +360,10 @@ class GitHubRepoProjectService:
             result = await repo.delete_project(project_id, workspace_id)
             await session.commit()
             return result
+
+
+# Singletons
+faq_service = FAQService()
+knowledge_doc_service = KnowledgeDocService()
+knowledge_collection_service = KnowledgeCollectionService()
+github_repo_project_service = GitHubRepoProjectService()

--- a/modules/llm/service.py
+++ b/modules/llm/service.py
@@ -113,3 +113,7 @@ class CloudProviderService:
         async with AsyncSessionLocal() as session:
             repo = CloudProviderRepository(session)
             return await repo.get_provider_count()
+
+
+# Singleton
+cloud_provider_service = CloudProviderService()

--- a/modules/monitoring/service.py
+++ b/modules/monitoring/service.py
@@ -71,3 +71,8 @@ class PaymentService:
         async with AsyncSessionLocal() as session:
             repo = PaymentRepository(session)
             return await repo.get_payment_stats(bot_id)
+
+
+# Singletons
+audit_service = AuditService()
+payment_service = PaymentService()

--- a/modules/speech/service.py
+++ b/modules/speech/service.py
@@ -62,3 +62,7 @@ class PresetService:
             result = await repo.delete_preset(name, workspace_id=workspace_id)
             await session.commit()
             return result
+
+
+# Singleton
+preset_service = PresetService()

--- a/modules/telephony/service.py
+++ b/modules/telephony/service.py
@@ -86,3 +86,7 @@ class GSMService:
         async with AsyncSessionLocal() as session:
             repo = GSMSMSLogRepository(session)
             return await repo.count_sms()
+
+
+# Singleton
+gsm_service = GSMService()


### PR DESCRIPTION
## Summary

- Add singleton instances to all 15 `modules/*/service.py` files with clean domain names (e.g., `kanban_service`, `audit_service`, `database_service`)
- Update `db/integration.py` facade to **import** singletons from domain modules instead of **creating** them
- Both import paths resolve to the **same object instance** (verified by identity check)
- 30 singletons migrated, all 29 class aliases preserved

### Before
```python
# db/integration.py created singletons
from modules.kanban.service import KanbanService as AsyncKanbanManager
async_kanban_manager = AsyncKanbanManager()  # instance created here
```

### After
```python
# modules/kanban/service.py owns the singleton
kanban_service = KanbanService()

# db/integration.py imports it
from modules.kanban.service import kanban_service as async_kanban_manager
```

Closes #508

## Test plan

- [x] Smoke test: all 30 singletons + 29 classes + 3 functions import from `db/integration`
- [x] Singleton identity: `async_kanban_manager is kanban_service` (same object via both paths)
- [x] Ruff lint + format pass (16 files)
- [x] Unit tests: 65/65 passed
- [ ] Docker health check after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)