### PR TITLE
refactor: landing cleanup — remove legacy sections

### DIFF
--- a/landing/en/index.html
+++ b/landing/en/index.html
@@ -174,13 +174,6 @@ ym(97860132, "init", {
 .ai-section__title { font-family: circe, sans-serif; font-weight: 700; font-size: 36px; color: #fff; margin-bottom: 16px; }
 .ai-section__subtitle { font-family: circe, sans-serif; font-weight: 300; font-size: 18px; color: rgba(255,255,255,0.7); margin-bottom: 48px; line-height: 1.6; }
 
-.benefits-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; margin-bottom: 60px; }
-.benefit-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; padding: 32px; transition: all 0.3s ease; }
-.benefit-card:hover { background: rgba(255,255,255,0.08); border-color: rgba(255,255,255,0.15); transform: translateY(-4px); }
-.benefit-card__icon { font-size: 40px; margin-bottom: 16px; display: block; }
-.benefit-card__title { font-family: circe, sans-serif; font-weight: 700; font-size: 20px; color: #fff; margin-bottom: 8px; }
-.benefit-card__text { font-family: circe, sans-serif; font-weight: 300; font-size: 15px; color: rgba(255,255,255,0.6); line-height: 1.5; }
-
 .modes-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; margin-bottom: 60px; }
 .mode-card { background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; padding: 40px; position: relative; }
 .mode-card--featured { border-color: #c2410c; box-shadow: 0 0 40px rgba(194,65,12,0.15); }
@@ -214,12 +207,10 @@ ym(97860132, "init", {
 .scrollable-content::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 4px; }
 
 @media (max-width: 991px) {
-    .benefits-grid { grid-template-columns: repeat(2, 1fr); }
     .modes-grid { grid-template-columns: 1fr; }
     .ai-section__title { font-size: 28px; }
 }
 @media (max-width: 640px) {
-    .benefits-grid { grid-template-columns: 1fr; }
     .ai-section { padding: 48px 0; }
     .ai-section__inner { padding: 0 20px; }
     .ai-section__title { font-size: 24px; }
@@ -296,46 +287,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                     </div>
                 </div>
             </a>
-        </div>
-    </div>
-
-    <!-- Benefits Section -->
-    <div class="ai-section">
-        <div class="ai-section__inner">
-            <h2 class="ai-section__title">Why AI Secretary</h2>
-            <p class="ai-section__subtitle">One assistant instead of an entire department — from day one</p>
-            <div class="benefits-grid">
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#128101;</span>
-                    <div class="benefit-card__title">Replaces 4-5 employees</div>
-                    <div class="benefit-card__text">Secretary, sales manager, support agent, SMM manager, and analyst — all in one AI assistant.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#9203;</span>
-                    <div class="benefit-card__title">Works 24/7/365</div>
-                    <div class="benefit-card__text">No weekends, vacations, or sick days. Instantly responds to clients at any time of day — even at night and on holidays.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#128274;</span>
-                    <div class="benefit-card__title">Local = Private</div>
-                    <div class="benefit-card__text">Local installation on your GPU — all data stays on your server. Maximum privacy without compromises.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#9729;&#65039;</span>
-                    <div class="benefit-card__title">Cloud from 3,000 KZT/mo</div>
-                    <div class="benefit-card__text">No GPU needed? Cloud mode works on any VPS. Connect Gemini, GPT-4, Claude, DeepSeek — minimal cost per request.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#128279;</span>
-                    <div class="benefit-card__title">All communication channels</div>
-                    <div class="benefit-card__text">Telegram, WhatsApp, website widget, amoCRM, WooCommerce — a single control point for all communications.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#127891;</span>
-                    <div class="benefit-card__title">Learns from your data</div>
-                    <div class="benefit-card__text">Upload your knowledge base — and the assistant consults like an experienced employee. Wiki RAG, FAQ, LoRA fine-tuning.</div>
-                </div>
-            </div>
         </div>
     </div>
 

--- a/landing/en/portfolio/index.html
+++ b/landing/en/portfolio/index.html
@@ -150,30 +150,10 @@ ym(97860132, "init", {
 <!-- /Yandex.Metrika counter -->
 
 <style>
-/* CTA section styles */
-.cta-section { text-align: center; padding: 60px 0; }
-.cta-section__title { font-family: circe, sans-serif; font-weight: 700; font-size: 32px; color: #fff; margin-bottom: 16px; }
-.cta-section__text { font-family: circe, sans-serif; font-weight: 300; font-size: 17px; color: rgba(255,255,255,0.6); margin-bottom: 32px; }
-.cta-buttons { display: flex; gap: 16px; justify-content: center; flex-wrap: wrap; }
-.cta-btn { display: inline-flex; align-items: center; gap: 8px; padding: 14px 32px; border-radius: 40px; font-family: circe, sans-serif; font-weight: 700; font-size: 16px; text-decoration: none; transition: all 0.3s ease; }
-.cta-btn--primary { background: #c2410c; color: #fff; border: 2px solid #c2410c; }
-.cta-btn--primary:hover { background: #a83608; border-color: #a83608; }
-.cta-btn--outline { background: transparent; color: #fff; border: 2px solid rgba(255,255,255,0.3); }
-.cta-btn--outline:hover { border-color: #fff; background: rgba(255,255,255,0.05); }
-
-.ai-section { padding: 80px 0; position: relative; }
-.ai-section__inner { max-width: 1200px; margin: 0 auto; padding: 0 40px; }
-
 .scrollable-content { position: relative; overflow-y: auto; overflow-x: hidden; -webkit-overflow-scrolling: touch; }
 .scrollable-content::-webkit-scrollbar { width: 4px; }
 .scrollable-content::-webkit-scrollbar-track { background: transparent; }
 .scrollable-content::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 4px; }
-
-@media (max-width: 640px) {
-    .ai-section { padding: 48px 0; }
-    .ai-section__inner { padding: 0 20px; }
-    .cta-buttons { flex-direction: column; align-items: center; }
-}
 </style>
 </head>
 
@@ -475,18 +455,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <div class="project-page-slide__scroll">
             <p>Scroll</p>
             <div class="project-page-slide__scroll-line"></div>
-        </div>
-    </div>
-
-    <!-- CTA Section -->
-    <div class="ai-section cta-section">
-        <div class="ai-section__inner">
-            <div class="cta-section__title">Try the demo</div>
-            <div class="cta-section__text">Interactive demonstration of all modules — no registration required</div>
-            <div class="cta-buttons">
-                <a href="https://demo.ai-sekretar24.ru/full/" class="cta-btn cta-btn--primary" target="_blank">Full Demo (Admin)</a>
-                <a href="https://demo.ai-sekretar24.ru/cloud/" class="cta-btn cta-btn--outline" target="_blank">Cloud Demo</a>
-            </div>
         </div>
     </div>
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -174,13 +174,6 @@ ym(97860132, "init", {
 .ai-section__title { font-family: circe, sans-serif; font-weight: 700; font-size: 36px; color: #fff; margin-bottom: 16px; }
 .ai-section__subtitle { font-family: circe, sans-serif; font-weight: 300; font-size: 18px; color: rgba(255,255,255,0.7); margin-bottom: 48px; line-height: 1.6; }
 
-.benefits-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; margin-bottom: 60px; }
-.benefit-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; padding: 32px; transition: all 0.3s ease; }
-.benefit-card:hover { background: rgba(255,255,255,0.08); border-color: rgba(255,255,255,0.15); transform: translateY(-4px); }
-.benefit-card__icon { font-size: 40px; margin-bottom: 16px; display: block; }
-.benefit-card__title { font-family: circe, sans-serif; font-weight: 700; font-size: 20px; color: #fff; margin-bottom: 8px; }
-.benefit-card__text { font-family: circe, sans-serif; font-weight: 300; font-size: 15px; color: rgba(255,255,255,0.6); line-height: 1.5; }
-
 .modes-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; margin-bottom: 60px; }
 .mode-card { background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; padding: 40px; position: relative; }
 .mode-card--featured { border-color: #c2410c; box-shadow: 0 0 40px rgba(194,65,12,0.15); }
@@ -214,12 +207,10 @@ ym(97860132, "init", {
 .scrollable-content::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 4px; }
 
 @media (max-width: 991px) {
-    .benefits-grid { grid-template-columns: repeat(2, 1fr); }
     .modes-grid { grid-template-columns: 1fr; }
     .ai-section__title { font-size: 28px; }
 }
 @media (max-width: 640px) {
-    .benefits-grid { grid-template-columns: 1fr; }
     .ai-section { padding: 48px 0; }
     .ai-section__inner { padding: 0 20px; }
     .ai-section__title { font-size: 24px; }
@@ -296,46 +287,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                     </div>
                 </div>
             </a>
-        </div>
-    </div>
-
-    <!-- Benefits Section -->
-    <div class="ai-section">
-        <div class="ai-section__inner">
-            <h2 class="ai-section__title">Почему ИИ-Секретарь</h2>
-            <p class="ai-section__subtitle">Один ассистент вместо целого отдела — с первого дня</p>
-            <div class="benefits-grid">
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#128101;</span>
-                    <div class="benefit-card__title">Заменяет 4-5 сотрудников</div>
-                    <div class="benefit-card__text">Секретарь, менеджер по продажам, оператор техподдержки, SMM-менеджер и аналитик — в одном ИИ-ассистенте.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#9203;</span>
-                    <div class="benefit-card__title">Работает 24/7/365</div>
-                    <div class="benefit-card__text">Без выходных, отпусков и больничных. Мгновенно отвечает клиентам в любое время суток — даже ночью и в праздники.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#128274;</span>
-                    <div class="benefit-card__title">Локальный = приватный</div>
-                    <div class="benefit-card__text">Локальная установка на вашем GPU — все данные остаются на вашем сервере. Максимальная конфиденциальность без компромиссов.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#9729;&#65039;</span>
-                    <div class="benefit-card__title">Облако от 3 000 тг/мес</div>
-                    <div class="benefit-card__text">Не нужен GPU? Облачный режим работает на любом VPS. Подключаем Gemini, GPT-4, Claude, DeepSeek — копеечная стоимость запросов.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#128279;</span>
-                    <div class="benefit-card__title">Все каналы связи</div>
-                    <div class="benefit-card__text">Telegram, WhatsApp, виджет для сайта, amoCRM, WooCommerce — единая точка управления всеми коммуникациями.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#127891;</span>
-                    <div class="benefit-card__title">Обучается на ваших данных</div>
-                    <div class="benefit-card__text">Загружаете базу знаний — и ассистент консультирует как опытный сотрудник. Wiki RAG, FAQ, LoRA fine-tuning.</div>
-                </div>
-            </div>
         </div>
     </div>
 

--- a/landing/kk/index.html
+++ b/landing/kk/index.html
@@ -174,13 +174,6 @@ ym(97860132, "init", {
 .ai-section__title { font-family: circe, sans-serif; font-weight: 700; font-size: 36px; color: #fff; margin-bottom: 16px; }
 .ai-section__subtitle { font-family: circe, sans-serif; font-weight: 300; font-size: 18px; color: rgba(255,255,255,0.7); margin-bottom: 48px; line-height: 1.6; }
 
-.benefits-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; margin-bottom: 60px; }
-.benefit-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; padding: 32px; transition: all 0.3s ease; }
-.benefit-card:hover { background: rgba(255,255,255,0.08); border-color: rgba(255,255,255,0.15); transform: translateY(-4px); }
-.benefit-card__icon { font-size: 40px; margin-bottom: 16px; display: block; }
-.benefit-card__title { font-family: circe, sans-serif; font-weight: 700; font-size: 20px; color: #fff; margin-bottom: 8px; }
-.benefit-card__text { font-family: circe, sans-serif; font-weight: 300; font-size: 15px; color: rgba(255,255,255,0.6); line-height: 1.5; }
-
 .modes-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; margin-bottom: 60px; }
 .mode-card { background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; padding: 40px; position: relative; }
 .mode-card--featured { border-color: #c2410c; box-shadow: 0 0 40px rgba(194,65,12,0.15); }
@@ -214,12 +207,10 @@ ym(97860132, "init", {
 .scrollable-content::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 4px; }
 
 @media (max-width: 991px) {
-    .benefits-grid { grid-template-columns: repeat(2, 1fr); }
     .modes-grid { grid-template-columns: 1fr; }
     .ai-section__title { font-size: 28px; }
 }
 @media (max-width: 640px) {
-    .benefits-grid { grid-template-columns: 1fr; }
     .ai-section { padding: 48px 0; }
     .ai-section__inner { padding: 0 20px; }
     .ai-section__title { font-size: 24px; }
@@ -296,46 +287,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                     </div>
                 </div>
             </a>
-        </div>
-    </div>
-
-    <!-- Benefits Section -->
-    <div class="ai-section">
-        <div class="ai-section__inner">
-            <h2 class="ai-section__title">Неліктен ЖИ-Хатшы</h2>
-            <p class="ai-section__subtitle">Бірінші күннен бастап бүкіл бөлімнің орнына бір ассистент</p>
-            <div class="benefits-grid">
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#128101;</span>
-                    <div class="benefit-card__title">4-5 қызметкерді алмастырады</div>
-                    <div class="benefit-card__text">Хатшы, сату менеджері, техқолдау операторы, SMM-менеджер және аналитик — бір ЖИ-ассистентте.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#9203;</span>
-                    <div class="benefit-card__title">24/7/365 жұмыс істейді</div>
-                    <div class="benefit-card__text">Демалыссыз, демалыстарсыз және ауырған күндерсіз. Клиенттерге тәулік бойы кез келген уақытта — тіпті түнде және мерекелерде лезде жауап береді.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#128274;</span>
-                    <div class="benefit-card__title">Жергілікті = құпия</div>
-                    <div class="benefit-card__text">Сіздің GPU-ға жергілікті орнату — барлық деректер сіздің серверіңізде қалады. Ымыраларсыз максималды құпиялылық.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#9729;&#65039;</span>
-                    <div class="benefit-card__title">Бұлт 3 000 тг/айдан бастап</div>
-                    <div class="benefit-card__text">GPU қажет емес пе? Бұлтты режим кез келген VPS-те жұмыс істейді. Gemini, GPT-4, Claude, DeepSeek қосамыз — сұраулардың құны тиынға тұрады.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#128279;</span>
-                    <div class="benefit-card__title">Барлық байланыс арналары</div>
-                    <div class="benefit-card__text">Telegram, WhatsApp, сайт виджеті, amoCRM, WooCommerce — барлық коммуникацияларды басқарудың бірыңғай нүктесі.</div>
-                </div>
-                <div class="benefit-card">
-                    <span class="benefit-card__icon">&#127891;</span>
-                    <div class="benefit-card__title">Сіздің деректеріңізден үйренеді</div>
-                    <div class="benefit-card__text">Білім базасын жүктейсіз — ассистент тәжірибелі қызметкер сияқты кеңес береді. Wiki RAG, FAQ, LoRA fine-tuning.</div>
-                </div>
-            </div>
         </div>
     </div>
 

--- a/landing/kk/portfolio/index.html
+++ b/landing/kk/portfolio/index.html
@@ -150,30 +150,10 @@ ym(97860132, "init", {
 <!-- /Yandex.Metrika counter -->
 
 <style>
-/* CTA section styles */
-.cta-section { text-align: center; padding: 60px 0; }
-.cta-section__title { font-family: circe, sans-serif; font-weight: 700; font-size: 32px; color: #fff; margin-bottom: 16px; }
-.cta-section__text { font-family: circe, sans-serif; font-weight: 300; font-size: 17px; color: rgba(255,255,255,0.6); margin-bottom: 32px; }
-.cta-buttons { display: flex; gap: 16px; justify-content: center; flex-wrap: wrap; }
-.cta-btn { display: inline-flex; align-items: center; gap: 8px; padding: 14px 32px; border-radius: 40px; font-family: circe, sans-serif; font-weight: 700; font-size: 16px; text-decoration: none; transition: all 0.3s ease; }
-.cta-btn--primary { background: #c2410c; color: #fff; border: 2px solid #c2410c; }
-.cta-btn--primary:hover { background: #a83608; border-color: #a83608; }
-.cta-btn--outline { background: transparent; color: #fff; border: 2px solid rgba(255,255,255,0.3); }
-.cta-btn--outline:hover { border-color: #fff; background: rgba(255,255,255,0.05); }
-
-.ai-section { padding: 80px 0; position: relative; }
-.ai-section__inner { max-width: 1200px; margin: 0 auto; padding: 0 40px; }
-
 .scrollable-content { position: relative; overflow-y: auto; overflow-x: hidden; -webkit-overflow-scrolling: touch; }
 .scrollable-content::-webkit-scrollbar { width: 4px; }
 .scrollable-content::-webkit-scrollbar-track { background: transparent; }
 .scrollable-content::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 4px; }
-
-@media (max-width: 640px) {
-    .ai-section { padding: 48px 0; }
-    .ai-section__inner { padding: 0 20px; }
-    .cta-buttons { flex-direction: column; align-items: center; }
-}
 </style>
 </head>
 
@@ -475,18 +455,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <div class="project-page-slide__scroll">
             <p>Scroll</p>
             <div class="project-page-slide__scroll-line"></div>
-        </div>
-    </div>
-
-    <!-- CTA Section -->
-    <div class="ai-section cta-section">
-        <div class="ai-section__inner">
-            <div class="cta-section__title">Демоны байқап көріңіз</div>
-            <div class="cta-section__text">Барлық модульдердің интерактивті демонстрациясы — тіркеусіз</div>
-            <div class="cta-buttons">
-                <a href="https://demo.ai-sekretar24.ru/full/" class="cta-btn cta-btn--primary" target="_blank">Full Demo (Admin)</a>
-                <a href="https://demo.ai-sekretar24.ru/cloud/" class="cta-btn cta-btn--outline" target="_blank">Cloud Demo</a>
-            </div>
         </div>
     </div>
 

--- a/landing/portfolio/index.html
+++ b/landing/portfolio/index.html
@@ -150,30 +150,10 @@ ym(97860132, "init", {
 <!-- /Yandex.Metrika counter -->
 
 <style>
-/* CTA section styles */
-.cta-section { text-align: center; padding: 60px 0; }
-.cta-section__title { font-family: circe, sans-serif; font-weight: 700; font-size: 32px; color: #fff; margin-bottom: 16px; }
-.cta-section__text { font-family: circe, sans-serif; font-weight: 300; font-size: 17px; color: rgba(255,255,255,0.6); margin-bottom: 32px; }
-.cta-buttons { display: flex; gap: 16px; justify-content: center; flex-wrap: wrap; }
-.cta-btn { display: inline-flex; align-items: center; gap: 8px; padding: 14px 32px; border-radius: 40px; font-family: circe, sans-serif; font-weight: 700; font-size: 16px; text-decoration: none; transition: all 0.3s ease; }
-.cta-btn--primary { background: #c2410c; color: #fff; border: 2px solid #c2410c; }
-.cta-btn--primary:hover { background: #a83608; border-color: #a83608; }
-.cta-btn--outline { background: transparent; color: #fff; border: 2px solid rgba(255,255,255,0.3); }
-.cta-btn--outline:hover { border-color: #fff; background: rgba(255,255,255,0.05); }
-
-.ai-section { padding: 80px 0; position: relative; }
-.ai-section__inner { max-width: 1200px; margin: 0 auto; padding: 0 40px; }
-
 .scrollable-content { position: relative; overflow-y: auto; overflow-x: hidden; -webkit-overflow-scrolling: touch; }
 .scrollable-content::-webkit-scrollbar { width: 4px; }
 .scrollable-content::-webkit-scrollbar-track { background: transparent; }
 .scrollable-content::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 4px; }
-
-@media (max-width: 640px) {
-    .ai-section { padding: 48px 0; }
-    .ai-section__inner { padding: 0 20px; }
-    .cta-buttons { flex-direction: column; align-items: center; }
-}
 </style>
 </head>
 
@@ -475,18 +455,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <div class="project-page-slide__scroll">
             <p>Scroll</p>
             <div class="project-page-slide__scroll-line"></div>
-        </div>
-    </div>
-
-    <!-- CTA Section -->
-    <div class="ai-section cta-section">
-        <div class="ai-section__inner">
-            <div class="cta-section__title">Попробуйте демо</div>
-            <div class="cta-section__text">Интерактивная демонстрация всех модулей — без регистрации</div>
-            <div class="cta-buttons">
-                <a href="https://demo.ai-sekretar24.ru/full/" class="cta-btn cta-btn--primary" target="_blank">Full Demo (Admin)</a>
-                <a href="https://demo.ai-sekretar24.ru/cloud/" class="cta-btn cta-btn--outline" target="_blank">Cloud Demo</a>
-            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary

- Removed "Почему ИИ-Секретарь" / "Why AI Secretary" / "Неліктен ЖИ-Хатшы" benefits section from all 3 main pages (ru/en/kk) — 6 benefit cards + CSS
- Removed "Попробуйте демо" / "Try the demo" / "Демоны байқап көріңіз" CTA section from all 3 portfolio pages (ru/en/kk) — demo links + CSS
- Keeps modes, channels, providers, and bottom CTA on main pages
- Keeps project cards slider on portfolio pages

## NEWS

🧹 **Лендинг стал чище**

Убраны лишние блоки с главной и портфолио. Теперь лендинг лаконичнее — сразу к делу: режимы работы, каналы, провайдеры и призыв к действию.

## Test plan

- [x] Server verified: 0 matches for `benefits-grid` on all 3 main pages
- [x] Server verified: 0 matches for `cta-section` on all 3 portfolio pages
- [x] Main page CTA "Готовы автоматизировать бизнес?" preserved
- [x] Setup pages unchanged
- [x] Privacy policy pages unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)