### PR TITLE
docs: update documentation for Phase 3.6 (#513) — Phase 3 complete

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1908,7 +1908,7 @@ pip install zipfile36  # или стандартный zipfile
   db/integration.py        # Backward-compat facade (re-imports singletons from modules/)
   db/repositories/         # Data access layer
   modules/*/service.py     # Domain services (31 classes)
-  modules/*/router.py      # Domain routers (22 migrated so far)
+  modules/*/router.py      # Domain routers (all 28 migrated)
   scripts/migrate_json_to_db.py
   scripts/test_db.py
   scripts/setup_db.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Always run lint locally before pushing. Protected branches require PR workflow �
 
 ### Modular Infrastructure (`modules/`)
 
-Foundation layer for modular decomposition (issue #489). Phases 0–2 complete, Phase 3 in progress.
+Foundation layer for modular decomposition (issue #489). Phases 0–2 complete, Phase 3 complete (all 28 routers migrated).
 
 - **`EventBus`** (`modules/core/events.py`): In-process async pub/sub. Handlers run concurrently via `asyncio.gather`; exceptions are logged, never propagated to publisher. `BaseEvent` dataclass with auto-timestamp.
 - **`TaskRegistry`** (`modules/core/tasks.py`): Named background tasks — periodic (interval-based) or one-shot. `start_all()` / `cancel_all(timeout)` lifecycle. `TaskInfo` dataclass tracks status, run count, last error.
@@ -159,7 +159,7 @@ Import from `modules.core`: `EventBus`, `BaseEvent`, `TaskRegistry`, `TaskInfo`,
 
 ### Domain Routers (`modules/*/router.py`)
 
-Phase 3 migration: routers move from `app/routers/` to domain modules. Original files become 1-3 line facades. Completed so far (Phase 3.2 + 3.3 + 3.4 + 3.5):
+Phase 3 migration complete: all 28 routers moved from `app/routers/` to domain modules. Original files are 1-3 line facade re-exports.
 
 | Domain | Router file | Facade |
 |--------|------------|--------|
@@ -176,6 +176,9 @@ Phase 3 migration: routers move from `app/routers/` to domain modules. Original 
 | `modules/sales/` | `router_bot_sales.py`, `router_yoomoney.py` | `app/routers/bot_sales.py`, `yoomoney_webhook.py` |
 | `modules/core/` | `router_auth.py`, `router_roles.py`, `router_workspace.py` | `app/routers/auth.py`, `roles.py`, `workspace.py` |
 | `modules/admin/` | `router_backup.py`, `router_legal.py`, `router_github_webhook.py` | `app/routers/backup.py`, `legal.py`, `github_webhook.py` |
+| `modules/monitoring/` | `router_audit.py`, `router_usage.py`, `router_monitor.py` | `app/routers/audit.py`, `usage.py`, `monitor.py` |
+| `modules/chat/` | `router.py` | `app/routers/chat.py` |
+| `modules/llm/` | `router.py` | `app/routers/llm.py` |
 
 New routers import domain services directly (`from modules.monitoring.service import audit_service`) instead of through the facade.
 

--- a/wiki-pages/Architecture.md
+++ b/wiki-pages/Architecture.md
@@ -43,7 +43,7 @@
 
 | Компонент | Описание |
 |-----------|----------|
-| `app/routers/` | 28 отдельных файлов роутеров |
+| `app/routers/` | 28 фасадов-реэкспортов (1–3 строки), логика в `modules/*/router*.py` |
 | `db/repositories/` | 45 файлов, чистая изоляция, `BaseRepository` с generic CRUD |
 | `telegram_bot/`, `whatsapp_bot/` | Отдельные процессы, общаются через HTTP API |
 | `app/services/` | Доменные сервисы (amoCRM, Wiki RAG, backup и др.) |
@@ -434,6 +434,38 @@ from modules.kanban.service import kanban_service as async_kanban_manager
 
 ---
 
+### Phase 3.6: Роутеры — monitoring, chat, llm
+
+> **Статус:** реализовано (PR [#534](https://github.com/ShaerWare/AI_Secretary_System/pull/534), issue [#513](https://github.com/ShaerWare/AI_Secretary_System/issues/513))
+
+Последние 5 роутеров перенесены в доменные модули. Все импорты из `db.integration` заменены на прямые импорты из доменных сервисов. **Все 28 роутеров мигрированы — Phase 3 завершена.**
+
+| Старый файл | Новый файл | Ключевые изменения |
+|---|---|---|
+| `app/routers/audit.py` (126 строк) | `modules/monitoring/router_audit.py` | Чистый перенос (0 db.integration imports) |
+| `app/routers/usage.py` (301 строка) | `modules/monitoring/router_usage.py` | Чистый перенос (0 db.integration imports) |
+| `app/routers/monitor.py` (246 строк) | `modules/monitoring/router_monitor.py` | Чистый перенос (0 db.integration imports) |
+| `app/routers/chat.py` (1176 строк) | `modules/chat/router.py` | 7 db.integration → domain imports |
+| `app/routers/llm.py` (1633 строки) | `modules/llm/router.py` | 2 db.integration → domain imports |
+
+Замены импортов (9):
+- `async_chat_manager` → `chat_service` из `modules.chat.service`
+- `async_chat_share_manager` → `chat_share_service` из `modules.chat.service`
+- `async_bot_instance_manager` → `bot_instance_service` из `modules.channels.telegram.service`
+- `async_whatsapp_instance_manager` → `whatsapp_instance_service` из `modules.channels.whatsapp.service`
+- `async_widget_instance_manager` → `widget_instance_service` из `modules.channels.widget.service`
+- `async_cloud_provider_manager` → `cloud_provider_service` из `modules.llm.service`
+- `async_knowledge_collection_manager` → `knowledge_collection_service` из `modules.knowledge.service`
+- `async_audit_logger` → `audit_service` из `modules.monitoring.service`
+
+Нюансы:
+- **audit.py, usage.py, monitor.py** — 0 импортов из `db.integration`, чистый перенос
+- **chat.py** — SSE streaming + RAG логика, 7 кросс-доменных импортов (telegram, whatsapp, widget, knowledge, llm)
+- **llm.py** — крупнейший роутер (1633 строки, 37 routes), inline `db.repositories` / `db.database` импорты оставлены как есть
+- **monitor.py** — условная регистрация в cloud mode, условие остаётся в `orchestrator.py`
+
+---
+
 ## Тесты
 
 24 unit-теста для core-инфраструктуры:
@@ -460,7 +492,7 @@ pytest tests/unit/test_event_bus.py tests/unit/test_task_registry.py tests/unit/
 | **0** | Инфраструктура core (EventBus, TaskRegistry, HealthRegistry) | [#490](https://github.com/ShaerWare/AI_Secretary_System/issues/490) | ✅ Завершена |
 | **1** | Разделение `db/models.py` → доменные модули | [#491](https://github.com/ShaerWare/AI_Secretary_System/issues/491) | ✅ Завершена |
 | **2** | Разделение `db/integration.py` → доменные сервисы + фасад | [#492](https://github.com/ShaerWare/AI_Secretary_System/issues/492) | ✅ Завершена (#501, #502, #503) |
-| **3** | Перенос роутеров в доменные модули | [#493](https://github.com/ShaerWare/AI_Secretary_System/issues/493) | 🔄 В работе (#508 ✅, #509 ✅, #510 ✅, #511 ✅, #512 ✅, #513–#514) |
+| **3** | Перенос роутеров в доменные модули | [#493](https://github.com/ShaerWare/AI_Secretary_System/issues/493) | ✅ Завершена (#508 ✅, #509 ✅, #510 ✅, #511 ✅, #512 ✅, #513 ✅, #514) |
 | **4** | Декомпозиция `orchestrator.py` | [#494](https://github.com/ShaerWare/AI_Secretary_System/issues/494) | ⏳ |
 | **5** | Внедрение EventBus-событий | [#495](https://github.com/ShaerWare/AI_Secretary_System/issues/495) | ⏳ |
 | **6** | Протокольные интерфейсы | [#496](https://github.com/ShaerWare/AI_Secretary_System/issues/496) | ⏳ |


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Add 5 new domain routers (monitoring×3, chat, llm), mark Phase 3 as complete (all 28 routers migrated)
- **BACKLOG.md**: Update migrated router count to "all 28"
- **Architecture.md**: Add Phase 3.6 section with full migration table, mark #513 ✅, update Phase 3 status to complete, update `app/routers/` description to reflect facade-only status

## Test plan

- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)