### PR TITLE
fix: разделитель в collapsed sidebar при развёрнутой группе

### DIFF
--- a/admin/src/components/AccordionNav.vue
+++ b/admin/src/components/AccordionNav.vue
@@ -236,7 +236,8 @@ function hasActiveItem(group: typeof navGroups.value[0]) {
           ]"
           @click="toggleGroup(group.id)"
         >
-          <component :is="group.icon" class="w-5 h-5" />
+          <div v-if="isGroupExpanded(group.id)" class="h-px w-5 bg-border" />
+          <component :is="group.icon" v-else class="w-5 h-5" />
         </button>
         <div
           :class="[


### PR DESCRIPTION
## Summary

- В свёрнутом sidebar при развёрнутой группе теперь горизонтальная линия вместо иконки раздела
- Дополнение к #528 — единообразное поведение в обоих режимах sidebar

## NEWS

🧹 **Единообразие навигации**

Теперь и в свёрнутом боковом меню раскрытый раздел показывает аккуратный разделитель вместо иконки — одинаковое поведение в обоих режимах.

## Test plan

- [ ] Свернуть sidebar → развернуть группу → иконка заменяется на линию
- [ ] Свернуть группу → иконка возвращается
- [ ] Развёрнутый sidebar — без изменений (работает как в #528)
- [ ] `npm run build` проходит

🤖 Generated with [Claude Code](https://claude.com/claude-code)