### PR TITLE
docs: Phase 3.3 — documentation update

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1908,7 +1908,7 @@ pip install zipfile36  # или стандартный zipfile
   db/integration.py        # Backward-compat facade (re-imports singletons from modules/)
   db/repositories/         # Data access layer
   modules/*/service.py     # Domain services (31 classes)
-  modules/*/router.py      # Domain routers (6 migrated so far)
+  modules/*/router.py      # Domain routers (11 migrated so far)
   scripts/migrate_json_to_db.py
   scripts/test_db.py
   scripts/setup_db.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ Import from `modules.core`: `EventBus`, `BaseEvent`, `TaskRegistry`, `TaskInfo`,
 
 ### Domain Routers (`modules/*/router.py`)
 
-Phase 3 migration: routers move from `app/routers/` to domain modules. Original files become 1-3 line facades. Completed so far (Phase 3.2):
+Phase 3 migration: routers move from `app/routers/` to domain modules. Original files become 1-3 line facades. Completed so far (Phase 3.2 + 3.3):
 
 | Domain | Router file | Facade |
 |--------|------------|--------|
@@ -167,6 +167,9 @@ Phase 3 migration: routers move from `app/routers/` to domain modules. Original 
 | `modules/crm/` | `router.py` | `app/routers/amocrm.py` (exports `router` + `webhook_router`) |
 | `modules/telephony/` | `router.py` | `app/routers/gsm.py` |
 | `modules/speech/` | `router_tts.py`, `router_stt.py`, `router_services.py` | `app/routers/tts.py`, `stt.py`, `services.py` |
+| `modules/knowledge/` | `router_faq.py`, `router_wiki_rag.py`, `router_github_repos.py` | `app/routers/faq.py`, `wiki_rag.py`, `github_repos.py` |
+| `modules/kanban/` | `router.py` | `app/routers/kanban.py` |
+| `modules/claude_code/` | `router.py` | `app/routers/claude_code.py` |
 
 New routers import domain services directly (`from modules.monitoring.service import audit_service`) instead of through the facade.
 

--- a/SYSTEM_DOCS.md
+++ b/SYSTEM_DOCS.md
@@ -394,7 +394,7 @@ npm run build -- --mode demo-web  # Cloud demo (role=web, cloud mode) → /cloud
 # Both deployed by: bash /root/deploy-demo.sh
 ```
 
-## API (21 роутер, ~371 endpoint)
+## API (28 роутеров, ~400 endpoints)
 
 | Роутер | Файл | Endpoints | Описание |
 |--------|------|-----------|----------|
@@ -402,7 +402,7 @@ npm run build -- --mode demo-web  # Cloud demo (role=web, cloud mode) → /cloud
 | audit | `audit.py` | 4 | Audit log, export, cleanup |
 | services | `services.py` → `modules/speech/router_services.py` | 6 | vLLM start/stop/restart, logs |
 | monitor | `monitor.py` | 9 | GPU/CPU/system stats, health, metrics SSE |
-| faq | `faq.py` | 7 | FAQ CRUD, reload, test, export |
+| faq | `faq.py` → `modules/knowledge/router_faq.py` | 7 | FAQ CRUD, reload, test, export |
 | stt | `stt.py` → `modules/speech/router_stt.py` | 4 | STT status, transcribe, test |
 | llm | `llm.py` | 42 | Backend, persona, params, providers, VLESS proxy, models, bridge |
 | tts | `tts.py` → `modules/speech/router_tts.py` | 14 | Presets, params, test, cache, streaming |
@@ -417,8 +417,14 @@ npm run build -- --mode demo-web  # Cloud demo (role=web, cloud mode) → /cloud
 | amocrm | `amocrm.py` → `modules/crm/router.py` | 16 | amoCRM OAuth2, contacts, leads, pipelines |
 | usage | `usage.py` | 10 | Usage tracking, limits, statistics |
 | legal | `legal.py` | 11 | Legal compliance |
-| wiki_rag | `wiki_rag.py` | 9 | Wiki RAG stats/search, Knowledge Base CRUD |
+| wiki_rag | `wiki_rag.py` → `modules/knowledge/router_wiki_rag.py` | 9 | Wiki RAG stats/search, Knowledge Base CRUD |
+| github_repos | `github_repos.py` → `modules/knowledge/router_github_repos.py` | 7 | GitHub repo projects (clone, sync, RAG index) |
+| kanban | `kanban.py` → `modules/kanban/router.py` | 18 | Kanban tasks, projects, checklist, dependencies, dataset |
+| claude_code | `claude_code.py` → `modules/claude_code/router.py` | 10 | Claude Code WS + REST sessions, projects |
 | github | `github_webhook.py` | 1 | GitHub CI/CD webhook |
+| roles | `roles.py` | 6 | RBAC roles CRUD |
+| workspace | `workspace.py` | 8 | Workspaces, members, invites |
+| woocommerce | `woocommerce.py` → `modules/ecommerce/router.py` | 5 | WooCommerce integration |
 
 ### OpenAI-Compatible API
 
@@ -502,4 +508,4 @@ ORCHESTRATOR_PORT=8002
 Полный список переменных в `.env.example`.
 
 ---
