### PR TITLE
feat: mobile internet QMI scripts + auto-reconnect monitor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,16 @@ python scripts/manage_users.py set-role <user> <role>        # Change role
 python scripts/manage_users.py disable <user>                # Deactivate
 ```
 
+### Mobile Internet (SIM7600E-H QMI)
+
+```bash
+sudo bash scripts/setup_mobile_internet.sh start   # Connect wwan0 via QMI
+sudo bash scripts/setup_mobile_internet.sh stop    # Disconnect
+sudo bash scripts/setup_mobile_internet.sh status  # Check connection
+sudo bash scripts/mobile-internet-monitor.sh       # Daemon: auto-reconnect + VPN route failover
+# systemd: scripts/mobile-internet.service          # Install as persistent service
+```
+
 ### Database Migrations
 
 Three migration systems:

--- a/scripts/mobile-internet-monitor.sh
+++ b/scripts/mobile-internet-monitor.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# Мониторинг мобильного интернета SIM7600E-H
+#
+# Функции:
+#   1. Держит wwan0 поднятым (QMI reconnect)
+#   2. Переключает маршрут VPN-сервера на wwan0 если WiFi пропал
+#   3. Возвращает маршрут на WiFi когда он вернулся
+#
+# Использование:
+#   sudo bash scripts/mobile-internet-monitor.sh
+#   # Или как systemd-сервис (см. scripts/mobile-internet.service)
+
+set -uo pipefail
+
+# === Конфигурация ===
+QMI_DEV="/dev/cdc-wdm2"
+APN="internet"
+VPN_SERVER="155.212.231.7"
+CHECK_INTERVAL=15        # Секунд между проверками
+RECONNECT_COOLDOWN=30    # Секунд между попытками реконнекта QMI
+LOG_TAG="mobile-inet"
+
+# === Переменные состояния ===
+WWAN_IFACE=""
+WIFI_IFACE=""
+LAST_RECONNECT=0
+VPN_ROUTE_VIA=""  # "wifi" или "wwan" — текущий маршрут до VPN
+
+log() { logger -t "$LOG_TAG" "$1"; echo "$(date '+%H:%M:%S') $1"; }
+
+find_wwan() {
+    for iface in wwan0 wwan1 usb0; do
+        if ip link show "$iface" &>/dev/null; then
+            WWAN_IFACE="$iface"
+            return 0
+        fi
+    done
+    return 1
+}
+
+find_wifi() {
+    # Ищем WiFi интерфейс с IP-адресом
+    WIFI_IFACE=""
+    for iface in $(ip -br link show type none 2>/dev/null | awk '{print $1}'); do
+        if iw dev "$iface" info &>/dev/null 2>&1; then
+            if ip addr show "$iface" 2>/dev/null | grep -q "inet "; then
+                WIFI_IFACE="$iface"
+                return 0
+            fi
+        fi
+    done
+    # Fallback: ищем по имени wl*
+    for iface in $(ip -br addr show | grep "^wl" | awk '{print $1}'); do
+        if ip addr show "$iface" 2>/dev/null | grep -q "inet "; then
+            WIFI_IFACE="$iface"
+            return 0
+        fi
+    done
+    return 1
+}
+
+wwan_has_ip() {
+    [[ -n "$WWAN_IFACE" ]] && ip addr show "$WWAN_IFACE" 2>/dev/null | grep -q "inet "
+}
+
+wwan_can_ping() {
+    [[ -n "$WWAN_IFACE" ]] && ping -I "$WWAN_IFACE" -c 2 -W 5 8.8.8.8 &>/dev/null
+}
+
+wifi_gateway() {
+    # Возвращает gateway WiFi
+    ip route show dev "$WIFI_IFACE" 2>/dev/null | grep default | awk '{print $3}' | head -1
+}
+
+wwan_gateway() {
+    ip route show dev "$WWAN_IFACE" 2>/dev/null | grep default | awk '{print $3}' | head -1
+}
+
+reconnect_qmi() {
+    local now
+    now=$(date +%s)
+    if (( now - LAST_RECONNECT < RECONNECT_COOLDOWN )); then
+        return 1
+    fi
+    LAST_RECONNECT=$now
+
+    log "QMI reconnect: поднимаем wwan0..."
+
+    # Если интерфейс уже UP — не трогаем link, только переподключаем data
+    if ! ip link show "$WWAN_IFACE" 2>/dev/null | grep -q "UP"; then
+        ip link set "$WWAN_IFACE" down 2>/dev/null || true
+        echo Y > "/sys/class/net/$WWAN_IFACE/qmi/raw_ip" 2>/dev/null || true
+        ip link set "$WWAN_IFACE" up
+    fi
+
+    # Останавливаем старое соединение
+    qmicli -d "$QMI_DEV" --wds-stop-network=disable-autoconnect 2>/dev/null || true
+
+    # Подключаемся
+    local output
+    output=$(qmicli -d "$QMI_DEV" \
+        --wds-start-network="apn=$APN,ip-type=4" \
+        --client-no-release-cid 2>&1) || {
+        log "QMI connect failed: $output"
+        return 1
+    }
+
+    # Получаем IP через QMI
+    sleep 2
+    local wds_info ip gw prefix prefixlen
+    wds_info=$(qmicli -d "$QMI_DEV" --wds-get-current-settings 2>&1) || return 1
+
+    ip=$(echo "$wds_info" | grep -oP 'IPv4 address: \K[\d.]+')
+    gw=$(echo "$wds_info" | grep -oP 'IPv4 gateway address: \K[\d.]+')
+    prefix=$(echo "$wds_info" | grep -oP 'IPv4 subnet mask: \K[\d.]+' || echo "255.255.255.0")
+
+    if [[ -z "$ip" ]]; then
+        log "QMI: IP не получен"
+        return 1
+    fi
+
+    prefixlen=$(python3 -c "import ipaddress; print(ipaddress.IPv4Network('0.0.0.0/$prefix').prefixlen)" 2>/dev/null || echo "24")
+
+    ip addr flush dev "$WWAN_IFACE" 2>/dev/null || true
+    ip addr add "$ip/$prefixlen" dev "$WWAN_IFACE" 2>/dev/null || true
+    if [[ -n "$gw" ]]; then
+        ip route add default via "$gw" dev "$WWAN_IFACE" metric 800 2>/dev/null || true
+    fi
+
+    log "QMI connected: $ip via $gw on $WWAN_IFACE"
+    return 0
+}
+
+set_vpn_route_via_wwan() {
+    if [[ "$VPN_ROUTE_VIA" == "wwan" ]]; then
+        return 0  # Уже через wwan
+    fi
+    local gw
+    gw=$(wwan_gateway)
+    if [[ -z "$gw" ]]; then
+        log "WARN: нет gateway для wwan, не могу переключить VPN маршрут"
+        return 1
+    fi
+
+    # Удаляем старый маршрут и ставим через wwan
+    ip route del "$VPN_SERVER" 2>/dev/null || true
+    ip route add "$VPN_SERVER" via "$gw" dev "$WWAN_IFACE" 2>/dev/null || {
+        log "ERR: не удалось добавить маршрут $VPN_SERVER via $gw dev $WWAN_IFACE"
+        return 1
+    }
+
+    VPN_ROUTE_VIA="wwan"
+    log "VPN маршрут → wwan0 ($gw)"
+}
+
+set_vpn_route_via_wifi() {
+    if [[ "$VPN_ROUTE_VIA" == "wifi" ]]; then
+        return 0
+    fi
+    local gw
+    gw=$(wifi_gateway)
+    if [[ -z "$gw" ]]; then
+        return 1
+    fi
+
+    ip route del "$VPN_SERVER" 2>/dev/null || true
+    ip route add "$VPN_SERVER" via "$gw" dev "$WIFI_IFACE" 2>/dev/null || {
+        return 1
+    }
+
+    VPN_ROUTE_VIA="wifi"
+    log "VPN маршрут → WiFi ($gw)"
+}
+
+detect_current_vpn_route() {
+    local route
+    route=$(ip route show "$VPN_SERVER" 2>/dev/null)
+    if echo "$route" | grep -q "$WWAN_IFACE" 2>/dev/null; then
+        VPN_ROUTE_VIA="wwan"
+    elif [[ -n "$WIFI_IFACE" ]] && echo "$route" | grep -q "$WIFI_IFACE" 2>/dev/null; then
+        VPN_ROUTE_VIA="wifi"
+    else
+        VPN_ROUTE_VIA="unknown"
+    fi
+}
+
+# === Main loop ===
+log "Запуск монитора мобильного интернета"
+log "QMI: $QMI_DEV, APN: $APN, VPN: $VPN_SERVER"
+
+if [[ $EUID -ne 0 ]]; then
+    log "WARN: запущен без root — переключение маршрутов не будет работать"
+fi
+
+while true; do
+    find_wwan || { log "wwan интерфейс не найден"; sleep "$CHECK_INTERVAL"; continue; }
+    find_wifi  # WiFi может отсутствовать — это нормально
+
+    detect_current_vpn_route
+
+    # 1. Проверяем wwan0
+    if ! wwan_has_ip; then
+        log "wwan0 без IP — пробуем переподключить QMI"
+        reconnect_qmi && sleep 5  # Даём время на установку соединения
+    fi
+
+    # 2. Проверяем connectivity (только если есть IP)
+    WWAN_ONLINE=false
+    if wwan_has_ip; then
+        if wwan_can_ping; then
+            WWAN_ONLINE=true
+        else
+            log "wwan0 имеет IP но не пингует — пробуем реконнект"
+            reconnect_qmi && sleep 5
+            # Повторная проверка после реконнекта
+            wwan_can_ping && WWAN_ONLINE=true
+        fi
+    fi
+
+    # 3. Логика маршрутизации VPN
+    if find_wifi; then
+        # WiFi есть — VPN через WiFi (приоритетнее)
+        set_vpn_route_via_wifi
+    elif $WWAN_ONLINE; then
+        # WiFi нет, wwan работает — VPN через wwan
+        set_vpn_route_via_wwan
+    else
+        log "WARN: ни WiFi ни wwan не доступны для VPN"
+    fi
+
+    sleep "$CHECK_INTERVAL"
+done

--- a/scripts/mobile-internet.service
+++ b/scripts/mobile-internet.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=SIM7600E-H Mobile Internet Monitor
+Documentation=https://github.com/ShaerWare/AI_Secretary_System
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/bin/bash /home/shaerware/Documents/AI_Secretary_System/scripts/mobile-internet-monitor.sh
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=mobile-inet
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/setup_mobile_internet.sh
+++ b/scripts/setup_mobile_internet.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+# Настройка мобильного интернета через SIM7600E-H (QMI)
+#
+# Использование:
+#   sudo bash scripts/setup_mobile_internet.sh start   # Поднять интернет
+#   sudo bash scripts/setup_mobile_internet.sh stop    # Отключить
+#   sudo bash scripts/setup_mobile_internet.sh status  # Проверить
+#
+# Требует: libqmi-utils, udhcpc или dhclient
+
+set -euo pipefail
+
+QMI_DEV="/dev/cdc-wdm2"
+APN="internet"
+IFACE="wwan0"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_ok()   { echo -e "${GREEN}[OK]${NC} $1"; }
+log_err()  { echo -e "${RED}[ERR]${NC} $1"; }
+log_info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+check_root() {
+    if [[ $EUID -ne 0 ]]; then
+        log_err "Нужен root. Запустите: sudo $0 $1"
+        exit 1
+    fi
+}
+
+find_wwan_iface() {
+    # SIM7600 creates wwan0 or similar interface
+    for iface in wwan0 wwan1 usb0; do
+        if ip link show "$iface" &>/dev/null; then
+            IFACE="$iface"
+            return 0
+        fi
+    done
+    # Try to find by driver
+    for path in /sys/class/net/*/device/driver; do
+        if [[ -e "$path" ]] && readlink -f "$path" | grep -q "qmi_wwan\|cdc_ether"; then
+            IFACE=$(echo "$path" | cut -d'/' -f5)
+            return 0
+        fi
+    done
+    return 1
+}
+
+do_start() {
+    check_root "start"
+
+    log_info "Поиск QMI устройства..."
+    if [[ ! -e "$QMI_DEV" ]]; then
+        log_err "QMI устройство $QMI_DEV не найдено"
+        exit 1
+    fi
+    log_ok "QMI: $QMI_DEV"
+
+    log_info "Поиск сетевого интерфейса..."
+    if ! find_wwan_iface; then
+        log_err "Не найден wwan интерфейс (wwan0/usb0)"
+        log_info "Попробуйте: modprobe qmi_wwan"
+        exit 1
+    fi
+    log_ok "Интерфейс: $IFACE"
+
+    # Check if already connected
+    if ip addr show "$IFACE" 2>/dev/null | grep -q "inet "; then
+        log_info "Интерфейс $IFACE уже имеет IP адрес"
+        ip addr show "$IFACE" | grep "inet "
+        return 0
+    fi
+
+    # Set interface raw IP mode (required for QMI)
+    log_info "Настройка raw IP mode..."
+    ip link set "$IFACE" down 2>/dev/null || true
+    echo Y > "/sys/class/net/$IFACE/qmi/raw_ip" 2>/dev/null || true
+    ip link set "$IFACE" up
+
+    # Stop any existing QMI connection
+    qmicli -d "$QMI_DEV" --wds-stop-network=disable-autoconnect 2>/dev/null || true
+
+    # Start QMI network connection
+    log_info "Подключение к сети (APN: $APN)..."
+    OUTPUT=$(qmicli -d "$QMI_DEV" \
+        --wds-start-network="apn=$APN,ip-type=4" \
+        --client-no-release-cid 2>&1) || {
+        log_err "Не удалось подключиться: $OUTPUT"
+        exit 1
+    }
+
+    # Extract packet data handle
+    HANDLE=$(echo "$OUTPUT" | grep -oP 'Packet data handle: \K\d+' || echo "")
+    CID=$(echo "$OUTPUT" | grep -oP 'CID: \K\d+' || echo "")
+    log_ok "Подключено (handle=$HANDLE, cid=$CID)"
+
+    # Save handle for stop
+    echo "$HANDLE:$CID" > /tmp/qmi_connection_info
+
+    # Get IP via DHCP
+    log_info "Получение IP адреса (udhcpc/dhclient)..."
+    if command -v udhcpc &>/dev/null; then
+        udhcpc -i "$IFACE" -f -q -n 2>&1 || {
+            log_info "udhcpc не сработал, пробуем через QMI..."
+            _get_ip_from_qmi
+        }
+    elif command -v dhclient &>/dev/null; then
+        dhclient -1 "$IFACE" 2>&1 || {
+            log_info "dhclient не сработал, пробуем через QMI..."
+            _get_ip_from_qmi
+        }
+    else
+        log_info "DHCP клиент не найден, получаем IP через QMI..."
+        _get_ip_from_qmi
+    fi
+
+    # Verify
+    if ip addr show "$IFACE" | grep -q "inet "; then
+        IP=$(ip addr show "$IFACE" | grep -oP 'inet \K[\d.]+')
+        log_ok "IP адрес: $IP на $IFACE"
+    else
+        log_err "IP адрес не получен"
+        exit 1
+    fi
+
+    log_ok "Мобильный интернет активен на $IFACE"
+    echo ""
+    log_info "Для маршрутизации всего трафика:"
+    echo "  sudo ip route add default via $IP dev $IFACE metric 100"
+    log_info "Для проверки:"
+    echo "  ping -I $IFACE 8.8.8.8"
+}
+
+_get_ip_from_qmi() {
+    # Get IP settings directly from QMI
+    WDS_INFO=$(qmicli -d "$QMI_DEV" --wds-get-current-settings 2>&1) || return 1
+
+    IP=$(echo "$WDS_INFO" | grep -oP 'IPv4 address: \K[\d.]+' || echo "")
+    GW=$(echo "$WDS_INFO" | grep -oP 'IPv4 gateway address: \K[\d.]+' || echo "")
+    DNS1=$(echo "$WDS_INFO" | grep -oP 'IPv4 primary DNS: \K[\d.]+' || echo "")
+    DNS2=$(echo "$WDS_INFO" | grep -oP 'IPv4 secondary DNS: \K[\d.]+' || echo "")
+    PREFIX=$(echo "$WDS_INFO" | grep -oP 'IPv4 subnet mask: \K[\d.]+' || echo "255.255.255.0")
+
+    if [[ -z "$IP" ]]; then
+        log_err "Не удалось получить IP из QMI"
+        return 1
+    fi
+
+    # Calculate prefix length from subnet mask
+    PREFIXLEN=$(python3 -c "
+import ipaddress
+print(ipaddress.IPv4Network('0.0.0.0/$PREFIX').prefixlen)
+" 2>/dev/null || echo "24")
+
+    ip addr add "$IP/$PREFIXLEN" dev "$IFACE" 2>/dev/null || true
+
+    if [[ -n "$GW" ]]; then
+        ip route add default via "$GW" dev "$IFACE" metric 700 2>/dev/null || true
+    fi
+
+    # Set DNS
+    if [[ -n "$DNS1" ]]; then
+        log_info "DNS: $DNS1 ${DNS2:+$DNS2}"
+    fi
+}
+
+do_stop() {
+    check_root "stop"
+
+    log_info "Отключение мобильного интернета..."
+
+    # Read saved connection info
+    if [[ -f /tmp/qmi_connection_info ]]; then
+        IFS=: read -r HANDLE CID < /tmp/qmi_connection_info
+        qmicli -d "$QMI_DEV" \
+            --wds-stop-network="$HANDLE" \
+            --client-cid="$CID" 2>/dev/null || true
+        rm -f /tmp/qmi_connection_info
+    else
+        qmicli -d "$QMI_DEV" --wds-stop-network=disable-autoconnect 2>/dev/null || true
+    fi
+
+    find_wwan_iface 2>/dev/null || true
+    ip addr flush dev "$IFACE" 2>/dev/null || true
+    ip link set "$IFACE" down 2>/dev/null || true
+
+    log_ok "Мобильный интернет отключен"
+}
+
+do_status() {
+    echo "=== QMI устройство ==="
+    if [[ -e "$QMI_DEV" ]]; then
+        log_ok "$QMI_DEV существует"
+    else
+        log_err "$QMI_DEV не найден"
+        return
+    fi
+
+    echo ""
+    echo "=== Сетевой интерфейс ==="
+    if find_wwan_iface; then
+        log_ok "Интерфейс: $IFACE"
+        ip addr show "$IFACE" 2>/dev/null | grep -E "inet |state "
+    else
+        log_err "wwan интерфейс не найден"
+    fi
+
+    echo ""
+    echo "=== QMI статус ==="
+    if [[ $EUID -eq 0 ]]; then
+        qmicli -d "$QMI_DEV" --wds-get-packet-service-status 2>/dev/null || log_err "QMI запрос не удался"
+        echo ""
+        qmicli -d "$QMI_DEV" --wds-get-current-settings 2>/dev/null || true
+    else
+        log_info "Для полного статуса запустите: sudo $0 status"
+        # At least show interface info
+        if find_wwan_iface; then
+            if ip addr show "$IFACE" 2>/dev/null | grep -q "inet "; then
+                log_ok "IP есть — интернет вероятно активен"
+            else
+                log_info "IP нет — интернет не подключен"
+            fi
+        fi
+    fi
+}
+
+case "${1:-status}" in
+    start)  do_start ;;
+    stop)   do_stop ;;
+    status) do_status ;;
+    *)
+        echo "Использование: $0 {start|stop|status}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

- Скрипт `setup_mobile_internet.sh` — ручное управление мобильным интернетом через SIM7600E-H (QMI start/stop/status)
- Скрипт `mobile-internet-monitor.sh` — daemon, который держит wwan0 поднятым и автоматически переключает VPN-маршрут между WiFi и wwan при потере связи
- Systemd unit `mobile-internet.service` для постоянной работы монитора
- Обновлён `CLAUDE.md` — добавлена секция Mobile Internet

Relates to #560

## NEWS

📡 **Мобильный интернет — автоматическое резервирование**

Добавлены скрипты для автономной работы через SIM7600E-H модем.
Система автоматически поднимает мобильный интернет через QMI и
переключает VPN-маршрут на мобильную сеть, если WiFi пропал.
Когда WiFi возвращается — маршрут переключается обратно. Работает как systemd-сервис 24/7.

## Test plan

- [ ] `sudo bash scripts/setup_mobile_internet.sh status` — проверить обнаружение QMI устройства
- [ ] `sudo bash scripts/setup_mobile_internet.sh start` — подключение wwan0
- [ ] `sudo bash scripts/mobile-internet-monitor.sh` — запуск монитора, проверить переключение маршрутов
- [ ] Отключить WiFi — убедиться что VPN маршрут переключился на wwan
- [ ] Включить WiFi обратно — маршрут вернулся на WiFi

🤖 Generated with [Claude Code](https://claude.com/claude-code)