### PR TITLE
docs: Phase 4.5 documentation update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,20 +184,23 @@ Phase 3 migration complete: all 28 routers moved from `app/routers/` to domain m
 | `modules/chat/` | `router.py` | `app/routers/chat.py` |
 | `modules/llm/` | `router.py` | `app/routers/llm.py` |
 
-**Phase 4.3 routers** (extracted from `orchestrator.py`, not from `app/routers/`):
+**Phase 4 routers** (extracted from `orchestrator.py`, not from `app/routers/`):
 
-| Domain | Router file | Endpoints |
-|--------|------------|-----------|
-| `modules/compat/` | `router.py` | Legacy telephony (`/tts`, `/stt`, `/chat`, `/process_call`, `/reset_conversation`) + OpenAI-compat (`/v1/*`) |
-| `modules/core/` | `router_health.py` | `/`, `/health`, `/admin/deployment-mode` |
-| `modules/llm/` | `router_finetune.py` | LLM finetune: dataset, training, LoRA adapters (`/admin/finetune/*`) |
-| `modules/speech/` | `router_finetune.py` | TTS finetune: samples, training, models (`/admin/tts-finetune/*`) |
+| Domain | Router file | Endpoints | Phase |
+|--------|------------|-----------|-------|
+| `modules/compat/` | `router.py` | Legacy telephony (`/tts`, `/stt`, `/chat`, `/process_call`, `/reset_conversation`) + OpenAI-compat (`/v1/*`) | 4.3 |
+| `modules/core/` | `router_health.py` | `/`, `/health`, `/admin/deployment-mode` | 4.3 |
+| `modules/llm/` | `router_finetune.py` | LLM finetune: dataset, training, LoRA adapters (`/admin/finetune/*`) | 4.4 |
+| `modules/speech/` | `router_finetune.py` | TTS finetune: samples, training, models (`/admin/tts-finetune/*`) | 4.4 |
+| `modules/speech/` | `router_voices.py` | Voice selection + test (`/admin/voices`, `/admin/voice`, `/admin/voice/test`) | 4.5 |
+| `modules/llm/` | `router_models.py` | HuggingFace model management (`/admin/models/*`) | 4.5 |
+| `modules/monitoring/` | `router_logs.py` | Log viewing + streaming (`/admin/logs/*`) | 4.5 |
 
-New routers import domain services directly (`from modules.monitoring.service import audit_service`) instead of through the facade.
+New routers import domain services directly (`from modules.monitoring.service import audit_service`) instead of through the facade. GPU-only routers (`router_voices.py`, `router_models.py`, `router_finetune.py`) are conditionally registered when `DEPLOYMENT_MODE != "cloud"`.
 
 ### Key Components
 
-**`orchestrator.py`** (~2471 lines): FastAPI entry point. Initializes all services as module-level globals, populates `ServiceContainer`, includes all routers. Extracted: `StreamingTTSManager` → `modules/speech/streaming.py` (Phase 4.1), widget public endpoints → `modules/channels/widget/router_public.py` (Phase 4.2), legacy telephony + OpenAI-compat + core health endpoints → `modules/compat/router.py` + `modules/core/router_health.py` (Phase 4.3), finetune endpoints → `modules/llm/router_finetune.py` + `modules/speech/router_finetune.py` (Phase 4.4).
+**`orchestrator.py`** (~1121 lines): FastAPI entry point. **Zero inline endpoints** — all extracted to module routers. Contains: imports, middleware, router registration, global service variables, startup/shutdown lifecycle, static file serving. Extracted: `StreamingTTSManager` → `modules/speech/streaming.py` (Phase 4.1), widget public endpoints → `modules/channels/widget/router_public.py` (Phase 4.2), legacy telephony + OpenAI-compat + core health → `modules/compat/router.py` + `modules/core/router_health.py` (Phase 4.3), finetune endpoints → `modules/llm/router_finetune.py` + `modules/speech/router_finetune.py` (Phase 4.4), remaining admin endpoints (voices, models, logs) → `modules/speech/router_voices.py` + `modules/llm/router_models.py` + `modules/monitoring/router_logs.py` (Phase 4.5).
 
 **`ServiceContainer` (`app/dependencies.py`)**: Singleton holding references to all initialized services. Routers get services via FastAPI `Depends`. Populated during app startup.
 

