### PR TITLE
fix: разделитель вместо иконки при развёрнутой группе меню

### DIFF
--- a/admin/src/components/AccordionNav.vue
+++ b/admin/src/components/AccordionNav.vue
@@ -182,13 +182,18 @@ function hasActiveItem(group: typeof navGroups.value[0]) {
         ]"
         @click="toggleGroup(group.id)"
       >
-        <component :is="group.icon" class="w-5 h-5 shrink-0" />
-        <span class="flex-1 ml-3 text-left font-medium truncate">
-          {{ t(group.nameKey) }}
-        </span>
+        <template v-if="isGroupExpanded(group.id)">
+          <div class="h-px flex-1 bg-border" />
+        </template>
+        <template v-else>
+          <component :is="group.icon" class="w-5 h-5 shrink-0" />
+          <span class="flex-1 ml-3 text-left font-medium truncate">
+            {{ t(group.nameKey) }}
+          </span>
+        </template>
         <ChevronDown
           :class="[
-            'w-4 h-4 transition-transform duration-200',
+            'w-4 h-4 shrink-0 transition-transform duration-200',
             isGroupExpanded(group.id) ? 'rotate-180' : ''
           ]"
         />


### PR DESCRIPTION
## Summary

- При развёрнутой группе бокового меню показывается горизонтальный разделитель вместо иконки + текста
- При свёрнутой группе — прежнее поведение (иконка + название + chevron)
- Collapsed sidebar не затронут

## NEWS

🧹 **Чище навигация в боковом меню**

Когда раздел меню раскрыт, заголовок теперь показывает аккуратный разделитель вместо иконки — меньше визуального шума, проще найти нужный пункт. При свёрнутом разделе иконка остаётся на месте.

## Test plan

- [ ] Развернуть группу — убедиться что вместо иконки горизонтальная линия
- [ ] Свернуть группу — иконка + текст на месте
- [ ] Свернуть sidebar — иконки групп на месте
- [ ] `npm run build` проходит без ошибок

🤖 Generated with [Claude Code](https://claude.com/claude-code)