### PR TITLE
fix: CRM default tab + chat stream error handling

### DIFF
--- a/admin/src/api/chat.ts
+++ b/admin/src/api/chat.ts
@@ -207,6 +207,7 @@ export const chatApi = {
 
       const decoder = new TextDecoder()
       let buffer = ''
+      let receivedDone = false
 
       while (true) {
         const { done, value } = await reader.read()
@@ -220,10 +221,14 @@ export const chatApi = {
           if (line.startsWith('data: ')) {
             const data = line.slice(6)
             if (data === '[DONE]') {
+              receivedDone = true
               onChunk({ type: 'done' })
             } else {
               try {
                 const parsed = JSON.parse(data)
+                if (parsed.type === 'done' || parsed.type === 'assistant_message' || parsed.type === 'error') {
+                  receivedDone = true
+                }
                 onChunk(parsed)
               } catch {
                 // Ignore parse errors
@@ -231,6 +236,11 @@ export const chatApi = {
             }
           }
         }
+      }
+
+      // Stream ended without a terminal event — treat as error
+      if (!receivedDone) {
+        onChunk({ type: 'error', content: 'Stream ended unexpectedly' })
       }
     }).catch((e) => {
       if (e.name !== 'AbortError') {

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -994,6 +994,9 @@ function sendMessage() {
       pendingUserContent.value = null
       streamingContent.value = ''
       console.error('Stream error:', data.content)
+      // Refetch to show user message that was already saved to DB
+      refetchSession()
+      refetchSessions()
       nextTick(() => messageInputRef.value?.focus())
     }
   }, llmOverride)

--- a/admin/src/views/CrmView.vue
+++ b/admin/src/views/CrmView.vue
@@ -297,10 +297,6 @@ onMounted(async () => {
     showToast(String(query.error), 'error')
   }
 
-  // Default to kanban tab if connected
-  if (isConnected.value) {
-    activeTab.value = 'kanban'
-  }
 })
 </script>
 


### PR DESCRIPTION
## Summary

- **CRM**: вкладка «Настройки» теперь всегда стартовая при входе в раздел CRM (раньше перескакивало на канбан при подключённом amoCRM)
- **Chat**: добавлен `receivedDone` флаг — если SSE-стрим оборвался без `[DONE]`, показывается ошибка
- **Chat**: при ошибке стрима выполняется refetch сессии, чтобы сообщение пользователя (уже сохранённое в БД) отобразилось

## NEWS

🔧 **Исправления в CRM и чате**

Раздел CRM теперь всегда открывается на вкладке «Настройки» — больше не перескакивает на канбан. Также улучшена обработка ситуаций, когда ответ ИИ в чате обрывается — ваше сообщение не потеряется, а ошибка будет показана корректно.

## Test plan

- [ ] Открыть CRM при подключённом amoCRM — должна быть вкладка «Настройки»
- [ ] Отправить сообщение в чат, оборвать ответ (kill backend) — сообщение пользователя должно остаться
- [ ] Нормальный чат-стрим работает без регрессий

🤖 Generated with [Claude Code](https://claude.com/claude-code)