### PR TITLE
docs: update for Phase 3.2 — domain routers

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1908,6 +1908,7 @@ pip install zipfile36  # или стандартный zipfile
   db/integration.py        # Backward-compat facade (re-imports singletons from modules/)
   db/repositories/         # Data access layer
   modules/*/service.py     # Domain services (31 classes)
+  modules/*/router.py      # Domain routers (6 migrated so far)
   scripts/migrate_json_to_db.py
   scripts/test_db.py
   scripts/setup_db.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Always run lint locally before pushing. Protected branches require PR workflow �
 
 ### Modular Infrastructure (`modules/`)
 
-Foundation layer for modular decomposition (issue #489). Phases 0–2 complete.
+Foundation layer for modular decomposition (issue #489). Phases 0–2 complete, Phase 3 in progress.
 
 - **`EventBus`** (`modules/core/events.py`): In-process async pub/sub. Handlers run concurrently via `asyncio.gather`; exceptions are logged, never propagated to publisher. `BaseEvent` dataclass with auto-timestamp.
 - **`TaskRegistry`** (`modules/core/tasks.py`): Named background tasks — periodic (interval-based) or one-shot. `start_all()` / `cancel_all(timeout)` lifecycle. `TaskInfo` dataclass tracks status, run count, last error.
@@ -156,6 +156,19 @@ Import from `modules.core`: `EventBus`, `BaseEvent`, `TaskRegistry`, `TaskInfo`,
 | `modules/telephony/` | `service.py` | `GSMService` |
 
 **Import pattern**: `from modules.chat.service import chat_service` (direct, preferred) or `from db.integration import async_chat_manager` (backward-compatible alias). Domain `__init__.py` files do NOT re-export services (see Known Issues #9).
+
+### Domain Routers (`modules/*/router.py`)
+
+Phase 3 migration: routers move from `app/routers/` to domain modules. Original files become 1-3 line facades. Completed so far (Phase 3.2):
+
+| Domain | Router file | Facade |
+|--------|------------|--------|
+| `modules/ecommerce/` | `router.py` | `app/routers/woocommerce.py` |
+| `modules/crm/` | `router.py` | `app/routers/amocrm.py` (exports `router` + `webhook_router`) |
+| `modules/telephony/` | `router.py` | `app/routers/gsm.py` |
+| `modules/speech/` | `router_tts.py`, `router_stt.py`, `router_services.py` | `app/routers/tts.py`, `stt.py`, `services.py` |
+
+New routers import domain services directly (`from modules.monitoring.service import audit_service`) instead of through the facade.
 
 ### Key Components
 
@@ -196,9 +209,9 @@ Import from `modules.core`: `EventBus`, `BaseEvent`, `TaskRegistry`, `TaskInfo`,
 ## Code Patterns
 
 **Adding a new API endpoint:**
-1. Create/edit router in `app/routers/`
-2. Use `ServiceContainer` from `app/dependencies.py` for DI
-3. Add router to `__all__` in `app/routers/__init__.py`
+1. Create/edit router in `modules/{domain}/router.py` (preferred) or `app/routers/` (legacy)
+2. Use domain service singletons (`from modules.chat.service import chat_service`) for DB access
+3. If using `app/routers/`, add to `__all__` in `app/routers/__init__.py`
 4. Register in `orchestrator.py` with `app.include_router()`
 
 **Adding a new cloud LLM provider type:**

--- a/SYSTEM_DOCS.md
+++ b/SYSTEM_DOCS.md
@@ -400,21 +400,21 @@ npm run build -- --mode demo-web  # Cloud demo (role=web, cloud mode) → /cloud
 |--------|------|-----------|----------|
 | auth | `auth.py` | 6 | JWT login, profile, password, auth status |
 | audit | `audit.py` | 4 | Audit log, export, cleanup |
-| services | `services.py` | 6 | vLLM start/stop/restart, logs |
+| services | `services.py` → `modules/speech/router_services.py` | 6 | vLLM start/stop/restart, logs |
 | monitor | `monitor.py` | 9 | GPU/CPU/system stats, health, metrics SSE |
 | faq | `faq.py` | 7 | FAQ CRUD, reload, test, export |
-| stt | `stt.py` | 4 | STT status, transcribe, test |
+| stt | `stt.py` → `modules/speech/router_stt.py` | 4 | STT status, transcribe, test |
 | llm | `llm.py` | 42 | Backend, persona, params, providers, VLESS proxy, models, bridge |
-| tts | `tts.py` | 14 | Presets, params, test, cache, streaming |
+| tts | `tts.py` → `modules/speech/router_tts.py` | 14 | Presets, params, test, cache, streaming |
 | chat | `chat.py` | 13 | Sessions, messages, streaming, branching |
 | telegram | `telegram.py` | 28 | Bot instances CRUD, control, sales, payments |
 | widget | `widget.py` | 7 | Widget instances CRUD |
 | whatsapp | `whatsapp.py` | 10 | WhatsApp bot instances CRUD, control |
-| gsm | `gsm.py` | 14 | GSM telephony (SIM7600E-H) |
+| gsm | `gsm.py` → `modules/telephony/router.py` | 14 | GSM telephony (SIM7600E-H) |
 | backup | `backup.py` | 8 | Backup/restore configuration |
 | bot_sales | `bot_sales.py` | 43 | Sales funnel, segments, testimonials, subscribers, broadcast |
 | yoomoney | `yoomoney_webhook.py` | 1 | YooMoney payment callback |
-| amocrm | `amocrm.py` | 16 | amoCRM OAuth2, contacts, leads, pipelines |
+| amocrm | `amocrm.py` → `modules/crm/router.py` | 16 | amoCRM OAuth2, contacts, leads, pipelines |
 | usage | `usage.py` | 10 | Usage tracking, limits, statistics |
 | legal | `legal.py` | 11 | Legal compliance |
 | wiki_rag | `wiki_rag.py` | 9 | Wiki RAG stats/search, Knowledge Base CRUD |

--- a/wiki-pages/Architecture.md
+++ b/wiki-pages/Architecture.md
@@ -313,6 +313,33 @@ from modules.kanban.service import kanban_service as async_kanban_manager
 
 ---
 
+### Phase 3.2: Роутеры — ecommerce, crm, telephony, speech
+
+> **Статус:** реализовано (PR [#518](https://github.com/ShaerWare/AI_Secretary_System/pull/518), issue [#509](https://github.com/ShaerWare/AI_Secretary_System/issues/509))
+
+6 «листовых» роутеров (без межроутерных зависимостей) перенесены из `app/routers/` в доменные модули. Все импорты из `db.integration` заменены на прямые импорты из доменных сервисов. Оригинальные файлы стали тонкими фасадами (1-3 строки).
+
+| Старый файл | Новый файл | Ключевые изменения |
+|---|---|---|
+| `app/routers/woocommerce.py` | `modules/ecommerce/router.py` | 4 db.integration → domain imports |
+| `app/routers/amocrm.py` | `modules/crm/router.py` | 4 db.integration → domain imports, dual router (`router` + `webhook_router`) |
+| `app/routers/gsm.py` | `modules/telephony/router.py` | 9 inline db.integration → 2 top-level domain imports |
+| `app/routers/tts.py` | `modules/speech/router_tts.py` | 1 db.integration → domain import |
+| `app/routers/stt.py` | `modules/speech/router_stt.py` | Без изменений (0 db.integration imports) |
+| `app/routers/services.py` | `modules/speech/router_services.py` | Без изменений (0 db.integration imports) |
+
+Замены импортов:
+- `async_audit_logger` → `audit_service` из `modules.monitoring.service`
+- `async_knowledge_collection_manager` → `knowledge_collection_service` из `modules.knowledge.service`
+- `async_knowledge_doc_manager` → `knowledge_doc_service` из `modules.knowledge.service`
+- `async_woocommerce_manager` → `woocommerce_service` из `modules.ecommerce.service`
+- `async_amocrm_manager` → `amocrm_service` из `modules.crm.service`
+- `async_preset_manager` → `preset_service` из `modules.speech.service`
+- `async_config_manager` (inline) → `config_service` из `modules.core.service`
+- `async_gsm_manager` (inline) → `gsm_service` из `modules.telephony.service`
+
+---
+
 ## Тесты
 
 24 unit-теста для core-инфраструктуры:
@@ -339,7 +366,7 @@ pytest tests/unit/test_event_bus.py tests/unit/test_task_registry.py tests/unit/
 | **0** | Инфраструктура core (EventBus, TaskRegistry, HealthRegistry) | [#490](https://github.com/ShaerWare/AI_Secretary_System/issues/490) | ✅ Завершена |
 | **1** | Разделение `db/models.py` → доменные модули | [#491](https://github.com/ShaerWare/AI_Secretary_System/issues/491) | ✅ Завершена |
 | **2** | Разделение `db/integration.py` → доменные сервисы + фасад | [#492](https://github.com/ShaerWare/AI_Secretary_System/issues/492) | ✅ Завершена (#501, #502, #503) |
-| **3** | Перенос роутеров в доменные модули | [#493](https://github.com/ShaerWare/AI_Secretary_System/issues/493) | 🔄 В работе (#508 ✅, #509–#514) |
+| **3** | Перенос роутеров в доменные модули | [#493](https://github.com/ShaerWare/AI_Secretary_System/issues/493) | 🔄 В работе (#508 ✅, #509 ✅, #510–#514) |
 | **4** | Декомпозиция `orchestrator.py` | [#494](https://github.com/ShaerWare/AI_Secretary_System/issues/494) | ⏳ |
 | **5** | Внедрение EventBus-событий | [#495](https://github.com/ShaerWare/AI_Secretary_System/issues/495) | ⏳ |
 | **6** | Протокольные интерфейсы | [#496](https://github.com/ShaerWare/AI_Secretary_System/issues/496) | ⏳ |


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Add Domain Routers section with migration table; update "Adding a new API endpoint" pattern to prefer `modules/{domain}/router.py`; note Phase 3 in progress
- **SYSTEM_DOCS.md**: Update 6 router entries in API table with `→ modules/*/router*.py` new locations
- **BACKLOG.md**: Add `modules/*/router.py` to file structure listing
- **wiki-pages/Architecture.md**: Add Phase 3.2 section with full router mapping and import replacement table; update plan table (#509 ✅)
- **GitHub Wiki**: Synced Architecture.md

## Test plan

- [x] Documentation changes only — no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)