### PR TITLE
docs: Phase 4.6 documentation update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,10 +135,10 @@ Always run lint locally before pushing. Protected branches require PR workflow �
 
 ### Modular Infrastructure (`modules/`)
 
-Foundation layer for modular decomposition (issue #489). Phases 0–3 complete (all 28 routers migrated). Phase 4 (orchestrator decomposition) in progress.
+Foundation layer for modular decomposition (issue #489). Phases 0–4.6 complete: all 28 routers migrated (Phase 3), all inline endpoints extracted from `orchestrator.py` (Phase 4.1–4.5), all background tasks migrated to `TaskRegistry` (Phase 4.6). Phase 5 (EventBus events) and Phase 6 (protocol interfaces) pending.
 
 - **`EventBus`** (`modules/core/events.py`): In-process async pub/sub. Handlers run concurrently via `asyncio.gather`; exceptions are logged, never propagated to publisher. `BaseEvent` dataclass with auto-timestamp.
-- **`TaskRegistry`** (`modules/core/tasks.py`): Named background tasks — periodic (interval-based) or one-shot. `start_all()` / `cancel_all(timeout)` lifecycle. `TaskInfo` dataclass tracks status, run count, last error.
+- **`TaskRegistry`** (`modules/core/tasks.py`): Named background tasks — periodic (interval-based) or one-shot. `start_all()` / `cancel_all(timeout)` lifecycle. `TaskInfo` dataclass tracks status, run count, last error. 6 tasks registered in `startup_event()`: `session-cleanup` (1h), `periodic-vacuum` (7d), `kanban-sync` (15min), `woocommerce-sync` (daily 23:00 UTC), `wiki-embeddings` (one-shot), `wiki-collection-indexes` (one-shot). Task functions in `modules/core/maintenance.py`, `modules/knowledge/tasks.py`, `modules/kanban/tasks.py`, `modules/ecommerce/tasks.py`.
 - **`HealthRegistry`** (`modules/core/health.py`): Modular health checks with per-check timeout (`asyncio.wait_for`). Status aggregation: all ok → ok, any degraded → degraded, any error → error.
 
 - **`InternetMonitor`** (`modules/core/internet_monitor.py`): Periodic connectivity checker (ping DNS/Cloudflare). Auto-switches LLM backend: online → cloud provider (claude_bridge priority), offline → local vLLM. Publishes `InternetStatusChanged` events via EventBus. Configurable thresholds, 30s default interval. Status endpoint: `GET /admin/gsm/internet-status`. Health check includes `internet` section.
@@ -210,7 +210,7 @@ New routers import domain services directly (`from modules.monitoring.service im
 
 ### Key Components
 
-**`orchestrator.py`** (~1121 lines): FastAPI entry point. **Zero inline endpoints** — all extracted to module routers. Contains: imports, middleware, router registration, global service variables, startup/shutdown lifecycle, static file serving. Extracted: `StreamingTTSManager` → `modules/speech/streaming.py` (Phase 4.1), widget public endpoints → `modules/channels/widget/router_public.py` (Phase 4.2), legacy telephony + OpenAI-compat + core health → `modules/compat/router.py` + `modules/core/router_health.py` (Phase 4.3), finetune endpoints → `modules/llm/router_finetune.py` + `modules/speech/router_finetune.py` (Phase 4.4), remaining admin endpoints (voices, models, logs) → `modules/speech/router_voices.py` + `modules/llm/router_models.py` + `modules/monitoring/router_logs.py` (Phase 4.5).
+**`orchestrator.py`** (~1030 lines): FastAPI entry point. **Zero inline endpoints** — all business logic extracted to `modules/*/router*.py` (Phase 4.1–4.5). **Zero raw `asyncio.create_task()`** — all background tasks via `TaskRegistry` (Phase 4.6). Contains only: imports, CORS/middleware, router registration (~28 `include_router` calls), global service variables, `startup_event()` (~260 lines, initializes services + registers tasks), `shutdown_event()` (cancel tasks + close DB), static file serving, Vite dev proxy.
 
 **`ServiceContainer` (`app/dependencies.py`)**: Singleton holding references to all initialized services. Routers get services via FastAPI `Depends`. Populated during app startup.
 

--- a/wiki-pages/Architecture.md
+++ b/wiki-pages/Architecture.md
@@ -591,6 +591,29 @@ from modules.kanban.service import kanban_service as async_kanban_manager
 
 **Результат:** orchestrator.py: 2471 → 1121 строк (−1350). Содержит: импорты, middleware, регистрацию роутеров, глобальные сервисные переменные, startup/shutdown lifecycle, раздачу статических файлов.
 
+### Phase 4.6: Background tasks → TaskRegistry
+
+> **Статус:** реализовано (PR [#578](https://github.com/ShaerWare/AI_Secretary_System/pull/578), issue [#551](https://github.com/ShaerWare/AI_Secretary_System/issues/551))
+
+Перенос 6 фоновых задач из `asyncio.create_task()` в `TaskRegistry` (инфраструктура Phase 0).
+
+**Новые файлы:**
+
+| Файл | Задачи | Тип |
+|------|--------|-----|
+| `modules/core/maintenance.py` | `cleanup_expired_sessions` (1ч), `periodic_vacuum` (7д, initial_delay=24ч) | periodic |
+| `modules/knowledge/tasks.py` | `build_wiki_embeddings`, `load_collection_indexes` | one-shot |
+| `modules/kanban/tasks.py` | `sync_kanban_issues` (15мин, initial_delay=60с) | periodic |
+| `modules/ecommerce/tasks.py` | `woocommerce_daily_sync` (ежедневно 23:00 UTC) | one-shot с внутренним cron |
+
+**Ключевые решения:**
+- WooCommerce sync зарегистрирован как one-shot (управляет своим расписанием внутри), т.к. TaskRegistry не поддерживает cron
+- Wiki RAG задачи используют `functools.partial(fn, wiki_rag)` для передачи сервиса
+- Core maintenance в отдельном `maintenance.py` (не `tasks.py`), чтобы не путать с инфраструктурой TaskRegistry
+- `task_registry.cancel_all()` добавлен в `shutdown_event()` для graceful shutdown
+
+**Результат:** orchestrator.py: 1121 → 1030 строк (−91). Удалены `asyncio`, `datetime`, `timedelta` из импортов.
+
 ---
 
 ## Тесты
@@ -620,7 +643,7 @@ pytest tests/unit/test_event_bus.py tests/unit/test_task_registry.py tests/unit/
 | **1** | Разделение `db/models.py` → доменные модули | [#491](https://github.com/ShaerWare/AI_Secretary_System/issues/491) | ✅ Завершена |
 | **2** | Разделение `db/integration.py` → доменные сервисы + фасад | [#492](https://github.com/ShaerWare/AI_Secretary_System/issues/492) | ✅ Завершена (#501, #502, #503) |
 | **3** | Перенос роутеров в доменные модули | [#493](https://github.com/ShaerWare/AI_Secretary_System/issues/493) | ✅ Завершена (#508 ✅, #509 ✅, #510 ✅, #511 ✅, #512 ✅, #513 ✅, #514) |
-| **4** | Декомпозиция `orchestrator.py` | [#494](https://github.com/ShaerWare/AI_Secretary_System/issues/494) | 🔄 4.1 ✅ 4.2 ✅ 4.3 ✅ 4.4 ✅ 4.5 ✅ |
+| **4** | Декомпозиция `orchestrator.py` | [#494](https://github.com/ShaerWare/AI_Secretary_System/issues/494) | 🔄 4.1 ✅ 4.2 ✅ 4.3 ✅ 4.4 ✅ 4.5 ✅ 4.6 ✅ |
 | **5** | Внедрение EventBus-событий | [#495](https://github.com/ShaerWare/AI_Secretary_System/issues/495) | ⏳ |
 | **6** | Протокольные интерфейсы | [#496](https://github.com/ShaerWare/AI_Secretary_System/issues/496) | ⏳ |
 


### PR DESCRIPTION
## Summary
- Update CLAUDE.md: orchestrator.py 1121 → 1030 lines, document TaskRegistry usage and 4 new task files
- Update wiki Architecture.md: add Phase 4.6 section, update status to 4.6 ✅

## Test plan
- [x] Documentation only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)