### PR TITLE
docs: update CLAUDE.md and wiki for Phase 4.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Always run lint locally before pushing. Protected branches require PR workflow �
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │                  Orchestrator (port 8002)                     │
-│  orchestrator.py + app/routers/ (28 routers, ~400 endpoints) │
+│  orchestrator.py + app/routers/ (21 routers, ~371 endpoints) │
 │  ┌────────────────────────────────────────────────────────┐  │
 │  │        Vue 3 Admin Panel (24 views, PWA)                │  │
 │  │                admin/dist/                              │  │
@@ -125,7 +125,7 @@ Always run lint locally before pushing. Protected branches require PR workflow �
 
 ### Modular Infrastructure (`modules/`)
 
-Foundation layer for modular decomposition (issue #489). Phases 0–2 complete, Phase 3 complete (all 28 routers migrated).
+Foundation layer for modular decomposition (issue #489). Phases 0–3 complete (all 28 routers migrated). Phase 4 (orchestrator decomposition) in progress.
 
 - **`EventBus`** (`modules/core/events.py`): In-process async pub/sub. Handlers run concurrently via `asyncio.gather`; exceptions are logged, never propagated to publisher. `BaseEvent` dataclass with auto-timestamp.
 - **`TaskRegistry`** (`modules/core/tasks.py`): Named background tasks — periodic (interval-based) or one-shot. `start_all()` / `cancel_all(timeout)` lifecycle. `TaskInfo` dataclass tracks status, run count, last error.
@@ -153,7 +153,7 @@ Import from `modules.core`: `EventBus`, `BaseEvent`, `TaskRegistry`, `TaskInfo`,
 | `modules/llm/` | `service.py` | `CloudProviderService` |
 | `modules/monitoring/` | `service.py` | `AuditService`, `PaymentService` |
 | `modules/admin/` | `service.py` | `ResourceShareService` |
-| `modules/speech/` | `service.py` | `PresetService` |
+| `modules/speech/` | `service.py`, `streaming.py` | `PresetService`, `StreamingTTSManager` |
 | `modules/crm/` | `service.py` | `AmoCRMService` |
 | `modules/ecommerce/` | `service.py` | `WooCommerceService` |
 | `modules/telephony/` | `service.py` | `GSMService` |
@@ -188,7 +188,7 @@ New routers import domain services directly (`from modules.monitoring.service im
 
 ### Key Components
 
-**`orchestrator.py`** (~4100 lines): FastAPI entry point. Initializes all services as module-level globals, populates `ServiceContainer`, includes all routers. Legacy OpenAI-compatible `/v1/*` endpoints still live here.
+**`orchestrator.py`** (~4060 lines): FastAPI entry point. Initializes all services as module-level globals, populates `ServiceContainer`, includes all routers. Legacy OpenAI-compatible `/v1/*` endpoints still live here. `StreamingTTSManager` extracted to `modules/speech/streaming.py` (Phase 4.1).
 
 **`ServiceContainer` (`app/dependencies.py`)**: Singleton holding references to all initialized services. Routers get services via FastAPI `Depends`. Populated during app startup.
 
@@ -322,6 +322,13 @@ docker compose restart ai-secretary          # REQUIRED: re-bind new dist/ inode
 5. Build — `npm run build` (verify `VITE_DEMO_MODE` is NOT set)
 6. Restart — `docker compose restart ai-secretary`
 7. Verify — `curl http://localhost:8002/health` + test `/admin/auth/login`
+
+### Automated Deployment
+
+```bash
+./deploy.sh                # git pull, re-apply patches, build admin, restart orchestrator
+./test_system.sh           # Quick health checks and API smoke tests
+```
 
 ### Demo Sites
 

--- a/wiki-pages/Architecture.md
+++ b/wiki-pages/Architecture.md
@@ -265,7 +265,7 @@ modules/
 | `modules/llm/` | `service.py` | `CloudProviderService` |
 | `modules/monitoring/` | `service.py` | `AuditService`, `PaymentService` |
 | `modules/admin/` | `service.py` | `ResourceShareService` |
-| `modules/speech/` | `service.py` | `PresetService` |
+| `modules/speech/` | `service.py`, `streaming.py` | `PresetService`, `StreamingTTSManager` |
 | `modules/crm/` | `service.py` | `AmoCRMService` |
 | `modules/ecommerce/` | `service.py` | `WooCommerceService` |
 | `modules/telephony/` | `service.py` | `GSMService` |
@@ -466,6 +466,24 @@ from modules.kanban.service import kanban_service as async_kanban_manager
 
 ---
 
+## Phase 4: Декомпозиция orchestrator.py
+
+### Phase 4.1: StreamingTTSManager → modules/speech/streaming.py
+
+> **Статус:** реализовано (PR [#564](https://github.com/ShaerWare/AI_Secretary_System/pull/564), issue [#546](https://github.com/ShaerWare/AI_Secretary_System/issues/546))
+
+Класс `StreamingTTSManager` (220 строк) извлечён из `orchestrator.py` в `modules/speech/streaming.py`. Менеджер обеспечивает параллельный синтез TTS во время streaming LLM: накапливает текст, разбивает на предложения, синтезирует в `ThreadPoolExecutor`, кэширует склеенное аудио.
+
+**Ключевые решения:**
+- `numpy` — lazy import внутри `_cache_full_audio()` (избегает ошибок импорта в cloud mode без GPU)
+- Глобальная переменная `streaming_tts_manager` и все 17 точек использования остаются в `orchestrator.py` (будут перенесены в Phase 4.5)
+- `synthesize_with_current_voice()` оставлена в orchestrator (зависит от 4 глобалов, будет перенесена в Phase 4.5)
+- 5 неиспользуемых импортов удалены из orchestrator (`hashlib`, `re`, `OrderedDict`, `ThreadPoolExecutor`, `numpy`)
+
+**Результат:** orchestrator.py: 4287 → 4062 строк (−225)
+
+---
+
 ## Тесты
 
 24 unit-теста для core-инфраструктуры:
@@ -493,7 +511,7 @@ pytest tests/unit/test_event_bus.py tests/unit/test_task_registry.py tests/unit/
 | **1** | Разделение `db/models.py` → доменные модули | [#491](https://github.com/ShaerWare/AI_Secretary_System/issues/491) | ✅ Завершена |
 | **2** | Разделение `db/integration.py` → доменные сервисы + фасад | [#492](https://github.com/ShaerWare/AI_Secretary_System/issues/492) | ✅ Завершена (#501, #502, #503) |
 | **3** | Перенос роутеров в доменные модули | [#493](https://github.com/ShaerWare/AI_Secretary_System/issues/493) | ✅ Завершена (#508 ✅, #509 ✅, #510 ✅, #511 ✅, #512 ✅, #513 ✅, #514) |
-| **4** | Декомпозиция `orchestrator.py` | [#494](https://github.com/ShaerWare/AI_Secretary_System/issues/494) | ⏳ |
+| **4** | Декомпозиция `orchestrator.py` | [#494](https://github.com/ShaerWare/AI_Secretary_System/issues/494) | 🔄 Phase 4.1 ✅ |
 | **5** | Внедрение EventBus-событий | [#495](https://github.com/ShaerWare/AI_Secretary_System/issues/495) | ⏳ |
 | **6** | Протокольные интерфейсы | [#496](https://github.com/ShaerWare/AI_Secretary_System/issues/496) | ⏳ |
 


### PR DESCRIPTION
## Summary
- Update `modules/speech` table in CLAUDE.md: add `streaming.py` / `StreamingTTSManager`
- Update orchestrator.py line count (~4100 → ~4060)
- Note Phase 4 in progress in modular infrastructure header
- Add Phase 4.1 section to wiki `Architecture.md` (already pushed to wiki repo)
- Sync `wiki-pages/Architecture.md` local copy

## Test plan
- [x] Documentation-only changes, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)