### PR TITLE
feat: подсветка синтаксиса Prism.js + фикс кнопок скролла

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@tanstack/vue-query": "^5.62.9",
+        "@types/prismjs": "^1.26.6",
         "@vueuse/core": "^14.1.0",
         "chart.js": "^4.5.1",
         "class-variance-authority": "^0.7.1",
@@ -19,6 +20,7 @@
         "marked": "^17.0.2",
         "pinia": "^2.3.0",
         "pinia-plugin-persistedstate": "~3.2.3",
+        "prismjs": "^1.30.0",
         "radix-vue": "^1.9.11",
         "tailwind-merge": "^2.6.0",
         "vue": "^3.5.13",
@@ -1273,6 +1275,12 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.6",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+      "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -3524,6 +3532,15 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/punycode": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.62.9",
+    "@types/prismjs": "^1.26.6",
     "@vueuse/core": "^14.1.0",
     "chart.js": "^4.5.1",
     "class-variance-authority": "^0.7.1",
@@ -24,6 +25,7 @@
     "marked": "^17.0.2",
     "pinia": "^2.3.0",
     "pinia-plugin-persistedstate": "~3.2.3",
+    "prismjs": "^1.30.0",
     "radix-vue": "^1.9.11",
     "tailwind-merge": "^2.6.0",
     "vue": "^3.5.13",

--- a/admin/src/assets/main.css
+++ b/admin/src/assets/main.css
@@ -223,6 +223,100 @@
   }
 }
 
