### PR TITLE
feat: GSM SIM7600E-H — real hardware mode + admin UI

### DIFF
--- a/admin/src/api/gsm.ts
+++ b/admin/src/api/gsm.ts
@@ -25,6 +25,8 @@ export interface GSMStatus {
   audio_port: string
   module_info?: string | null
   last_error?: string | null
+  mock_mode?: boolean
+  network_mode?: string | null
 }
 
 export interface GSMConfig {
@@ -162,6 +164,18 @@ export const gsmApi = {
 
   sendSMS: (number: string, text: string) =>
     api.post<{ status: string; message: string }>('/admin/gsm/sms', { number, text }),
+
+  readModemSMS: () =>
+    api.post<{ status: string; count: number; messages: SMSMessage[] }>(
+      '/admin/gsm/sms/read-modem',
+    ),
+
+  clearModemSMS: () =>
+    api.post<{ status: string; message: string }>('/admin/gsm/sms/clear-modem'),
+
+  // DTMF
+  sendDTMF: (digits: string) =>
+    api.post<{ status: string; message: string }>('/admin/gsm/dtmf', { digits }),
 
   // Debug
   executeAT: (command: string, timeout = 5.0) =>

--- a/admin/src/views/GSMView.vue
+++ b/admin/src/views/GSMView.vue
@@ -24,6 +24,7 @@ import {
   User,
   Save,
   Usb,
+  Download,
 } from 'lucide-vue-next'
 import { ref, computed, watch } from 'vue'
 import { useToastStore } from '@/stores/toast'
@@ -210,6 +211,22 @@ const executeATMutation = useMutation({
   },
 })
 
+const readModemSMSMutation = useMutation({
+  mutationFn: () => gsmApi.readModemSMS(),
+  onSuccess: (data) => {
+    toast.success(`Прочитано SMS с SIM: ${data.count}`)
+    refetchSMS()
+  },
+  onError: (error: Error) => {
+    toast.error(`Ошибка чтения SIM: ${error.message}`)
+  },
+})
+
+// ============== Computed: SMS ==============
+
+const hasCyrillic = computed(() => /[а-яёА-ЯЁ]/.test(smsText.value))
+const smsMaxChars = computed(() => hasCyrillic.value ? 70 : 160)
+
 // ============== Methods ==============
 
 function saveConfig() {
@@ -274,6 +291,14 @@ function getCallStateColor(state: string): string {
       </div>
 
       <div class="flex items-center gap-2">
+        <!-- Mock Mode Badge -->
+        <span
+          v-if="status?.mock_mode"
+          class="px-2 py-1 bg-yellow-500/20 text-yellow-500 rounded text-xs font-medium"
+        >
+          MOCK
+        </span>
+
         <!-- Status Badge -->
         <div class="flex items-center gap-2 px-3 py-1.5 bg-card rounded-lg border border-border">
           <span :class="['w-2 h-2 rounded-full', isConnected ? 'bg-green-500' : 'bg-red-500']" />
@@ -356,7 +381,7 @@ function getCallStateColor(state: string): string {
             </button>
           </div>
 
-          <div v-else class="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div v-else class="grid grid-cols-2 md:grid-cols-5 gap-4">
             <!-- Signal -->
             <div class="p-4 bg-secondary/50 rounded-lg">
               <div class="flex items-center gap-2 mb-2 text-muted-foreground">
@@ -389,6 +414,9 @@ v-for="i in 4" :key="i" :class="[
                 <span class="text-sm">Сеть</span>
               </div>
               <div class="font-medium">{{ status?.network_name ?? '—' }}</div>
+              <div v-if="status?.network_mode" class="text-xs text-muted-foreground mt-1">
+                {{ status.network_mode }}
+              </div>
             </div>
 
             <!-- Phone Number -->
@@ -398,6 +426,15 @@ v-for="i in 4" :key="i" :class="[
                 <span class="text-sm">Номер</span>
               </div>
               <div class="font-medium font-mono">{{ status?.phone_number ?? '—' }}</div>
+            </div>
+
+            <!-- AT Port -->
+            <div class="p-4 bg-secondary/50 rounded-lg">
+              <div class="flex items-center gap-2 mb-2 text-muted-foreground">
+                <Usb class="w-4 h-4" />
+                <span class="text-sm">Порт</span>
+              </div>
+              <div class="font-medium font-mono text-sm">{{ status?.at_port ?? '—' }}</div>
             </div>
           </div>
         </div>
@@ -532,8 +569,14 @@ v-for="i in 4" :key="i" :class="[
                 placeholder="Текст сообщения..."
                 class="w-full px-3 py-2 bg-background border border-border rounded focus:outline-none focus:ring-2 focus:ring-primary resize-none"
               />
-              <div class="text-xs text-muted-foreground mt-1 text-right">
-                {{ smsText.length }} / 160
+              <div class="flex justify-between text-xs text-muted-foreground mt-1">
+                <span v-if="hasCyrillic" class="text-yellow-500">
+                  Кириллица: 70 символов/SMS (UCS2)
+                </span>
+                <span v-else>&nbsp;</span>
+                <span :class="smsText.length > smsMaxChars ? 'text-red-500' : ''">
+                  {{ smsText.length }} / {{ smsMaxChars }}
+                </span>
               </div>
             </div>
 
@@ -553,9 +596,21 @@ v-for="i in 4" :key="i" :class="[
         <div class="bg-card rounded-lg border border-border">
           <div class="p-4 border-b border-border flex items-center justify-between">
             <h2 class="text-lg font-semibold">История SMS</h2>
-            <button class="p-2 hover:bg-secondary rounded" @click="refetchSMS()">
-              <RefreshCw class="w-4 h-4" />
-            </button>
+            <div class="flex items-center gap-2">
+              <button
+                class="flex items-center gap-1 px-3 py-1.5 bg-secondary rounded text-sm hover:bg-secondary/80 disabled:opacity-50"
+                :disabled="readModemSMSMutation.isPending.value"
+                title="Прочитать SMS из памяти SIM-карты"
+                @click="readModemSMSMutation.mutate()"
+              >
+                <Loader2 v-if="readModemSMSMutation.isPending.value" class="w-4 h-4 animate-spin" />
+                <Download v-else class="w-4 h-4" />
+                С SIM
+              </button>
+              <button class="p-2 hover:bg-secondary rounded" @click="refetchSMS()">
+                <RefreshCw class="w-4 h-4" />
+              </button>
+            </div>
           </div>
 
           <div v-if="!smsData?.messages?.length" class="p-8 text-center text-muted-foreground">

--- a/app/services/gsm_service.py
+++ b/app/services/gsm_service.py
@@ -59,6 +59,7 @@ class GSMStatus:
     module_info: Optional[str] = None
     last_error: Optional[str] = None
     mock_mode: bool = False
+    network_mode: Optional[str] = None  # GSM, HSDPA, LTE, etc
 
     def to_dict(self) -> dict:
         return {
@@ -72,6 +73,7 @@ class GSMStatus:
             "module_info": self.module_info,
             "last_error": self.last_error,
             "mock_mode": self.mock_mode,
+            "network_mode": self.network_mode,
         }
 
 
@@ -346,6 +348,9 @@ class GSMService:
             info_lines = [ln for ln in lines if ln not in ("OK", "") and not ln.startswith("AT")]
             if info_lines:
                 status.module_info = " / ".join(info_lines)
+
+        # Network mode (GSM/HSDPA/LTE)
+        status.network_mode = await self.get_network_mode()
 
         status.last_error = self.last_error
         return status
@@ -624,6 +629,94 @@ class GSMService:
                 self.on_sms_received(line)
             except Exception as e:
                 logger.error(f"on_sms_received callback error: {e}")
+
+    # ================================================================
+    # SMS Read/Delete from SIM + DTMF + Network Mode
+    # ================================================================
+
+    NETWORK_MODES: Dict[int, str] = {
+        0: "No service",
+        1: "GSM",
+        2: "GPRS",
+        3: "EGPRS (EDGE)",
+        4: "WCDMA",
+        5: "HSDPA",
+        6: "HSUPA",
+        7: "HSDPA+HSUPA",
+        8: "LTE",
+        9: "TDS-CDMA",
+        10: "TDS-HSDPA",
+        11: "TDS-HSUPA",
+        12: "TDS-HSDPA+HSUPA",
+        13: "CDMA",
+        14: "EVDO",
+        15: "CDMA/EVDO",
+        16: "CDMA/LTE",
+        17: "EVDO/LTE",
+        18: "CDMA/EVDO/LTE",
+    }
+
+    async def get_network_mode(self) -> Optional[str]:
+        """Get current network access mode (GSM, HSDPA, LTE, etc)."""
+        ok, lines = await self.execute_at("AT+CNSMOD?")
+        if ok:
+            for ln in lines:
+                if "+CNSMOD:" in ln:
+                    try:
+                        mode_num = int(ln.split(",")[1].strip())
+                        return self.NETWORK_MODES.get(mode_num, f"Unknown({mode_num})")
+                    except (ValueError, IndexError):
+                        pass
+        return None
+
+    async def read_sms(self, index: int) -> Optional[Dict]:
+        """Read single SMS by index from SIM storage."""
+        ok, lines = await self.execute_at(f"AT+CMGR={index}", timeout=5.0)
+        if not ok or not lines:
+            return None
+
+        for i, ln in enumerate(lines):
+            if ln.startswith("+CMGR:"):
+                text = lines[i + 1] if i + 1 < len(lines) and lines[i + 1] != "OK" else ""
+                sender_match = re.search(r'"(\+?[0-9]+)"', ln)
+                sender = sender_match.group(1) if sender_match else "unknown"
+                return {
+                    "index": index,
+                    "sender": sender,
+                    "text": text,
+                    "raw_header": ln,
+                }
+        return None
+
+    async def read_all_sms(self) -> List[Dict]:
+        """Read all SMS from SIM. Uses text mode listing."""
+        await self.execute_at("AT+CMGF=1")
+        messages = await self.list_sms_from_modem("ALL")
+        await self.execute_at("AT+CMGF=0")
+        return messages
+
+    async def delete_sms(self, index: int) -> bool:
+        """Delete a single SMS by index from SIM."""
+        ok, _ = await self.execute_at(f"AT+CMGD={index}")
+        return ok
+
+    async def delete_all_sms(self) -> bool:
+        """Delete all SMS from SIM storage."""
+        ok, _ = await self.execute_at("AT+CMGD=1,4", timeout=10.0)
+        return ok
+
+    async def send_dtmf(self, digits: str) -> bool:
+        """Send DTMF tones during an active call."""
+        if not self.active_call or self.active_call.state != "active":
+            return False
+
+        for digit in digits:
+            if digit in "0123456789*#ABCD":
+                ok, _ = await self.execute_at(f'AT+VTS="{digit}"')
+                if not ok:
+                    return False
+                await asyncio.sleep(0.3)
+        return True
 
     # ================================================================
     # Mock AT Responses

--- a/modules/telephony/router.py
+++ b/modules/telephony/router.py
@@ -63,6 +63,7 @@ class GSMStatus(BaseModel):
     module_info: Optional[str] = None
     last_error: Optional[str] = None
     mock_mode: bool = False
+    network_mode: Optional[str] = None  # GSM, HSDPA, LTE, etc
 
 
 class GSMConfig(BaseModel):
@@ -171,6 +172,12 @@ class DialRequest(BaseModel):
     number: str
 
 
+class DTMFRequest(BaseModel):
+    """Запрос на отправку DTMF тонов."""
+
+    digits: str
+
+
 # ============== Helpers ==============
 
 
@@ -211,6 +218,7 @@ async def gsm_status(
         module_info=status.module_info,
         last_error=status.last_error,
         mock_mode=status.mock_mode,
+        network_mode=status.network_mode,
     )
 
 
@@ -407,6 +415,74 @@ async def send_sms(
         return {"status": "ok", "message": f"SMS отправлено на {request.number}"}
     else:
         raise HTTPException(status_code=500, detail=error or "Не удалось отправить SMS")
+
+
+# ============== DTMF Endpoint ==============
+
+
+@router.post("/dtmf")
+async def send_dtmf(
+    request: DTMFRequest,
+    gsm_svc=Depends(get_gsm_service),
+    user: User = Depends(require_permission("gsm", "manage")),
+):
+    """Отправить DTMF тоны во время звонка."""
+    gsm = _require_gsm(gsm_svc)
+
+    ok = await gsm.send_dtmf(request.digits)
+    if ok:
+        return {"status": "ok", "message": f"DTMF отправлено: {request.digits}"}
+    else:
+        raise HTTPException(status_code=400, detail="Нет активного звонка или ошибка DTMF")
+
+
+# ============== Modem SMS Endpoints ==============
+
+
+@router.post("/sms/read-modem")
+async def read_modem_sms(
+    gsm_svc=Depends(get_gsm_service),
+    user: User = Depends(require_permission("gsm", "manage")),
+):
+    """Прочитать SMS из памяти модема (SIM-карта)."""
+    gsm = _require_gsm(gsm_svc)
+
+    messages = await gsm.read_all_sms()
+    # Save to DB and delete from SIM
+    saved = []
+    for msg in messages:
+        sms = await gsm_service.create_sms(
+            direction="incoming",
+            number=msg.get("number", "unknown"),
+            text=msg.get("text", ""),
+            status="received",
+        )
+        saved.append(sms)
+
+    # Clean SIM storage to prevent overflow (only 15 slots)
+    if messages:
+        await gsm.delete_all_sms()
+
+    return {
+        "status": "ok",
+        "count": len(saved),
+        "messages": saved,
+    }
+
+
+@router.post("/sms/clear-modem")
+async def clear_modem_sms(
+    gsm_svc=Depends(get_gsm_service),
+    user: User = Depends(require_permission("gsm", "manage")),
+):
+    """Очистить все SMS из памяти модема."""
+    gsm = _require_gsm(gsm_svc)
+
+    ok = await gsm.delete_all_sms()
+    if ok:
+        return {"status": "ok", "message": "SMS на SIM-карте удалены"}
+    else:
+        raise HTTPException(status_code=500, detail="Не удалось очистить SMS")
 
 
 # ============== Debug Endpoints ==============

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1039,10 +1039,11 @@ async def startup_event():
             try:
                 from app.services.gsm_service import GSMService
 
-                gsm_service = GSMService(mock_mode=True)
+                gsm_service = GSMService()
                 await gsm_service.initialize()
                 container.gsm_service = gsm_service
-                logger.info("✅ GSM service initialized (mock mode)")
+                mode = "mock" if gsm_service.mock_mode else "hardware"
+                logger.info(f"✅ GSM service initialized ({mode} mode)")
             except Exception as gsm_err:
                 logger.warning(f"⚠️ GSM service not available: {gsm_err}")
 


### PR DESCRIPTION
## Summary

- Switch GSM service from forced `mock_mode=True` to auto-detection of real hardware
- Add new methods to `gsm_service.py`: `read_sms`, `read_all_sms`, `delete_sms`, `delete_all_sms`, `send_dtmf`, `get_network_mode` with `NETWORK_MODES` dict
- Add `network_mode` field to GSM status (GSM/HSDPA/LTE)
- New endpoints: `POST /admin/gsm/dtmf`, `POST /admin/gsm/sms/read-modem`, `POST /admin/gsm/sms/clear-modem`
- Frontend: MOCK badge, network mode display, AT port card, "Read from SIM" button, Cyrillic-aware SMS char counter (70 UCS2 vs 160 GSM7)

## NEWS

📡 **GSM-модем SIM7600E-H — реальное железо вместо заглушки**

GSM-модуль теперь автоматически определяет подключённый модем и работает с реальным железом. Поддержка SMS на русском языке через PDU/UCS2, определение типа сети (2G/3G/LTE), чтение SMS с SIM-карты прямо из админки, отправка DTMF-тонов. В UI появились бейдж режима (MOCK/железо), показ типа сети, кнопка «С SIM» и счётчик символов с учётом кириллицы.

## Test plan

- [ ] Start backend: `./start_gpu.sh` — GSM service initializes in hardware mode (not mock)
- [ ] `curl http://localhost:8002/admin/gsm/status` — shows `mock_mode: false`, signal, network_mode
- [ ] Send SMS from admin UI with Cyrillic text — verify delivery
- [ ] Send AT command from Debug tab — verify response
- [ ] Call the modem → verify incoming call appears in admin
- [ ] "Read from SIM" button reads and imports SMS from modem SIM storage
- [ ] Frontend build: `cd admin && npm run build` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)