--- a/wiki-pages/Architecture.md
+++ b/wiki-pages/Architecture.md
@@ -557,6 +557,40 @@ from modules.kanban.service import kanban_service as async_kanban_manager
 
 **Результат:** orchestrator.py: 2875 → 2471 строк (−404)
 
+### Phase 4.5: Remaining admin endpoints → modules/speech/ + modules/llm/ + modules/monitoring/
+
+> **Статус:** реализовано (PR [#572](https://github.com/ShaerWare/AI_Secretary_System/pull/572), issue [#550](https://github.com/ShaerWare/AI_Secretary_System/issues/550))
+
+Извлечены ВСЕ оставшиеся inline-эндпоинты из `orchestrator.py`. После этой фазы в файле **ноль** `@app.get/post/put/delete` — остались только `@app.on_event("startup")` и `@app.on_event("shutdown")`.
+
+**modules/speech/router_voices.py** (~205 строк):
+- `VoiceRequest` Pydantic-модель
+- 4 эндпоинта: `GET /admin/voices`, `GET /admin/voice`, `POST /admin/voice`, `POST /admin/voice/test`
+- Все используют `get_container()` вместо глобальных переменных
+
+**modules/llm/router_models.py** (~113 строк):
+- 10 эндпоинтов: list, scan (start/cancel/status), download (start/cancel/status), delete, search, details
+- Prefix: `/admin/models`
+- Использует `get_model_manager()`
+
+**modules/monitoring/router_logs.py** (~53 строки):
+- 3 эндпоинта: list, read, stream (SSE)
+- Prefix: `/admin/logs`
+- SSE streaming использует `require_permission("system", "view")`
+
+**Что удалено из orchestrator.py:**
+- 52 inline-эндпоинта (35 мёртвых дубликатов + 17 уникальных)
+- 18 Pydantic-моделей (все продублированы в модульных роутерах)
+- `get_current_tts_service()` helper
+- 16 неиспользуемых импортов
+
+**Ключевые решения:**
+- `router_voices.py` и `router_models.py` регистрируются внутри `if DEPLOYMENT_MODE != "cloud"` (GPU-only)
+- `router_logs.py` регистрируется безусловно (доступен во всех режимах)
+- 35 из 52 эндпоинтов были мёртвыми дубликатами (shadowed модульными роутерами, зарегистрированными ранее)
+
+**Результат:** orchestrator.py: 2471 → 1121 строк (−1350). Содержит: импорты, middleware, регистрацию роутеров, глобальные сервисные переменные, startup/shutdown lifecycle, раздачу статических файлов.
+
 ---
 
 ## Тесты
@@ -586,7 +620,7 @@ pytest tests/unit/test_event_bus.py tests/unit/test_task_registry.py tests/unit/
 | **1** | Разделение `db/models.py` → доменные модули | [#491](https://github.com/ShaerWare/AI_Secretary_System/issues/491) | ✅ Завершена |
 | **2** | Разделение `db/integration.py` → доменные сервисы + фасад | [#492](https://github.com/ShaerWare/AI_Secretary_System/issues/492) | ✅ Завершена (#501, #502, #503) |
 | **3** | Перенос роутеров в доменные модули | [#493](https://github.com/ShaerWare/AI_Secretary_System/issues/493) | ✅ Завершена (#508 ✅, #509 ✅, #510 ✅, #511 ✅, #512 ✅, #513 ✅, #514) |
-| **4** | Декомпозиция `orchestrator.py` | [#494](https://github.com/ShaerWare/AI_Secretary_System/issues/494) | 🔄 4.1 ✅ 4.2 ✅ 4.3 ✅ 4.4 ✅ |
+| **4** | Декомпозиция `orchestrator.py` | [#494](https://github.com/ShaerWare/AI_Secretary_System/issues/494) | 🔄 4.1 ✅ 4.2 ✅ 4.3 ✅ 4.4 ✅ 4.5 ✅ |
 | **5** | Внедрение EventBus-событий | [#495](https://github.com/ShaerWare/AI_Secretary_System/issues/495) | ⏳ |
 | **6** | Протокольные интерфейсы | [#496](https://github.com/ShaerWare/AI_Secretary_System/issues/496) | ⏳ |
 


### PR DESCRIPTION
## Summary
- Update CLAUDE.md: orchestrator.py line count 2471 → 1121, add 3 new Phase 4.5 routers (router_voices.py, router_models.py, router_logs.py)
- Update wiki Architecture.md: add Phase 4.5 section, update status to 4.5 ✅

## Test plan
- [x] Documentation only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)