-*Обновлено: 2026-03-03*
+*Обновлено: 2026-03-04*

--- a/wiki-pages/Architecture.md
+++ b/wiki-pages/Architecture.md
@@ -340,6 +340,38 @@ from modules.kanban.service import kanban_service as async_kanban_manager
 
 ---
 
+### Phase 3.3: Роутеры — kanban, claude_code, knowledge
+
+> **Статус:** реализовано (PR [#520](https://github.com/ShaerWare/AI_Secretary_System/pull/520), issue [#510](https://github.com/ShaerWare/AI_Secretary_System/issues/510))
+
+5 роутеров со сложными зависимостями перенесены в доменные модули. Все импорты из `db.integration` заменены на прямые импорты из доменных сервисов. Оригинальные файлы стали 1-строчными фасадами.
+
+| Старый файл | Новый файл | Ключевые изменения |
+|---|---|---|
+| `app/routers/faq.py` | `modules/knowledge/router_faq.py` | 2 db.integration → domain imports |
+| `app/routers/wiki_rag.py` | `modules/knowledge/router_wiki_rag.py` | 3 db.integration → domain imports |
+| `app/routers/github_repos.py` | `modules/knowledge/router_github_repos.py` | 4 db.integration → domain imports |
+| `app/routers/kanban.py` | `modules/kanban/router.py` | 5 top-level + 1 inline → 4 top-level domain imports |
+| `app/routers/claude_code.py` | `modules/claude_code/router.py` | 8 inline → 2 top-level (claude_code_service, claude_code_project_service) |
+
+Замены импортов:
+- `async_audit_logger` → `audit_service` из `modules.monitoring.service`
+- `async_faq_manager` → `faq_service` из `modules.knowledge.service`
+- `async_knowledge_collection_manager` → `knowledge_collection_service` из `modules.knowledge.service`
+- `async_knowledge_doc_manager` → `knowledge_doc_service` из `modules.knowledge.service`
+- `async_github_repo_project_manager` → `github_repo_project_service` из `modules.knowledge.service`
+- `async_kanban_manager` → `kanban_service` из `modules.kanban.service`
+- `async_kanban_project_manager` → `kanban_project_service` из `modules.kanban.service`
+- `async_claude_code_manager` → `claude_code_service` из `modules.claude_code.service`
+- `async_claude_code_project_manager` → `claude_code_project_service` из `modules.claude_code.service`
+
+Нюансы:
+- **claude_code.py** — все 8 inline `from db.integration import` внутри функций заменены на 2 top-level import из доменного сервиса
+- **kanban.py** — кросс-доменные зависимости: kanban → claude_code (cc-sessions), kanban → knowledge (dataset-sync/status/clear)
+- **Lazy imports** из `app.services.*` и `app.dependencies` оставлены lazy (не часть Phase 3)
+
+---
+
 ## Тесты
 
 24 unit-теста для core-инфраструктуры:
@@ -366,7 +398,7 @@ pytest tests/unit/test_event_bus.py tests/unit/test_task_registry.py tests/unit/
 | **0** | Инфраструктура core (EventBus, TaskRegistry, HealthRegistry) | [#490](https://github.com/ShaerWare/AI_Secretary_System/issues/490) | ✅ Завершена |
 | **1** | Разделение `db/models.py` → доменные модули | [#491](https://github.com/ShaerWare/AI_Secretary_System/issues/491) | ✅ Завершена |
 | **2** | Разделение `db/integration.py` → доменные сервисы + фасад | [#492](https://github.com/ShaerWare/AI_Secretary_System/issues/492) | ✅ Завершена (#501, #502, #503) |
-| **3** | Перенос роутеров в доменные модули | [#493](https://github.com/ShaerWare/AI_Secretary_System/issues/493) | 🔄 В работе (#508 ✅, #509 ✅, #510–#514) |
+| **3** | Перенос роутеров в доменные модули | [#493](https://github.com/ShaerWare/AI_Secretary_System/issues/493) | 🔄 В работе (#508 ✅, #509 ✅, #510 ✅, #511–#514) |
 | **4** | Декомпозиция `orchestrator.py` | [#494](https://github.com/ShaerWare/AI_Secretary_System/issues/494) | ⏳ |
 | **5** | Внедрение EventBus-событий | [#495](https://github.com/ShaerWare/AI_Secretary_System/issues/495) | ⏳ |
 | **6** | Протокольные интерфейсы | [#496](https://github.com/ShaerWare/AI_Secretary_System/issues/496) | ⏳ |


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Add 5 new domain routers (knowledge×3, kanban, claude_code) to Domain Routers table
- **SYSTEM_DOCS.md**: Update faq/wiki_rag entries with new paths, add 6 missing routers to API table (github_repos, kanban, claude_code, roles, workspace, woocommerce), fix count (21→28)
- **BACKLOG.md**: Update migrated router count (6→11)
- **Architecture.md**: Add Phase 3.3 section with full migration table and import replacement details, mark #510 ✅

## Test plan

- [x] All docs accurately reflect current codebase state
- [x] Wiki synced to GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)