+/* Prism.js syntax highlighting — theme-adaptive via CSS variables */
+.chat-markdown code .token.comment,
+.chat-markdown code .token.prolog,
+.chat-markdown code .token.doctype,
+.chat-markdown code .token.cdata {
+  color: hsl(var(--muted-foreground));
+  font-style: italic;
+}
+.chat-markdown code .token.punctuation {
+  color: hsl(var(--muted-foreground));
+}
+.chat-markdown code .token.property,
+.chat-markdown code .token.tag,
+.chat-markdown code .token.boolean,
+.chat-markdown code .token.number,
+.chat-markdown code .token.constant,
+.chat-markdown code .token.symbol {
+  color: hsl(20 90% 60%);
+}
+.chat-markdown code .token.selector,
+.chat-markdown code .token.attr-name,
+.chat-markdown code .token.string,
+.chat-markdown code .token.char,
+.chat-markdown code .token.builtin {
+  color: hsl(100 60% 50%);
+}
+.light .chat-markdown code .token.selector,
+.light .chat-markdown code .token.attr-name,
+.light .chat-markdown code .token.string,
+.light .chat-markdown code .token.char,
+.light .chat-markdown code .token.builtin {
+  color: hsl(100 60% 35%);
+}
+.chat-markdown code .token.operator,
+.chat-markdown code .token.entity,
+.chat-markdown code .token.url,
+.chat-markdown code .token.variable {
+  color: hsl(40 80% 60%);
+}
+.chat-markdown code .token.atrule,
+.chat-markdown code .token.attr-value,
+.chat-markdown code .token.keyword {
+  color: hsl(280 70% 65%);
+}
+.light .chat-markdown code .token.atrule,
+.light .chat-markdown code .token.attr-value,
+.light .chat-markdown code .token.keyword {
+  color: hsl(280 70% 45%);
+}
+.chat-markdown code .token.function,
+.chat-markdown code .token.class-name {
+  color: hsl(200 80% 65%);
+}
+.light .chat-markdown code .token.function,
+.light .chat-markdown code .token.class-name {
+  color: hsl(200 80% 40%);
+}
+.chat-markdown code .token.regex,
+.chat-markdown code .token.important {
+  color: hsl(35 90% 60%);
+}
+.chat-markdown code .token.important,
+.chat-markdown code .token.bold {
+  font-weight: bold;
+}
+.chat-markdown code .token.italic {
+  font-style: italic;
+}
+.chat-markdown code .token.deleted {
+  color: hsl(0 70% 60%);
+}
+.chat-markdown code .token.inserted {
+  color: hsl(120 60% 50%);
+}
+
+/* Night-eyes theme overrides for Prism */
+.night-eyes .chat-markdown code .token.property,
+.night-eyes .chat-markdown code .token.tag,
+.night-eyes .chat-markdown code .token.boolean,
+.night-eyes .chat-markdown code .token.number,
+.night-eyes .chat-markdown code .token.constant,
+.night-eyes .chat-markdown code .token.symbol {
+  color: hsl(30 80% 60%);
+}
+.night-eyes .chat-markdown code .token.atrule,
+.night-eyes .chat-markdown code .token.attr-value,
+.night-eyes .chat-markdown code .token.keyword {
+  color: hsl(35 70% 65%);
+}
+.night-eyes .chat-markdown code .token.function,
+.night-eyes .chat-markdown code .token.class-name {
+  color: hsl(40 60% 70%);
+}
+
 /* Chat markdown rendering */
 .chat-markdown {
   line-height: 1.6;

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -4,6 +4,25 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
 import { useI18n } from 'vue-i18n'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
+import Prism from 'prismjs'
+import 'prismjs/components/prism-javascript'
+import 'prismjs/components/prism-typescript'
+import 'prismjs/components/prism-python'
+import 'prismjs/components/prism-bash'
+import 'prismjs/components/prism-json'
+import 'prismjs/components/prism-css'
+import 'prismjs/components/prism-markup'
+import 'prismjs/components/prism-yaml'
+import 'prismjs/components/prism-sql'
+import 'prismjs/components/prism-docker'
+import 'prismjs/components/prism-nginx'
+import 'prismjs/components/prism-go'
+import 'prismjs/components/prism-rust'
+import 'prismjs/components/prism-java'
+import 'prismjs/components/prism-diff'
+import 'prismjs/components/prism-markdown'
+import 'prismjs/components/prism-jsx'
+import 'prismjs/components/prism-tsx'
 import { chatApi, ttsApi, llmApi, sttApi, wikiRagApi, type ChatSession, type ChatMessage, type ChatSessionSummary, type CloudProvider, type BranchNode, type SiblingInfo, type TokenUsage } from '@/api'
 import BranchTree from '@/components/BranchTree.vue'
 import ChatShareDialog from '@/components/ChatShareDialog.vue'
@@ -222,11 +241,22 @@ marked.use({
     code({ text, lang }) {
       const language = lang || ''
       const artifactId = `artifact-${currentMsgId}-${codeBlockCounter++}`
-      const escapedCode = text
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
+      // Map common lang aliases to Prism grammar keys
+      const langMap: Record<string, string> = {
+        js: 'javascript', ts: 'typescript', py: 'python',
+        sh: 'bash', shell: 'bash', zsh: 'bash',
+        yml: 'yaml', html: 'markup', xml: 'markup',
+        dockerfile: 'docker', conf: 'nginx',
+      }
+      const prismLang = langMap[language] || language
+      const grammar = prismLang ? Prism.languages[prismLang] : undefined
+      const highlightedCode = grammar
+        ? Prism.highlight(text, grammar, prismLang)
+        : text
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
       // SVG icons for buttons
       const copySvg = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>'
       const viewSvg = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>'
@@ -240,7 +270,7 @@ marked.use({
             <button class="code-block-btn" data-artifact-open="${artifactId}" title="${t('chatView.openInViewer')}">${viewSvg}</button>
           </div>
         </div>
-        <pre><code class="language-${language}">${escapedCode}</code></pre>
+        <pre><code class="language-${language}">${highlightedCode}</code></pre>
       </div>`
     }
   }
@@ -2835,12 +2865,14 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
       </div>
 
       <!-- Messages + Branch Tree row -->
-      <div class="flex-1 flex overflow-hidden relative min-h-0">
+      <div class="flex-1 flex overflow-hidden min-h-0">
+      <!-- Messages wrapper (relative for scroll buttons) -->
+      <div class="relative flex-1 min-w-0">
       <!-- Messages -->
       <div
         ref="messagesContainer"
         :class="[
-          'flex-1 overflow-y-auto overflow-x-hidden p-4 space-y-4 claude-messages-container',
+          'h-full overflow-y-auto overflow-x-hidden p-4 space-y-4 claude-messages-container',
           fullscreenStore.isFullscreen ? 'zen-messages' : ''
         ]"
         @click="handleMessagesClick"
@@ -3182,7 +3214,7 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
       <!-- Floating scroll buttons -->
       <div
         v-if="currentSession && !cc.isActive.value"
-        class="fixed right-1 sm:right-3 top-1/2 -translate-y-1/2 z-30 flex flex-col gap-1"
+        class="absolute right-1 sm:right-3 top-1/2 -translate-y-1/2 z-30 flex flex-col gap-1"
       >
         <button
           class="p-1.5 sm:p-2 rounded-full bg-card/80 backdrop-blur border border-border shadow-md text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
@@ -3199,6 +3231,7 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
           <ArrowDownToLine class="w-3.5 h-3.5 sm:w-4 sm:h-4" />
         </button>
       </div>
+      </div> <!-- /messages wrapper -->
 
       <!-- Branch Tree Panel -->
       <template v-if="showBranchTree">


### PR DESCRIPTION
## Summary

- Добавлена подсветка синтаксиса кода в чате через Prism.js (18 языков: JS, TS, Python, Bash, JSON, CSS, HTML, YAML, SQL, Docker, Nginx, Go, Rust, Java, Diff, Markdown, JSX, TSX)
- Кастомная тема Prism на CSS-переменных проекта — адаптируется к dark/light/night-eyes
- Кнопки скролла (вверх/вниз) переведены с `fixed` на `absolute` внутри wrapper'а области сообщений — больше не скрываются за Branch Tree и Settings панелями

## NEWS

🎨 **Подсветка синтаксиса в чате**

Блоки кода теперь подсвечиваются с учётом языка программирования! Поддерживаются Python, JavaScript, TypeScript, Go, Rust, SQL, Bash, Docker, YAML и многие другие. Цвета автоматически адаптируются к выбранной теме (тёмная, светлая, ночная).

Также исправлены кнопки прокрутки — теперь они не прячутся за боковыми панелями (дерево веток, настройки).

## Test plan

- [ ] Открыть чат, отправить сообщение с блоком кода Python/JS → подсветка синтаксиса
- [ ] Переключить dark/light/night-eyes → цвета подсветки адаптируются
- [ ] Открыть Branch Tree / Settings панель → кнопки скролла видимы слева от панелей
- [ ] Закрыть панели → кнопки у правого края области сообщений
- [ ] `npm run build` проходит без ошибок

🤖 Generated with [Claude Code](https://claude.com/claude-code)