### PR TITLE
docs: update for Phase 3.1 — singletons in domain services

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -586,7 +586,7 @@ db/
 ├── database.py           # SQLite engine
 ├── models.py             # ORM models (imports from modules/*/models.py)
 ├── redis_client.py       # Caching
-├── integration.py        # Backward-compat facade (aliases + singletons, 93 lines)
+├── integration.py        # Backward-compat facade (re-imports singletons from modules/)
 └── repositories/         # Data access layer (25 repositories)
 
 modules/                  # Domain services (31 classes in 15 files)
@@ -1905,7 +1905,7 @@ pip install zipfile36  # или стандартный zipfile
   db/database.py           # SQLite connection
   db/models.py             # ORM models
   db/redis_client.py       # Redis helpers
-  db/integration.py        # Backward-compat facade (aliases + singletons)
+  db/integration.py        # Backward-compat facade (re-imports singletons from modules/)
   db/repositories/         # Data access layer
   modules/*/service.py     # Domain services (31 classes)
   scripts/migrate_json_to_db.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Import from `modules.core`: `EventBus`, `BaseEvent`, `TaskRegistry`, `TaskInfo`,
 | `modules/ecommerce/` | `service.py` | `WooCommerceService` |
 | `modules/telephony/` | `service.py` | `GSMService` |
 
-**Import pattern**: `from modules.chat.service import ChatService` (direct) or `from db.integration import async_chat_manager` (backward-compatible singleton). Domain `__init__.py` files do NOT re-export services (see Known Issues #9).
+**Import pattern**: `from modules.chat.service import chat_service` (direct, preferred) or `from db.integration import async_chat_manager` (backward-compatible alias). Domain `__init__.py` files do NOT re-export services (see Known Issues #9).
 
 ### Key Components
 
@@ -165,7 +165,7 @@ Import from `modules.core`: `EventBus`, `BaseEvent`, `TaskRegistry`, `TaskInfo`,
 
 **Two service layers**: Core AI services at project root (`cloud_llm_service.py`, `vllm_llm_service.py`, `voice_clone_service.py`, `stt_service.py`, etc.). Domain services in `app/services/` (`amocrm_service.py`, `wiki_rag_service.py`, `backup_service.py`, `sales_funnel.py`, etc.).
 
-**Database layer** (`db/`): Async SQLAlchemy + aiosqlite. `db/database.py` creates engine. `db/integration.py` is a 93-line facade that re-exports domain services under old names (`AsyncChatManager = ChatService`) and creates module-level singletons (`async_chat_manager = AsyncChatManager()`). Repositories in `db/repositories/` inherit from `BaseRepository` with generic CRUD and `_apply_workspace_filter()` for multi-tenant queries.
+**Database layer** (`db/`): Async SQLAlchemy + aiosqlite. `db/database.py` creates engine. `db/integration.py` is a ~100-line facade that imports singletons and class aliases from domain services (`from modules.chat.service import chat_service as async_chat_manager`). Singletons are created in `modules/*/service.py`; the facade only re-exports them under old names. Repositories in `db/repositories/` inherit from `BaseRepository` with generic CRUD and `_apply_workspace_filter()` for multi-tenant queries.
 
 **Unit of Work**: Repositories only `flush()` — never `commit()`. Callers own transaction boundaries: service methods call `session.commit()`, `get_async_session()` auto-commits on success / rollbacks on exception.
 

--- a/SYSTEM_DOCS.md
+++ b/SYSTEM_DOCS.md
@@ -97,7 +97,7 @@ container.backup_service      # BackupService
 - **Redis**: Опциональное кэширование (graceful fallback если недоступен)
 - **Паттерн**: `BaseRepository[Model]` — generic CRUD для всех моделей
 - **Доменные сервисы**: 31 класс в `modules/*/service.py` (например, `ChatService` в `modules/chat/service.py`)
-- **Фасад**: `db/integration.py` (93 строки) — backward-compatible алиасы и синглтоны (например, `AsyncChatManager = ChatService`, `async_chat_manager = AsyncChatManager()`)
+- **Фасад**: `db/integration.py` (~100 строк) — импортирует синглтоны и классы из `modules/*/service.py` под старыми именами (например, `chat_service as async_chat_manager`)
 
 ### Таблицы (35 таблиц)
 

--- a/wiki-pages/Architecture.md
+++ b/wiki-pages/Architecture.md
@@ -37,7 +37,7 @@
 |-----------|--------|-------------|
 | `orchestrator.py` | ~4100 строк | FastAPI entry point, инициализация сервисов, legacy endpoints, background tasks, регистрация 28 роутеров |
 | `db/models.py` | ~200 строк (фасад) | Реэкспорт моделей из `modules/*/models.py` (54 модели) |
-| `db/integration.py` | 93 строки (фасад) | Реэкспорт сервисов из `modules/*/service.py` под старыми именами + 30 синглтонов |
+| `db/integration.py` | ~100 строк (фасад) | Импорт синглтонов и классов из `modules/*/service.py` под старыми именами |
 
 ### Что уже хорошо структурировано
 
@@ -270,7 +270,7 @@ modules/
 | `modules/ecommerce/` | `service.py` | `WooCommerceService` |
 | `modules/telephony/` | `service.py` | `GSMService` |
 
-**Импорт:** `from modules.chat.service import ChatService` (прямой) или `from db.integration import async_chat_manager` (backward-compatible синглтон).
+**Импорт:** `from modules.chat.service import chat_service` (прямой, предпочтительный) или `from db.integration import async_chat_manager` (backward-compatible алиас). Синглтоны создаются в доменных `service.py` и импортируются фасадом.
 
 **Known issue — circular import:** доменные `__init__.py` **нельзя** использовать для реэкспорта сервисов. Цепочка: `db/models.py` → `modules/X/__init__.py` → `service.py` → `db/repositories` → `db/models.py` (цикл). Сервисы импортируются напрямую: `from modules.chat.service import ChatService`. Будет решено в Phase 3+ (устранение eager imports в `db/models.py`).
 
@@ -280,15 +280,36 @@ modules/
 
 > **Статус:** реализовано (PR [#506](https://github.com/ShaerWare/AI_Secretary_System/pull/506), issue [#502](https://github.com/ShaerWare/AI_Secretary_System/issues/502))
 
-Монолитный `db/integration.py` (2688 строк) заменён на 93-строчный фасад. Файл импортирует сервисы из доменных модулей и реэкспортирует под старыми именами:
+Монолитный `db/integration.py` (2688 строк) заменён на ~100-строчный фасад. Файл импортирует классы и синглтоны из доменных модулей и реэкспортирует под старыми именами:
 
 ```python
 from modules.chat.service import ChatService as AsyncChatManager
-async_chat_manager = AsyncChatManager()
-# ... 30 синглтонов, 3 lifecycle-функции
+from modules.chat.service import chat_service as async_chat_manager
+# ... 29 классов, 30 синглтонов, 3 lifecycle-функции
 ```
 
 Ноль изменений в 28 файлах-потребителях.
+
+---
+
+### Phase 3.1: Синглтоны в доменных сервисах
+
+> **Статус:** реализовано (PR [#516](https://github.com/ShaerWare/AI_Secretary_System/pull/516), issue [#508](https://github.com/ShaerWare/AI_Secretary_System/issues/508))
+
+30 синглтонов перенесены из фасада `db/integration.py` в доменные `modules/*/service.py`. Каждый сервисный файл создаёт экземпляр с чистым именем:
+
+```python
+# modules/kanban/service.py
+kanban_service = KanbanService()
+kanban_project_service = KanbanProjectService()
+```
+
+Фасад теперь **импортирует** готовые синглтоны вместо создания:
+```python
+from modules.kanban.service import kanban_service as async_kanban_manager
+```
+
+Оба пути импорта ведут к одному объекту (`async_kanban_manager is kanban_service`).
 
 ---
 
@@ -318,7 +339,7 @@ pytest tests/unit/test_event_bus.py tests/unit/test_task_registry.py tests/unit/
 | **0** | Инфраструктура core (EventBus, TaskRegistry, HealthRegistry) | [#490](https://github.com/ShaerWare/AI_Secretary_System/issues/490) | ✅ Завершена |
 | **1** | Разделение `db/models.py` → доменные модули | [#491](https://github.com/ShaerWare/AI_Secretary_System/issues/491) | ✅ Завершена |
 | **2** | Разделение `db/integration.py` → доменные сервисы + фасад | [#492](https://github.com/ShaerWare/AI_Secretary_System/issues/492) | ✅ Завершена (#501, #502, #503) |
-| **3** | Перенос роутеров в доменные модули | [#493](https://github.com/ShaerWare/AI_Secretary_System/issues/493) | ⏳ |
+| **3** | Перенос роутеров в доменные модули | [#493](https://github.com/ShaerWare/AI_Secretary_System/issues/493) | 🔄 В работе (#508 ✅, #509–#514) |
 | **4** | Декомпозиция `orchestrator.py` | [#494](https://github.com/ShaerWare/AI_Secretary_System/issues/494) | ⏳ |
 | **5** | Внедрение EventBus-событий | [#495](https://github.com/ShaerWare/AI_Secretary_System/issues/495) | ⏳ |
 | **6** | Протокольные интерфейсы | [#496](https://github.com/ShaerWare/AI_Secretary_System/issues/496) | ⏳ |

--- a/wiki-pages/Kanban.md
+++ b/wiki-pages/Kanban.md
@@ -247,7 +247,7 @@ app/routers/kanban.py (10 endpoints)
       -> modules/kanban/models.py (KanbanTask, KanbanTaskDependency, KanbanChecklistItem)
 ```
 
-> **Примечание:** Синглтон `async_kanban_manager` в `db/integration.py` — backward-compatible алиас для `KanbanService`.
+> **Примечание:** Синглтон `kanban_service` определён в `modules/kanban/service.py`. В `db/integration.py` доступен как `async_kanban_manager` (backward-compatible алиас).
 
 Frontend:
 ```


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: update import pattern (`chat_service` preferred) and database layer description (facade imports, not creates)
- **SYSTEM_DOCS.md**: facade description updated
- **BACKLOG.md**: 2 facade references updated
- **Architecture.md**: add Phase 3.1 section, update facade code example, Phase 3 status → "in progress"
- **Kanban.md**: singleton location note updated
- **GitHub Wiki**: synced and pushed

## Test plan

- [ ] Documentation accurately reflects Phase 3.1 changes
- [ ] Wiki pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)