### PR TITLE
fix: landing subpages black screen

### DIFF
--- a/landing/en/portfolio/index.html
+++ b/landing/en/portfolio/index.html
@@ -18,6 +18,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     #hide-content {display: block;}
 </style>
 <![endif]-->
+<style>
+/* Subpage: bypass animation chain deadlock — force elements visible */
+[class*="animation--"] { animation: none !important; opacity: 1 !important; transform: none !important; }
+.our-project--loading { opacity: 1 !important; }
+</style>
 <title>Portfolio — AI Secretary Demo | AI Secretary System</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.1/css/swiper.min.css">
 <link rel="stylesheet" href="../../wp-content/themes/main/assets/styles/main.min.css">
@@ -172,7 +177,7 @@ ym(97860132, "init", {
 </style>
 </head>
 
-<body class="not-allowed">
+<body>
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSBHMBWL"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -187,7 +192,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <div class="hide-content" id="hide-content"></div>
 <div class="custom-cursor"></div>
 <div class="container container--big container--h-100per d-flex container--custom-scroll">
-<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between animation-wait wrapper_w-100per">
+<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between wrapper_w-100per">
 <header id="header" class="mix-blend animation animation--fade-down-header">
 <div class="burger">
 <a class="burger__btn magnit text text--custom" href="index.html">
@@ -216,7 +221,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <section class="centered-content">
 <div class="main-content our-project our-project--loading scrollable-content">
 
-    <div class="swiper-container">
+    <div id="projects-slider" class="swiper-container projects-slider">
         <div class="swiper-wrapper">
 
             <!-- 1. AI Chat -->
@@ -561,5 +566,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script type='text/javascript' src="../../wp-includes/js/sweetalert.min.js"></script>
 <script type='text/javascript' src="../../wp-includes/js/form.js"></script>
+<script>
+/* Fallback: ensure page is visible if animation chain fails */
+window.addEventListener("DOMContentLoaded", function() {
+  setTimeout(function() {
+    document.body.classList.remove("not-allowed");
+    var aw = document.querySelector(".animation-wait");
+    if (aw) aw.classList.remove("animation-wait");
+  }, 2000);
+});
+</script>
 </body>
 </html>

--- a/landing/en/privacy-policy/index.html
+++ b/landing/en/privacy-policy/index.html
@@ -18,6 +18,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     #hide-content {display: block;}
 </style>
 <![endif]-->
+<style>
+/* Subpage: bypass animation chain deadlock — force elements visible */
+[class*="animation--"] { animation: none !important; opacity: 1 !important; transform: none !important; }
+.our-project--loading { opacity: 1 !important; }
+</style>
 <title>Privacy Policy and Terms of Service | AI Secretary System</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.1/css/swiper.min.css">
 <link rel="stylesheet" href="../../wp-content/themes/main/assets/styles/main.min.css">
@@ -103,7 +108,7 @@ ym(97860132, "init", {
 <!-- /Yandex.Metrika counter -->
 </head>
 
-<body class="not-allowed">
+<body>
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSBHMBWL"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -118,7 +123,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <div class="hide-content" id="hide-content"></div>
 <div class="custom-cursor"></div>
 <div class="container container--big container--h-100per d-flex container--custom-scroll">
-<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between animation-wait wrapper_w-100per">
+<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between wrapper_w-100per">
 <header id="header" class="mix-blend animation animation--fade-down-header">
 <div class="burger">
 <a class="burger__btn magnit text text--custom" href="../index.html">
@@ -289,5 +294,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script type='text/javascript' src="../../wp-includes/js/sweetalert.min.js"></script>
 <script type='text/javascript' src="../../wp-includes/js/form.js"></script>
+<script>
+/* Fallback: ensure page is visible if animation chain fails */
+window.addEventListener("DOMContentLoaded", function() {
+  setTimeout(function() {
+    document.body.classList.remove("not-allowed");
+    var aw = document.querySelector(".animation-wait");
+    if (aw) aw.classList.remove("animation-wait");
+  }, 2000);
+});
+</script>
 </body>
 </html>

--- a/landing/en/setup/index.html
+++ b/landing/en/setup/index.html
@@ -18,6 +18,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     #hide-content {display: block;}
 </style>
 <![endif]-->
+<style>
+/* Subpage: bypass animation chain deadlock — force elements visible */
+[class*="animation--"] { animation: none !important; opacity: 1 !important; transform: none !important; }
+.our-project--loading { opacity: 1 !important; }
+</style>
 <title>AI Secretary Setup and Training | AI Secretary System</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.1/css/swiper.min.css">
 <link rel="stylesheet" href="../../wp-content/themes/main/assets/styles/main.min.css">
@@ -147,7 +152,7 @@ ym(97860132, "init", {
 </style>
 </head>
 
-<body class="not-allowed">
+<body>
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSBHMBWL"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -162,7 +167,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <div class="hide-content" id="hide-content"></div>
 <div class="custom-cursor"></div>
 <div class="container container--big container--h-100per d-flex container--custom-scroll">
-<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between animation-wait wrapper_w-100per">
+<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between wrapper_w-100per">
 <header id="header" class="mix-blend animation animation--fade-down-header">
 <div class="burger">
 <a class="burger__btn magnit text text--custom" href="index.html">
@@ -209,7 +214,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </ul>
         </div>
         <div class="process-box">
-            <div class="swiper-container">
+            <div id="process-slider" class="swiper-container">
                 <div class="swiper-wrapper">
                     <div class="swiper-slide process-box__item">
                         <h2 class="title title--medium animation--fade-up-slide-title">Business process analysis</h2>
@@ -409,5 +414,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script type='text/javascript' src="../../wp-includes/js/sweetalert.min.js"></script>
 <script type='text/javascript' src="../../wp-includes/js/form.js"></script>
+<script>
+/* Fallback: ensure page is visible if animation chain fails */
+window.addEventListener("DOMContentLoaded", function() {
+  setTimeout(function() {
+    document.body.classList.remove("not-allowed");
+    var aw = document.querySelector(".animation-wait");
+    if (aw) aw.classList.remove("animation-wait");
+  }, 2000);
+});
+</script>
 </body>
 </html>

--- a/landing/kk/portfolio/index.html
+++ b/landing/kk/portfolio/index.html
@@ -18,6 +18,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     #hide-content {display: block;}
 </style>
 <![endif]-->
+<style>
+/* Subpage: bypass animation chain deadlock — force elements visible */
+[class*="animation--"] { animation: none !important; opacity: 1 !important; transform: none !important; }
+.our-project--loading { opacity: 1 !important; }
+</style>
 <title>Портфолио — ЖИ-хатшының демосы | AI Secretary System</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.1/css/swiper.min.css">
 <link rel="stylesheet" href="../../wp-content/themes/main/assets/styles/main.min.css">
@@ -172,7 +177,7 @@ ym(97860132, "init", {
 </style>
 </head>
 
-<body class="not-allowed">
+<body>
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSBHMBWL"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -187,7 +192,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <div class="hide-content" id="hide-content"></div>
 <div class="custom-cursor"></div>
 <div class="container container--big container--h-100per d-flex container--custom-scroll">
-<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between animation-wait wrapper_w-100per">
+<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between wrapper_w-100per">
 <header id="header" class="mix-blend animation animation--fade-down-header">
 <div class="burger">
 <a class="burger__btn magnit text text--custom" href="index.html">
@@ -216,7 +221,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <section class="centered-content">
 <div class="main-content our-project our-project--loading scrollable-content">
 
-    <div class="swiper-container">
+    <div id="projects-slider" class="swiper-container projects-slider">
         <div class="swiper-wrapper">
 
             <!-- 1. ЖИ-мен Chat -->
@@ -561,5 +566,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script type='text/javascript' src="../../wp-includes/js/sweetalert.min.js"></script>
 <script type='text/javascript' src="../../wp-includes/js/form.js"></script>
+<script>
+/* Fallback: ensure page is visible if animation chain fails */
+window.addEventListener("DOMContentLoaded", function() {
+  setTimeout(function() {
+    document.body.classList.remove("not-allowed");
+    var aw = document.querySelector(".animation-wait");
+    if (aw) aw.classList.remove("animation-wait");
+  }, 2000);
+});
+</script>
 </body>
 </html>

--- a/landing/kk/privacy-policy/index.html
+++ b/landing/kk/privacy-policy/index.html
@@ -18,6 +18,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     #hide-content {display: block;}
 </style>
 <![endif]-->
+<style>
+/* Subpage: bypass animation chain deadlock — force elements visible */
+[class*="animation--"] { animation: none !important; opacity: 1 !important; transform: none !important; }
+.our-project--loading { opacity: 1 !important; }
+</style>
 <title>Құпиялылық саясаты және Пайдаланушы келісімі | AI Secretary System</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.1/css/swiper.min.css">
 <link rel="stylesheet" href="../../wp-content/themes/main/assets/styles/main.min.css">
@@ -103,7 +108,7 @@ ym(97860132, "init", {
 <!-- /Yandex.Metrika counter -->
 </head>
 
-<body class="not-allowed">
+<body>
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSBHMBWL"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -118,7 +123,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <div class="hide-content" id="hide-content"></div>
 <div class="custom-cursor"></div>
 <div class="container container--big container--h-100per d-flex container--custom-scroll">
-<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between animation-wait wrapper_w-100per">
+<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between wrapper_w-100per">
 <header id="header" class="mix-blend animation animation--fade-down-header">
 <div class="burger">
 <a class="burger__btn magnit text text--custom" href="../../index.html">
@@ -289,5 +294,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script type='text/javascript' src="../../wp-includes/js/sweetalert.min.js"></script>
 <script type='text/javascript' src="../../wp-includes/js/form.js"></script>
+<script>
+/* Fallback: ensure page is visible if animation chain fails */
+window.addEventListener("DOMContentLoaded", function() {
+  setTimeout(function() {
+    document.body.classList.remove("not-allowed");
+    var aw = document.querySelector(".animation-wait");
+    if (aw) aw.classList.remove("animation-wait");
+  }, 2000);
+});
+</script>
 </body>
 </html>

--- a/landing/kk/setup/index.html
+++ b/landing/kk/setup/index.html
@@ -18,6 +18,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     #hide-content {display: block;}
 </style>
 <![endif]-->
+<style>
+/* Subpage: bypass animation chain deadlock — force elements visible */
+[class*="animation--"] { animation: none !important; opacity: 1 !important; transform: none !important; }
+.our-project--loading { opacity: 1 !important; }
+</style>
 <title>ЖИ-хатшыны баптау және оқыту | AI Secretary System</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.1/css/swiper.min.css">
 <link rel="stylesheet" href="../../wp-content/themes/main/assets/styles/main.min.css">
@@ -147,7 +152,7 @@ ym(97860132, "init", {
 </style>
 </head>
 
-<body class="not-allowed">
+<body>
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSBHMBWL"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -162,7 +167,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <div class="hide-content" id="hide-content"></div>
 <div class="custom-cursor"></div>
 <div class="container container--big container--h-100per d-flex container--custom-scroll">
-<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between animation-wait wrapper_w-100per">
+<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between wrapper_w-100per">
 <header id="header" class="mix-blend animation animation--fade-down-header">
 <div class="burger">
 <a class="burger__btn magnit text text--custom" href="index.html">
@@ -209,7 +214,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </ul>
         </div>
         <div class="process-box">
-            <div class="swiper-container">
+            <div id="process-slider" class="swiper-container">
                 <div class="swiper-wrapper">
                     <div class="swiper-slide process-box__item">
                         <h2 class="title title--medium animation--fade-up-slide-title">Бизнес-процестерді талдау</h2>
@@ -409,5 +414,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script type='text/javascript' src="../../wp-includes/js/sweetalert.min.js"></script>
 <script type='text/javascript' src="../../wp-includes/js/form.js"></script>
+<script>
+/* Fallback: ensure page is visible if animation chain fails */
+window.addEventListener("DOMContentLoaded", function() {
+  setTimeout(function() {
+    document.body.classList.remove("not-allowed");
+    var aw = document.querySelector(".animation-wait");
+    if (aw) aw.classList.remove("animation-wait");
+  }, 2000);
+});
+</script>
 </body>
 </html>

--- a/landing/portfolio/index.html
+++ b/landing/portfolio/index.html
@@ -18,6 +18,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     #hide-content {display: block;}
 </style>
 <![endif]-->
+<style>
+/* Subpage: bypass animation chain deadlock — force elements visible */
+[class*="animation--"] { animation: none !important; opacity: 1 !important; transform: none !important; }
+.our-project--loading { opacity: 1 !important; }
+</style>
 <title>Портфолио — демо ИИ-секретаря | AI Secretary System</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.1/css/swiper.min.css">
 <link rel="stylesheet" href="../wp-content/themes/main/assets/styles/main.min.css">
@@ -172,7 +177,7 @@ ym(97860132, "init", {
 </style>
 </head>
 
-<body class="not-allowed">
+<body>
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSBHMBWL"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -187,7 +192,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <div class="hide-content" id="hide-content"></div>
 <div class="custom-cursor"></div>
 <div class="container container--big container--h-100per d-flex container--custom-scroll">
-<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between animation-wait wrapper_w-100per">
+<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between wrapper_w-100per">
 <header id="header" class="mix-blend animation animation--fade-down-header">
 <div class="burger">
 <a class="burger__btn magnit text text--custom" href="index.html">
@@ -216,7 +221,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <section class="centered-content">
 <div class="main-content our-project our-project--loading scrollable-content">
 
-    <div class="swiper-container">
+    <div id="projects-slider" class="swiper-container projects-slider">
         <div class="swiper-wrapper">
 
             <!-- 1. Chat с ИИ -->
@@ -561,5 +566,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script type='text/javascript' src="../wp-includes/js/sweetalert.min.js"></script>
 <script type='text/javascript' src="../wp-includes/js/form.js"></script>
+<script>
+/* Fallback: ensure page is visible if animation chain fails */
+window.addEventListener("DOMContentLoaded", function() {
+  setTimeout(function() {
+    document.body.classList.remove("not-allowed");
+    var aw = document.querySelector(".animation-wait");
+    if (aw) aw.classList.remove("animation-wait");
+  }, 2000);
+});
+</script>
 </body>
 </html>

--- a/landing/privacy-policy/index.html
+++ b/landing/privacy-policy/index.html
@@ -18,6 +18,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     #hide-content {display: block;}
 </style>
 <![endif]-->
+<style>
+/* Subpage: bypass animation chain deadlock — force elements visible */
+[class*="animation--"] { animation: none !important; opacity: 1 !important; transform: none !important; }
+.our-project--loading { opacity: 1 !important; }
+</style>
 <title>Политика конфиденциальности и Пользовательское соглашение | AI Secretary System</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.1/css/swiper.min.css">
 <link rel="stylesheet" href="../wp-content/themes/main/assets/styles/main.min.css">
@@ -103,7 +108,7 @@ ym(97860132, "init", {
 <!-- /Yandex.Metrika counter -->
 </head>
 
-<body class="not-allowed">
+<body>
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSBHMBWL"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -118,7 +123,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <div class="hide-content" id="hide-content"></div>
 <div class="custom-cursor"></div>
 <div class="container container--big container--h-100per d-flex container--custom-scroll">
-<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between animation-wait wrapper_w-100per">
+<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between wrapper_w-100per">
 <header id="header" class="mix-blend animation animation--fade-down-header">
 <div class="burger">
 <a class="burger__btn magnit text text--custom" href="../index.html">
@@ -289,5 +294,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script type='text/javascript' src="../wp-includes/js/sweetalert.min.js"></script>
 <script type='text/javascript' src="../wp-includes/js/form.js"></script>
+<script>
+/* Fallback: ensure page is visible if animation chain fails */
+window.addEventListener("DOMContentLoaded", function() {
+  setTimeout(function() {
+    document.body.classList.remove("not-allowed");
+    var aw = document.querySelector(".animation-wait");
+    if (aw) aw.classList.remove("animation-wait");
+  }, 2000);
+});
+</script>
 </body>
 </html>

--- a/landing/setup/index.html
+++ b/landing/setup/index.html
@@ -18,6 +18,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     #hide-content {display: block;}
 </style>
 <![endif]-->
+<style>
+/* Subpage: bypass animation chain deadlock — force elements visible */
+[class*="animation--"] { animation: none !important; opacity: 1 !important; transform: none !important; }
+.our-project--loading { opacity: 1 !important; }
+</style>
 <title>Настройка и обучение ИИ-секретаря | AI Secretary System</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.1/css/swiper.min.css">
 <link rel="stylesheet" href="../wp-content/themes/main/assets/styles/main.min.css">
@@ -147,7 +152,7 @@ ym(97860132, "init", {
 </style>
 </head>
 
-<body class="not-allowed">
+<body>
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSBHMBWL"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -162,7 +167,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <div class="hide-content" id="hide-content"></div>
 <div class="custom-cursor"></div>
 <div class="container container--big container--h-100per d-flex container--custom-scroll">
-<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between animation-wait wrapper_w-100per">
+<div class="wrapper wrapper_fullpage d-flex flex-direction-column justify-content-between wrapper_w-100per">
 <header id="header" class="mix-blend animation animation--fade-down-header">
 <div class="burger">
 <a class="burger__btn magnit text text--custom" href="index.html">
@@ -209,7 +214,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </ul>
         </div>
         <div class="process-box">
-            <div class="swiper-container">
+            <div id="process-slider" class="swiper-container">
                 <div class="swiper-wrapper">
                     <div class="swiper-slide process-box__item">
                         <h2 class="title title--medium animation--fade-up-slide-title">Анализ бизнес-процессов</h2>
@@ -409,5 +414,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script type='text/javascript' src="../wp-includes/js/sweetalert.min.js"></script>
 <script type='text/javascript' src="../wp-includes/js/form.js"></script>
+<script>
+/* Fallback: ensure page is visible if animation chain fails */
+window.addEventListener("DOMContentLoaded", function() {
+  setTimeout(function() {
+    document.body.classList.remove("not-allowed");
+    var aw = document.querySelector(".animation-wait");
+    if (aw) aw.classList.remove("animation-wait");
+  }, 2000);
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- All landing subpages (setup, portfolio, privacy-policy) in all 3 languages (ru/en/kk) displayed a black screen due to animation chain deadlock in `main.min.js`
- Root cause: JS animation bootstrap requires `.js-title-words` element (only present on main page); without it, `body.not-allowed` + `.animation-wait` create a permanent deadlock — all content stays at `opacity: 0`
- Fixed 9 subpages: removed blocking classes, added CSS override forcing `opacity: 1` on animated elements, added fallback JS, added missing Swiper IDs

## NEWS

🔧 **Исправлен чёрный экран на страницах лендинга**

Страницы «Настройка», «Портфолио» и «Политика конфиденциальности» на всех языках (RU/EN/KK) снова работают. Проблема была в цепочке анимаций — на внутренних страницах она не запускалась и блокировала весь контент.

## Test plan

- [x] Verified https://ai-sekretar24.ru/setup/ shows content (header, body, footer)
- [x] Verified https://ai-sekretar24.ru/portfolio/ shows content
- [x] Verified https://ai-sekretar24.ru/privacy-policy/ shows content
- [x] Verified https://ai-sekretar24.ru/en/setup/ (English variant)
- [x] Verified https://ai-sekretar24.ru/kk/portfolio/ (Kazakh variant)
- [x] Main page (/) still works with original animation chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)