### PR TITLE
feat: Telegram bot file upload — text & PDF extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ New routers import domain services directly (`from modules.monitoring.service im
 
 **SQLITE_BUSY retry**: `db/retry.py` `@retry_on_busy()` — exponential backoff (3 retries, 0.1s base). Applied to write methods in domain service classes (16 methods across 5 services).
 
-**Telegram bots**: Subprocesses managed by `multi_bot_manager.py`. Config pre-fetched from DB, written to `/tmp/bot_config_{id}.json`. Two frameworks: `python-telegram-bot` (legacy) + `aiogram` (new). `LLMRouter` in `telegram_bot/services/llm_router.py` routes through orchestrator chat API.
+**Telegram bots**: Subprocesses managed by `multi_bot_manager.py`. Config pre-fetched from DB, written to `/tmp/bot_config_{id}.json`. Two frameworks: `python-telegram-bot` (legacy) + `aiogram` (new). `LLMRouter` in `telegram_bot/services/llm_router.py` routes through orchestrator chat API. File uploads: `telegram_bot/services/file_extractor.py` extracts text from documents (text files + PDF via `pdfplumber`), injected into chat as plain text.
 
 **WhatsApp bots**: Same subprocess pattern via `whatsapp_manager.py`. Module: `whatsapp_bot/` (runs as `python -m whatsapp_bot`).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,5 +55,8 @@ redis>=5.0.0
 # Wiki RAG
 snowballstemmer>=2.2.0  # Russian/English stemming for BM25 search
 
+# Document text extraction (Telegram file uploads)
+pdfplumber>=0.10.0
+
 # Docker management (for starting vLLM from container)
 docker>=7.0.0

--- a/telegram_bot/handlers/files.py
+++ b/telegram_bot/handlers/files.py
@@ -1,14 +1,12 @@
-"""File and photo handler.
-
-Note: File upload to LLM is temporarily disabled.
-The LLM Router currently supports text-only interactions.
-File analysis will be added in a future update.
-"""
+"""File and photo handler — text extraction for documents."""
 
 import logging
 
 from aiogram import F, Router
 from aiogram.types import Message
+
+from ..services.file_extractor import extract_text
+from .messages import _get_lock, _handle_user_message
 
 
 router = Router()
@@ -17,37 +15,68 @@ logger = logging.getLogger(__name__)
 # 20 MB limit (Telegram Bot API file download limit)
 MAX_FILE_SIZE = 20 * 1024 * 1024
 
-# Temporary message while file processing is not supported
-FILE_NOT_SUPPORTED_MSG = (
-    "Анализ файлов временно недоступен.\n\n"
-    "Сейчас бот поддерживает только текстовые сообщения.\n"
-    "Функция анализа файлов будет добавлена в следующем обновлении."
+PHOTO_NOT_SUPPORTED_MSG = (
+    "Распознавание изображений пока не поддерживается.\n\n"
+    "Отправьте текстовый файл (.txt, .md, .csv, .py, .json и др.) или PDF."
 )
+
+DEFAULT_PROMPT = "Проанализируй этот файл"
 
 
 @router.message(F.document)
 async def on_document(message: Message) -> None:
-    """Handle document uploads — currently not supported."""
+    """Handle document uploads — extract text and send to LLM."""
     if not message.from_user or not message.document:
         return
 
-    # If there's a caption, we could process it as text
-    # For now, just inform user that files are not supported
-    await message.answer(FILE_NOT_SUPPORTED_MSG)
-    logger.info(
-        "File upload attempted by user %s (not supported yet)",
-        message.from_user.id,
-    )
+    user_id = message.from_user.id
+    doc = message.document
+
+    # --- size check ---
+    if doc.file_size and doc.file_size > MAX_FILE_SIZE:
+        await message.answer(
+            f"Файл слишком большой ({doc.file_size // (1024 * 1024)} МБ).\n"
+            f"Максимальный размер — {MAX_FILE_SIZE // (1024 * 1024)} МБ."
+        )
+        return
+
+    # --- download ---
+    try:
+        file_obj = await message.bot.get_file(doc.file_id)
+        bio = await message.bot.download_file(file_obj.file_path)
+        data = bio.read()
+    except Exception:
+        logger.exception("Failed to download file from user %s", user_id)
+        await message.answer("Не удалось скачать файл. Попробуйте ещё раз.")
+        return
+
+    # --- extract text ---
+    filename = doc.file_name or "file"
+    mime = doc.mime_type or ""
+    try:
+        text = extract_text(data, filename, mime)
+    except ValueError as exc:
+        await message.answer(str(exc))
+        return
+    except Exception:
+        logger.exception("Text extraction failed for %s from user %s", filename, user_id)
+        await message.answer("Не удалось извлечь текст из файла.")
+        return
+
+    # --- build message for LLM ---
+    caption = message.caption or DEFAULT_PROMPT
+    user_text = f"\U0001f4ce {filename}\n\n{text}\n\n{caption}"
+
+    lock = _get_lock(user_id)
+    async with lock:
+        await _handle_user_message(message, user_id, user_text)
 
 
 @router.message(F.photo)
 async def on_photo(message: Message) -> None:
-    """Handle photo uploads — currently not supported."""
+    """Handle photo uploads — not supported yet."""
     if not message.from_user or not message.photo:
         return
 
-    await message.answer(FILE_NOT_SUPPORTED_MSG)
-    logger.info(
-        "Photo upload attempted by user %s (not supported yet)",
-        message.from_user.id,
-    )
+    await message.answer(PHOTO_NOT_SUPPORTED_MSG)
+    logger.info("Photo upload attempted by user %s", message.from_user.id)

--- a/telegram_bot/services/file_extractor.py
+++ b/telegram_bot/services/file_extractor.py
@@ -1,0 +1,131 @@
+"""Extract text from uploaded files (text formats and PDF)."""
+
+import io
+import logging
+from pathlib import PurePosixPath
+
+
+logger = logging.getLogger(__name__)
+
+MAX_EXTRACTED_CHARS = 50_000
+
+# Extensions recognized as plain text
+TEXT_EXTENSIONS: set[str] = {
+    ".txt",
+    ".md",
+    ".csv",
+    ".py",
+    ".json",
+    ".xml",
+    ".html",
+    ".htm",
+    ".log",
+    ".yml",
+    ".yaml",
+    ".toml",
+    ".ini",
+    ".cfg",
+    ".conf",
+    ".sh",
+    ".bat",
+    ".sql",
+    ".env",
+    ".rst",
+    ".js",
+    ".ts",
+    ".css",
+    ".java",
+    ".c",
+    ".cpp",
+    ".h",
+    ".hpp",
+    ".go",
+    ".rs",
+    ".rb",
+    ".php",
+    ".swift",
+    ".kt",
+    ".r",
+    ".lua",
+    ".pl",
+}
+
+# MIME prefixes/types that indicate plain text
+TEXT_MIME_PREFIXES: tuple[str, ...] = (
+    "text/",
+    "application/json",
+    "application/xml",
+    "application/x-yaml",
+    "application/x-sh",
+    "application/sql",
+    "application/javascript",
+    "application/typescript",
+    "application/x-python",
+)
+
+PDF_MIMES: set[str] = {"application/pdf"}
+PDF_EXTENSIONS: set[str] = {".pdf"}
+
+
+def _is_text(mime: str, ext: str) -> bool:
+    if any(mime.startswith(p) for p in TEXT_MIME_PREFIXES):
+        return True
+    return ext in TEXT_EXTENSIONS
+
+
+def _is_pdf(mime: str, ext: str) -> bool:
+    return mime in PDF_MIMES or ext in PDF_EXTENSIONS
+
+
+def _extract_text_file(data: bytes) -> str:
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data.decode("latin-1")
+
+
+def _extract_pdf(data: bytes) -> str:
+    import pdfplumber
+
+    pages: list[str] = []
+    with pdfplumber.open(io.BytesIO(data)) as pdf:
+        for page in pdf.pages:
+            text = page.extract_text()
+            if text:
+                pages.append(text)
+    if not pages:
+        raise ValueError("PDF не содержит извлекаемого текста (возможно, это скан-копия).")
+    return "\n\n".join(pages)
+
+
+def extract_text(data: bytes, filename: str, mime: str) -> str:
+    """Extract text content from file bytes.
+
+    Args:
+        data: Raw file bytes.
+        filename: Original filename (used for extension detection).
+        mime: MIME type reported by Telegram.
+
+    Returns:
+        Extracted text, truncated to MAX_EXTRACTED_CHARS.
+
+    Raises:
+        ValueError: If the file format is not supported or extraction fails.
+    """
+    mime = (mime or "").lower()
+    ext = PurePosixPath(filename).suffix.lower() if filename else ""
+
+    if _is_pdf(mime, ext):
+        text = _extract_pdf(data)
+    elif _is_text(mime, ext):
+        text = _extract_text_file(data)
+    else:
+        raise ValueError(
+            f"Формат файла не поддерживается ({ext or mime}).\n"
+            "Поддерживаются: текстовые файлы (.txt, .md, .csv, .py, .json и др.) и PDF."
+        )
+
+    if len(text) > MAX_EXTRACTED_CHARS:
+        text = text[:MAX_EXTRACTED_CHARS] + "\n\n[... текст обрезан]"
+
+    return text


### PR DESCRIPTION
## Summary

- Add `pdfplumber` dependency for pure-Python PDF text extraction
- New `telegram_bot/services/file_extractor.py` — extracts text from 40+ text formats and PDFs
- Rewrite `telegram_bot/handlers/files.py` — download documents, extract text, pipe through LLM chat
- Photo handler updated with specific "not supported" message (OCR out of scope)
- CLAUDE.md updated to document file upload pipeline

Relates to #272

## NEWS

📎 **Бот теперь читает файлы!**

Отправьте текстовый файл или PDF в чат с ботом — он извлечёт
содержимое и проанализирует его. Поддерживаются .txt, .md, .csv,
.py, .json, .pdf и десятки других текстовых форматов. Добавьте
подпись к файлу, чтобы задать вопрос по содержимому.

## Test plan

- [ ] Send a `.txt` file → bot responds with analysis
- [ ] Send a `.pdf` with text → bot extracts and responds
- [ ] Send a file with caption "Кратко перескажи" → bot uses caption as prompt
- [ ] Send a file without caption → bot uses default prompt "Проанализируй этот файл"
- [ ] Send a `.docx` → bot replies "unsupported format"
- [ ] Send a 25MB file → bot replies "file too large"
- [ ] `ruff check` passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)