### PR TITLE
fix: add modules/ and whatsapp_bot/ to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,8 @@ COPY *.py ./
 COPY app/ ./app/
 COPY db/ ./db/
 COPY telegram_bot/ ./telegram_bot/
+COPY whatsapp_bot/ ./whatsapp_bot/
+COPY modules/ ./modules/
 COPY alembic/ ./alembic/
 COPY alembic.ini ./
 
@@ -179,13 +181,15 @@ COPY requirements.txt .
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --upgrade pip setuptools wheel \
     && pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu \
-    && pip install -r requirements.txt
+    && grep -v whisper requirements.txt > /tmp/req-cpu.txt && pip install -r /tmp/req-cpu.txt
 
 # Application code
 COPY *.py ./
 COPY app/ ./app/
 COPY db/ ./db/
 COPY telegram_bot/ ./telegram_bot/
+COPY whatsapp_bot/ ./whatsapp_bot/
+COPY modules/ ./modules/
 COPY alembic/ ./alembic/
 COPY alembic.ini ./
 COPY scripts/ ./scripts/


### PR DESCRIPTION
## Summary

- Add `COPY modules/ ./modules/` and `COPY whatsapp_bot/ ./whatsapp_bot/` to both GPU and CPU stages in Dockerfile
- Exclude `openai-whisper` from CPU stage requirements (known `pkg_resources` build failure)

These directories were added in Phase 2/3 refactoring but never added to the Dockerfile, causing `ModuleNotFoundError` on container rebuild.

## NEWS

🐳 **Исправлен Docker-билд**

При пересборке Docker-контейнера приложение не запускалось из-за отсутствия модулей. Теперь все необходимые директории корректно копируются в образ, и CPU-билд стабильно проходит.

## Test plan

- [x] Docker build succeeds on server
- [x] Container starts without ModuleNotFoundError
- [x] Health check returns `healthy`
- [x] Alembic migration runs inside container

🤖 Generated with [Claude Code](https://claude.com/claude-code)