### PR TITLE
feat: paste detection in chat — collapsible code attachments

### DIFF
--- a/admin/src/plugins/i18n.ts
+++ b/admin/src/plugins/i18n.ts
@@ -368,6 +368,8 @@ const messages = {
       zenMode: "Фокус-режим",
       exitZenMode: "Выйти из фокус-режима",
       zenSettings: "Настройки чата",
+      pastedLines: "{count} строк",
+      removePasted: "Удалить вложение",
       claudeCode: {
         enable: "Включить Claude Code",
         disable: "Выключить Claude Code",
@@ -1699,6 +1701,8 @@ const messages = {
       zenMode: "Focus mode",
       exitZenMode: "Exit focus mode",
       zenSettings: "Chat settings",
+      pastedLines: "{count} lines",
+      removePasted: "Remove attachment",
       claudeCode: {
         enable: "Enable Claude Code",
         disable: "Disable Claude Code",
@@ -3030,6 +3034,8 @@ const messages = {
       zenMode: "Фокус режимі",
       exitZenMode: "Фокус режимінен шығу",
       zenSettings: "Чат параметрлері",
+      pastedLines: "{count} жол",
+      removePasted: "Тіркемені жою",
       claudeCode: {
         enable: "Claude Code қосу",
         disable: "Claude Code өшіру",

--- a/admin/src/utils/pasteDetect.ts
+++ b/admin/src/utils/pasteDetect.ts
@@ -1,0 +1,71 @@
+export interface PastedBlock {
+  id: string
+  content: string
+  language: string
+  languageLabel: string
+  lineCount: number
+}
+
+export const PASTE_THRESHOLD_LINES = 5
+export const PASTE_THRESHOLD_CHARS = 500
+
+export function shouldTreatAsPaste(text: string): boolean {
+  const lineCount = text.split('\n').length
+  return lineCount >= PASTE_THRESHOLD_LINES || text.length >= PASTE_THRESHOLD_CHARS
+}
+
+const LANGUAGE_RULES: Array<{ key: string; label: string; test: (t: string) => boolean }> = [
+  { key: 'python', label: 'Python', test: t => /^(import |from .+ import |def |class |if __name__|@\w+)/.test(t) || /\bself\b/.test(t) },
+  { key: 'typescript', label: 'TypeScript', test: t => /^(import .+ from |export (interface|type|const|function|class|enum)|interface \w+|type \w+ =)/.test(t) || /: (string|number|boolean|void)\b/.test(t) },
+  { key: 'javascript', label: 'JavaScript', test: t => /^(import |export |const |let |var |function |class |module\.exports)/.test(t) || /=>\s*[{(]/.test(t) },
+  { key: 'tsx', label: 'TSX', test: t => /^import .+ from/.test(t) && /<\w+[\s/>]/.test(t) },
+  { key: 'jsx', label: 'JSX', test: t => /^(import |const |function )/.test(t) && /<\w+[\s/>]/.test(t) },
+  { key: 'php', label: 'PHP', test: t => /^<\?php|^\$\w+\s*=|\bfunction\s+\w+\s*\(/.test(t) && /;$/.test(t.split('\n')[0] || '') },
+  { key: 'java', label: 'Java', test: t => /^(package |import java\.|public (class|interface|enum)|private |protected )/.test(t) },
+  { key: 'go', label: 'Go', test: t => /^(package |import \(|func |type \w+ struct)/.test(t) },
+  { key: 'rust', label: 'Rust', test: t => /^(use |mod |fn |pub (fn|struct|enum|mod)|impl |let mut |#\[)/.test(t) },
+  { key: 'sql', label: 'SQL', test: t => /^(SELECT|INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|WITH)\b/i.test(t) },
+  { key: 'html', label: 'HTML', test: t => /^<!DOCTYPE|^<html|^<div|^<section|^<template/i.test(t) },
+  { key: 'css', label: 'CSS', test: t => /^(\.|#|@media|@import|:root|\w+\s*\{)/.test(t) && /\{[\s\S]*\}/.test(t) },
+  { key: 'bash', label: 'Bash', test: t => /^(#!\/bin\/(ba)?sh|set -|export |if \[|for \w+ in|sudo |apt |npm |yarn |pip )/.test(t) },
+  { key: 'yaml', label: 'YAML', test: t => /^\w+:\s*(\n|$)/.test(t) && !/[{};]/.test(t.split('\n')[0] || '') },
+  { key: 'json', label: 'JSON', test: t => /^\s*[[{]/.test(t) && (() => { try { JSON.parse(t); return true } catch { return false } })() },
+  { key: 'dockerfile', label: 'Dockerfile', test: t => /^(FROM |RUN |CMD |COPY |WORKDIR |EXPOSE |ENV |ARG |ENTRYPOINT )/i.test(t) },
+  { key: 'markdown', label: 'Markdown', test: t => /^(#{1,6} |\* |- |\d+\. |> |```|\[.+\]\(.+\))/.test(t) },
+]
+
+export function detectLanguage(text: string): { key: string; label: string } {
+  const trimmed = text.trim()
+  for (const rule of LANGUAGE_RULES) {
+    if (rule.test(trimmed)) {
+      return { key: rule.key, label: rule.label }
+    }
+  }
+  return { key: 'text', label: 'Text' }
+}
+
+let counter = 0
+
+export function createPastedBlock(text: string): PastedBlock {
+  const { key, label } = detectLanguage(text)
+  return {
+    id: `paste-${Date.now()}-${++counter}`,
+    content: text,
+    language: key,
+    languageLabel: label,
+    lineCount: text.split('\n').length,
+  }
+}
+
+export function buildMessageContent(text: string, blocks: PastedBlock[]): string {
+  if (blocks.length === 0) return text
+
+  const parts: string[] = []
+  for (const block of blocks) {
+    parts.push(`\`\`\`${block.language}\n${block.content}\n\`\`\``)
+  }
+  if (text) {
+    parts.push(text)
+  }
+  return parts.join('\n\n')
+}

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -84,6 +84,7 @@ import { claudeCodeApi, type CcProject, type CcProjectInput } from '@/api/claude
 import { kanbanApi, type KanbanTask } from '@/api/kanban'
 import { useResizablePanel } from '@/composables/useResizablePanel'
 import { getChatEmoji } from '@/utils/chatEmoji'
+import { shouldTreatAsPaste, createPastedBlock, buildMessageContent, type PastedBlock } from '@/utils/pasteDetect'
 import { useChatFullscreenStore } from '@/stores/chatFullscreen'
 
 const { t } = useI18n()
@@ -154,6 +155,20 @@ const { width: branchTreeWidth, startResize: startBranchResize, startTouchResize
 const { width: settingsWidth, startResize: startSettingsResize, startTouchResize: startSettingsTouchResize } = useResizablePanel('chat-settings-width', 500, 300, 800, 'left')
 const { width: artifactWidth, startResize: startArtifactResize, startTouchResize: startArtifactTouchResize } = useResizablePanel('chat-artifact-width', 500, 300, 800, 'left')
 
+// Pasted content blocks
+const pastedBlocks = ref<PastedBlock[]>([])
+
+function onPaste(e: ClipboardEvent) {
+  const text = e.clipboardData?.getData('text/plain')
+  if (!text || !shouldTreatAsPaste(text)) return
+  e.preventDefault()
+  pastedBlocks.value.push(createPastedBlock(text))
+}
+
+function removePastedBlock(id: string) {
+  pastedBlocks.value = pastedBlocks.value.filter(b => b.id !== id)
+}
+
 // Artifact viewer state
 const showArtifact = ref(false)
 const activeArtifact = ref<Artifact | null>(null)
@@ -202,6 +217,13 @@ function handleMessagesClick(e: MouseEvent) {
       navigator.clipboard.writeText(code)
       toastStore.success(t('common.copied'))
     }
+    return
+  }
+
+  // Handle code-block expand/collapse toggle
+  const codeContainer = target.closest('.code-block-container') as HTMLElement | null
+  if (codeContainer && !target.closest('button') && !target.closest('a')) {
+    codeContainer.classList.toggle('expanded')
     return
   }
 
@@ -967,10 +989,13 @@ async function deleteCcSession(ccSessionId: string, title: string, event: Event)
 }
 
 function sendMessage() {
-  if (!inputMessage.value.trim() || !currentSessionId.value || isStreaming.value) return
+  const hasText = inputMessage.value.trim().length > 0
+  const hasPaste = pastedBlocks.value.length > 0
+  if ((!hasText && !hasPaste) || !currentSessionId.value || isStreaming.value) return
 
-  const content = inputMessage.value.trim()
+  const content = buildMessageContent(inputMessage.value.trim(), pastedBlocks.value)
   inputMessage.value = ''
+  pastedBlocks.value = []
   if (messageInputRef.value) messageInputRef.value.style.height = 'auto'
 
   // Show user message immediately (optimistic)
@@ -1042,9 +1067,12 @@ function sendMessage() {
 }
 
 function ccSendMessage() {
-  if (!inputMessage.value.trim() || cc.isProcessing.value) return
-  const prompt = inputMessage.value.trim()
+  const hasText = inputMessage.value.trim().length > 0
+  const hasPaste = pastedBlocks.value.length > 0
+  if ((!hasText && !hasPaste) || cc.isProcessing.value) return
+  const prompt = buildMessageContent(inputMessage.value.trim(), pastedBlocks.value)
   inputMessage.value = ''
+  pastedBlocks.value = []
   if (messageInputRef.value) messageInputRef.value.style.height = 'auto'
   cc.sendMessage(prompt)
   nextTick(() => {
@@ -2760,6 +2788,25 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
           <span v-if="cc.currentModel.value" class="text-muted-foreground ml-1">· {{ cc.currentModel.value }}</span>
         </div>
         <div v-if="cc.error.value" class="mb-2 text-xs text-red-500">{{ cc.error.value }}</div>
+        <!-- Pasted blocks chips -->
+        <div v-if="pastedBlocks.length" class="flex flex-wrap gap-2 mb-2">
+          <div
+            v-for="block in pastedBlocks"
+            :key="block.id"
+            class="flex items-center gap-1.5 px-2.5 py-1.5 bg-secondary rounded-lg border border-border text-xs"
+          >
+            <FileText class="w-3.5 h-3.5 text-green-500 shrink-0" />
+            <span class="font-medium text-green-400">{{ block.languageLabel }}</span>
+            <span class="text-muted-foreground">{{ t('chatView.pastedLines', { count: block.lineCount }) }}</span>
+            <button
+              class="ml-1 p-0.5 rounded hover:bg-destructive/20 text-muted-foreground hover:text-destructive transition-colors"
+              :title="t('chatView.removePasted')"
+              @click="removePastedBlock(block.id)"
+            >
+              <X class="w-3 h-3" />
+            </button>
+          </div>
+        </div>
         <div class="flex gap-3 items-end">
           <textarea
             ref="messageInputRef"
@@ -2771,6 +2818,7 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
             @keydown.enter.exact.prevent="ccSendMessage"
             @keydown.ctrl.enter.prevent="ccSendMessage"
             @input="onInputAutoResize"
+            @paste="onPaste"
           />
           <!-- Abort button (while processing) -->
           <button
@@ -2784,7 +2832,7 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
           <!-- Send button -->
           <button
             v-else
-            :disabled="!inputMessage.trim() || !cc.isConnected.value"
+            :disabled="(!inputMessage.trim() && !pastedBlocks.length) || !cc.isConnected.value"
             class="p-3 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 transition-colors"
             @click="ccSendMessage"
           >
@@ -2812,6 +2860,25 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
           inputPosition === 'bottom' ? 'border-t border-border order-last' + (fullscreenStore.isFullscreen ? '' : ' pb-24') : 'border-b border-border'
         ]"
       >
+        <!-- Pasted blocks chips -->
+        <div v-if="pastedBlocks.length" class="flex flex-wrap gap-2 mb-2 max-w-3xl mx-auto">
+          <div
+            v-for="block in pastedBlocks"
+            :key="block.id"
+            class="flex items-center gap-1.5 px-2.5 py-1.5 bg-secondary rounded-lg border border-border text-xs"
+          >
+            <FileText class="w-3.5 h-3.5 text-primary shrink-0" />
+            <span class="font-medium">{{ block.languageLabel }}</span>
+            <span class="text-muted-foreground">{{ t('chatView.pastedLines', { count: block.lineCount }) }}</span>
+            <button
+              class="ml-1 p-0.5 rounded hover:bg-destructive/20 text-muted-foreground hover:text-destructive transition-colors"
+              :title="t('chatView.removePasted')"
+              @click="removePastedBlock(block.id)"
+            >
+              <X class="w-3 h-3" />
+            </button>
+          </div>
+        </div>
         <div
           :class="[
             'flex gap-3 max-w-3xl mx-auto',
@@ -2828,6 +2895,7 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
             @keydown.enter.exact.prevent="sendMessage"
             @keydown.ctrl.enter.prevent="sendMessage"
             @input="onInputAutoResize"
+            @paste="onPaste"
           />
           <!-- Microphone button -->
           <button
@@ -2847,7 +2915,7 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
           </button>
           <!-- Send button -->
           <button
-            :disabled="!inputMessage.trim() || isStreaming || isRecording"
+            :disabled="(!inputMessage.trim() && !pastedBlocks.length) || isStreaming || isRecording"
             class="p-3 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors"
             @click="sendMessage"
           >
@@ -3539,5 +3607,25 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
 .zen-messages {
   padding-left: 1rem;
   padding-right: 1rem;
+}
+
+/* Collapsible code blocks in user messages */
+.claude-message-user :deep(.code-block-container) {
+  position: relative;
+  cursor: pointer;
+}
+.claude-message-user :deep(.code-block-container:not(.expanded)) pre {
+  max-height: 200px;
+  overflow: hidden;
+}
+.claude-message-user :deep(.code-block-container:not(.expanded)) pre::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 60px;
+  background: linear-gradient(transparent, hsl(var(--secondary)));
+  pointer-events: none;
 }
 </style>

--- a/ai-secretary.service
+++ b/ai-secretary.service
@@ -1,7 +1,7 @@
 [Unit]
-Description=AI Secretary Orchestrator
-After=network.target docker.service
-Wants=docker.service
+Description=AI Secretary System (vLLM + XTTS + Orchestrator)
+After=network.target
+Wants=network.target
 
 [Service]
 Type=simple
@@ -10,11 +10,14 @@ Group=shaerware
 WorkingDirectory=/home/shaerware/Documents/AI_Secretary_System
 EnvironmentFile=/home/shaerware/Documents/AI_Secretary_System/.env
 Environment=COQUI_TOS_AGREED=1
-ExecStart=/home/shaerware/Documents/AI_Secretary_System/.venv/bin/python orchestrator.py
+ExecStart=/bin/bash /home/shaerware/Documents/AI_Secretary_System/start_gpu.sh
+ExecStop=/bin/kill -TERM $MAINPID
+KillMode=mixed
+KillSignal=SIGTERM
+TimeoutStartSec=300
+TimeoutStopSec=30
 Restart=on-failure
-RestartSec=10
-StandardOutput=append:/home/shaerware/Documents/AI_Secretary_System/logs/orchestrator.log
-StandardError=append:/home/shaerware/Documents/AI_Secretary_System/logs/orchestrator.log
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/mobile/src/api/chat.ts
+++ b/mobile/src/api/chat.ts
@@ -107,6 +107,17 @@ export const chatApi = {
       `/admin/chat/sessions/${sessionId}/messages/${messageId}`,
     ),
 
+  editMessage: (sessionId: string, messageId: string, content: string) =>
+    api.put<{ message: ChatMessage }>(
+      `/admin/chat/sessions/${sessionId}/messages/${messageId}`,
+      { content },
+    ),
+
+  summarizeBranch: (sessionId: string, messageId: string) =>
+    api.post<{ summary: string }>(
+      `/admin/chat/sessions/${sessionId}/messages/${messageId}/summarize`,
+    ),
+
   // Branches
   getBranches: (sessionId: string) =>
     api.get<{ branches: BranchNode[] }>(
@@ -122,6 +133,11 @@ export const chatApi = {
   newBranch: (sessionId: string) =>
     api.post<{ status: string; session: ChatSession }>(
       `/admin/chat/sessions/${sessionId}/branches/new`,
+    ),
+
+  regenerateResponse: (sessionId: string, messageId: string) =>
+    api.post<{ status: string }>(
+      `/admin/chat/sessions/${sessionId}/messages/${messageId}/regenerate`,
     ),
 
   streamMessage: (

--- a/mobile/src/components/ChatInput.vue
+++ b/mobile/src/components/ChatInput.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
 import { ref } from "vue";
+import {
+  shouldTreatAsPaste,
+  createPastedBlock,
+  buildMessageContent,
+  type PastedBlock,
+} from "@/utils/pasteDetect";
 
 defineProps<{
   disabled?: boolean;
@@ -13,12 +19,16 @@ const emit = defineEmits<{
 
 const input = ref("");
 const textarea = ref<HTMLTextAreaElement | null>(null);
+const pastedBlocks = ref<PastedBlock[]>([]);
 
 function handleSend() {
-  const content = input.value.trim();
-  if (!content) return;
+  const hasText = input.value.trim().length > 0;
+  const hasPaste = pastedBlocks.value.length > 0;
+  if (!hasText && !hasPaste) return;
+  const content = buildMessageContent(input.value.trim(), pastedBlocks.value);
   emit("send", content);
   input.value = "";
+  pastedBlocks.value = [];
   if (textarea.value) {
     textarea.value.style.height = "auto";
   }
@@ -36,12 +46,48 @@ function autoResize(e: Event) {
   el.style.height = "auto";
   el.style.height = Math.min(el.scrollHeight, 120) + "px";
 }
+
+function onPaste(e: ClipboardEvent) {
+  const text = e.clipboardData?.getData("text/plain");
+  if (!text || !shouldTreatAsPaste(text)) return;
+  e.preventDefault();
+  pastedBlocks.value.push(createPastedBlock(text));
+}
+
+function removePastedBlock(id: string) {
+  pastedBlocks.value = pastedBlocks.value.filter((b) => b.id !== id);
+}
 </script>
 
 <template>
   <div
     class="border-t border-stone-800 bg-stone-950/95 backdrop-blur px-4 py-3 safe-bottom"
   >
+    <!-- Pasted blocks chips -->
+    <div v-if="pastedBlocks.length" class="flex flex-wrap gap-2 mb-2">
+      <div
+        v-for="block in pastedBlocks"
+        :key="block.id"
+        class="flex items-center gap-1.5 px-2.5 py-1.5 bg-stone-800 rounded-lg border border-stone-700 text-xs"
+      >
+        <!-- file-code icon -->
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-amber-500 shrink-0">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" /><path d="m10 13-2 2 2 2" /><path d="m14 17 2-2-2-2" />
+        </svg>
+        <span class="font-medium text-amber-400">{{ block.languageLabel }}</span>
+        <span class="text-stone-500">{{ block.lineCount }} lines</span>
+        <button
+          class="ml-1 p-0.5 rounded hover:bg-red-900/30 text-stone-500 hover:text-red-400 transition-colors"
+          @click="removePastedBlock(block.id)"
+        >
+          <!-- X icon -->
+          <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+    </div>
+
     <div class="flex items-end gap-2">
       <textarea
         ref="textarea"
@@ -52,6 +98,7 @@ function autoResize(e: Event) {
         placeholder="Message..."
         @keydown="handleKeydown"
         @input="autoResize"
+        @paste="onPaste"
       />
 
       <!-- Stop button (during streaming) -->
@@ -75,7 +122,7 @@ function autoResize(e: Event) {
       <!-- Send button -->
       <button
         v-else
-        :disabled="disabled || !input.trim()"
+        :disabled="disabled || (!input.trim() && !pastedBlocks.length)"
         class="shrink-0 w-10 h-10 rounded-xl bg-amber-600 hover:bg-amber-700 disabled:bg-stone-700 disabled:text-stone-500 flex items-center justify-center transition-colors"
         @click="handleSend"
       >

--- a/mobile/src/components/MessageBubble.vue
+++ b/mobile/src/components/MessageBubble.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { ref, computed } from "vue";
 import type { ChatMessage } from "@/api/chat";
 import { renderMarkdown } from "@/utils/markdown";
 
@@ -12,12 +12,26 @@ const props = defineProps<{
 const emit = defineEmits<{
   speak: [text: string, id: string];
   stopSpeak: [];
+  copy: [text: string];
+  edit: [messageId: string, content: string];
+  saveToContext: [messageId: string, content: string];
+  summarizeBranch: [messageId: string];
+  deleteBranch: [messageId: string];
+  regenerate: [messageId: string];
 }>();
 
 const isUser = computed(() => props.message.role === "user");
+const isEditing = ref(false);
+const editContent = ref("");
+const copied = ref(false);
+
+const hasCodeBlock = computed(() => /```/.test(props.message.content));
 
 const renderedContent = computed(() => {
-  if (isUser.value) return props.message.content;
+  if (isUser.value) {
+    if (hasCodeBlock.value) return renderMarkdown(props.message.content);
+    return props.message.content;
+  }
   return renderMarkdown(props.message.content);
 });
 
@@ -27,6 +41,27 @@ function handleSpeak() {
   } else {
     emit("speak", props.message.content, props.message.id);
   }
+}
+
+function handleCopy() {
+  navigator.clipboard.writeText(props.message.content).then(() => {
+    copied.value = true;
+    setTimeout(() => (copied.value = false), 1500);
+  });
+}
+
+function startEdit() {
+  editContent.value = props.message.content;
+  isEditing.value = true;
+}
+
+function saveEdit() {
+  isEditing.value = false;
+  emit("edit", props.message.id, editContent.value);
+}
+
+function cancelEdit() {
+  isEditing.value = false;
 }
 </script>
 
@@ -43,60 +78,242 @@ function handleSpeak() {
           : 'bg-stone-800 text-stone-300 rounded-bl-md'
       "
     >
-      <div
-        v-if="isUser"
-        class="whitespace-pre-wrap break-words"
-      >
-        {{ renderedContent }}
-      </div>
-      <div
-        v-else
-        class="markdown-body break-words"
-        v-html="renderedContent"
-      />
+      <!-- Edit mode -->
+      <template v-if="isEditing">
+        <textarea
+          v-model="editContent"
+          class="w-full bg-stone-900 text-stone-200 text-sm rounded-lg p-2 border border-stone-600 focus:border-amber-500 focus:outline-none resize-y min-h-[60px]"
+          rows="4"
+        />
+        <div class="flex justify-end gap-2 mt-2">
+          <button
+            class="text-xs text-stone-400 hover:text-white px-2 py-1 rounded"
+            @click="cancelEdit"
+          >Cancel</button>
+          <button
+            class="text-xs text-amber-400 hover:text-amber-300 bg-amber-600/20 px-2 py-1 rounded"
+            @click="saveEdit"
+          >Save</button>
+        </div>
+      </template>
 
-      <!-- TTS button for assistant messages -->
-      <div
-        v-if="!isUser && !isStreaming && message.content"
-        class="flex justify-end mt-1 -mb-1"
-      >
-        <button
-          class="p-1 text-stone-500 hover:text-stone-300 transition-colors"
-          @click="handleSpeak"
+      <!-- Normal display -->
+      <template v-else>
+        <div
+          v-if="isUser && hasCodeBlock"
+          class="user-markdown break-words"
+          v-html="renderedContent"
+        />
+        <div
+          v-else-if="isUser"
+          class="whitespace-pre-wrap break-words"
         >
-          <svg
-            v-if="!isSpeaking"
-            xmlns="http://www.w3.org/2000/svg"
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
+          {{ renderedContent }}
+        </div>
+        <div
+          v-else
+          class="markdown-body break-words"
+          v-html="renderedContent"
+        />
+
+        <!-- Action buttons for assistant messages -->
+        <div
+          v-if="!isUser && !isStreaming && message.content"
+          class="flex items-center gap-0.5 mt-1.5 -mb-1 -mx-1 flex-wrap"
+        >
+          <!-- TTS -->
+          <button
+            class="p-1.5 rounded text-stone-500 hover:text-stone-300 transition-colors"
+            :title="isSpeaking ? 'Stop' : 'Speak'"
+            @click="handleSpeak"
           >
-            <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
-            <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
-            <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
-          </svg>
-          <svg
-            v-else
-            xmlns="http://www.w3.org/2000/svg"
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
+            <svg v-if="!isSpeaking" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+              <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+            </svg>
+            <svg v-else xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="6" y="4" width="4" height="16" />
+              <rect x="14" y="4" width="4" height="16" />
+            </svg>
+          </button>
+
+          <!-- Copy -->
+          <button
+            class="p-1.5 rounded transition-colors"
+            :class="copied ? 'text-green-400' : 'text-stone-500 hover:text-stone-300'"
+            title="Copy"
+            @click="handleCopy"
           >
-            <rect x="6" y="4" width="4" height="16" />
-            <rect x="14" y="4" width="4" height="16" />
-          </svg>
-        </button>
-      </div>
+            <svg v-if="!copied" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+            <svg v-else xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          </button>
+
+          <!-- Edit -->
+          <button
+            class="p-1.5 rounded text-stone-500 hover:text-stone-300 transition-colors"
+            title="Edit"
+            @click="startEdit"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+            </svg>
+          </button>
+
+          <!-- Save to context -->
+          <button
+            class="p-1.5 rounded text-stone-500 hover:text-stone-300 transition-colors"
+            title="Save to context"
+            @click="$emit('saveToContext', message.id, message.content)"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+            </svg>
+          </button>
+
+          <!-- Summarize branch -->
+          <button
+            class="p-1.5 rounded text-stone-500 hover:text-stone-300 transition-colors"
+            title="Summarize branch"
+            @click="$emit('summarizeBranch', message.id)"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" /><line x1="16" y1="13" x2="8" y2="13" /><line x1="16" y1="17" x2="8" y2="17" /><polyline points="10 9 9 9 8 9" />
+            </svg>
+          </button>
+
+          <!-- Delete branch from here -->
+          <button
+            class="p-1.5 rounded text-stone-500 hover:text-red-400 transition-colors"
+            title="Delete branch"
+            @click="$emit('deleteBranch', message.id)"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+            </svg>
+          </button>
+        </div>
+
+        <!-- Action buttons for user messages -->
+        <div
+          v-if="isUser && !isStreaming && message.content"
+          class="flex items-center justify-end gap-0.5 mt-1.5 -mb-1 -mx-1 flex-wrap"
+        >
+          <!-- TTS -->
+          <button
+            class="p-1.5 rounded text-amber-300/50 hover:text-amber-200 transition-colors"
+            :title="isSpeaking ? 'Stop' : 'Speak'"
+            @click="handleSpeak"
+          >
+            <svg v-if="!isSpeaking" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" /><path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+            </svg>
+            <svg v-else xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="6" y="4" width="4" height="16" /><rect x="14" y="4" width="4" height="16" />
+            </svg>
+          </button>
+
+          <!-- Copy -->
+          <button
+            class="p-1.5 rounded transition-colors"
+            :class="copied ? 'text-green-400' : 'text-amber-300/50 hover:text-amber-200'"
+            title="Copy"
+            @click="handleCopy"
+          >
+            <svg v-if="!copied" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+            <svg v-else xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          </button>
+
+          <!-- Edit -->
+          <button
+            class="p-1.5 rounded text-amber-300/50 hover:text-amber-200 transition-colors"
+            title="Edit"
+            @click="startEdit"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+            </svg>
+          </button>
+
+          <!-- Regenerate response -->
+          <button
+            class="p-1.5 rounded text-amber-300/50 hover:text-amber-200 transition-colors"
+            title="Regenerate response"
+            @click="$emit('regenerate', message.id)"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="23 4 23 10 17 10" /><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+            </svg>
+          </button>
+
+          <!-- Summarize branch -->
+          <button
+            class="p-1.5 rounded text-amber-300/50 hover:text-amber-200 transition-colors"
+            title="Summarize branch"
+            @click="$emit('summarizeBranch', message.id)"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" /><line x1="16" y1="13" x2="8" y2="13" /><line x1="16" y1="17" x2="8" y2="17" /><polyline points="10 9 9 9 8 9" />
+            </svg>
+          </button>
+
+          <!-- Delete branch from here -->
+          <button
+            class="p-1.5 rounded text-amber-300/50 hover:text-red-400 transition-colors"
+            title="Delete branch"
+            @click="$emit('deleteBranch', message.id)"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+            </svg>
+          </button>
+        </div>
+      </template>
     </div>
   </div>
 </template>
+
+<style scoped>
+/* User messages with code blocks: collapsible */
+.user-markdown :deep(pre) {
+  position: relative;
+  max-height: 200px;
+  overflow: hidden;
+  background: #1c1917;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  margin: 0.5rem 0;
+  font-size: 0.75rem;
+}
+.user-markdown :deep(pre)::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 50px;
+  background: linear-gradient(transparent, #1c1917);
+  pointer-events: none;
+}
+.user-markdown :deep(pre.expanded) {
+  max-height: none;
+}
+.user-markdown :deep(pre.expanded)::after {
+  display: none;
+}
+.user-markdown :deep(code) {
+  font-family: ui-monospace, monospace;
+  font-size: 0.75rem;
+  color: #d6d3d1;
+}
+.user-markdown :deep(p) {
+  margin: 0.25rem 0;
+}
+</style>

--- a/mobile/src/utils/pasteDetect.ts
+++ b/mobile/src/utils/pasteDetect.ts
@@ -1,0 +1,71 @@
+export interface PastedBlock {
+  id: string
+  content: string
+  language: string
+  languageLabel: string
+  lineCount: number
+}
+
+export const PASTE_THRESHOLD_LINES = 5
+export const PASTE_THRESHOLD_CHARS = 500
+
+export function shouldTreatAsPaste(text: string): boolean {
+  const lineCount = text.split('\n').length
+  return lineCount >= PASTE_THRESHOLD_LINES || text.length >= PASTE_THRESHOLD_CHARS
+}
+
+const LANGUAGE_RULES: Array<{ key: string; label: string; test: (t: string) => boolean }> = [
+  { key: 'python', label: 'Python', test: t => /^(import |from .+ import |def |class |if __name__|@\w+)/.test(t) || /\bself\b/.test(t) },
+  { key: 'typescript', label: 'TypeScript', test: t => /^(import .+ from |export (interface|type|const|function|class|enum)|interface \w+|type \w+ =)/.test(t) || /: (string|number|boolean|void)\b/.test(t) },
+  { key: 'javascript', label: 'JavaScript', test: t => /^(import |export |const |let |var |function |class |module\.exports)/.test(t) || /=>\s*[{(]/.test(t) },
+  { key: 'tsx', label: 'TSX', test: t => /^import .+ from/.test(t) && /<\w+[\s/>]/.test(t) },
+  { key: 'jsx', label: 'JSX', test: t => /^(import |const |function )/.test(t) && /<\w+[\s/>]/.test(t) },
+  { key: 'php', label: 'PHP', test: t => /^<\?php|^\$\w+\s*=|\bfunction\s+\w+\s*\(/.test(t) && /;$/.test(t.split('\n')[0] || '') },
+  { key: 'java', label: 'Java', test: t => /^(package |import java\.|public (class|interface|enum)|private |protected )/.test(t) },
+  { key: 'go', label: 'Go', test: t => /^(package |import \(|func |type \w+ struct)/.test(t) },
+  { key: 'rust', label: 'Rust', test: t => /^(use |mod |fn |pub (fn|struct|enum|mod)|impl |let mut |#\[)/.test(t) },
+  { key: 'sql', label: 'SQL', test: t => /^(SELECT|INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|WITH)\b/i.test(t) },
+  { key: 'html', label: 'HTML', test: t => /^<!DOCTYPE|^<html|^<div|^<section|^<template/i.test(t) },
+  { key: 'css', label: 'CSS', test: t => /^(\.|#|@media|@import|:root|\w+\s*\{)/.test(t) && /\{[\s\S]*\}/.test(t) },
+  { key: 'bash', label: 'Bash', test: t => /^(#!\/bin\/(ba)?sh|set -|export |if \[|for \w+ in|sudo |apt |npm |yarn |pip )/.test(t) },
+  { key: 'yaml', label: 'YAML', test: t => /^\w+:\s*(\n|$)/.test(t) && !/[{};]/.test(t.split('\n')[0] || '') },
+  { key: 'json', label: 'JSON', test: t => /^\s*[[{]/.test(t) && (() => { try { JSON.parse(t); return true } catch { return false } })() },
+  { key: 'dockerfile', label: 'Dockerfile', test: t => /^(FROM |RUN |CMD |COPY |WORKDIR |EXPOSE |ENV |ARG |ENTRYPOINT )/i.test(t) },
+  { key: 'markdown', label: 'Markdown', test: t => /^(#{1,6} |\* |- |\d+\. |> |```|\[.+\]\(.+\))/.test(t) },
+]
+
+export function detectLanguage(text: string): { key: string; label: string } {
+  const trimmed = text.trim()
+  for (const rule of LANGUAGE_RULES) {
+    if (rule.test(trimmed)) {
+      return { key: rule.key, label: rule.label }
+    }
+  }
+  return { key: 'text', label: 'Text' }
+}
+
+let counter = 0
+
+export function createPastedBlock(text: string): PastedBlock {
+  const { key, label } = detectLanguage(text)
+  return {
+    id: `paste-${Date.now()}-${++counter}`,
+    content: text,
+    language: key,
+    languageLabel: label,
+    lineCount: text.split('\n').length,
+  }
+}
+
+export function buildMessageContent(text: string, blocks: PastedBlock[]): string {
+  if (blocks.length === 0) return text
+
+  const parts: string[] = []
+  for (const block of blocks) {
+    parts.push(`\`\`\`${block.language}\n${block.content}\n\`\`\``)
+  }
+  if (text) {
+    parts.push(text)
+  }
+  return parts.join('\n\n')
+}

--- a/mobile/src/views/ChatView.vue
+++ b/mobile/src/views/ChatView.vue
@@ -316,6 +316,66 @@ async function saveContextFiles() {
   }
 }
 
+// === Message actions ===
+
+async function handleEditMessage(messageId: string, content: string) {
+  try {
+    await chatApi.editMessage(sessionId.value, messageId, content);
+    await loadSession();
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to edit";
+  }
+}
+
+function handleSaveToContext(_messageId: string, content: string) {
+  const name = `message-${Date.now()}.md`;
+  contextFiles.value.push({ name, content });
+  saveContextFiles();
+  showContextFiles.value = true;
+  showBranches.value = false;
+}
+
+async function handleSummarizeBranch(messageId: string) {
+  try {
+    const data = await chatApi.summarizeBranch(sessionId.value, messageId);
+    const name = `summary-${Date.now()}.md`;
+    contextFiles.value.push({ name, content: data.summary });
+    saveContextFiles();
+    showContextFiles.value = true;
+    showBranches.value = false;
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to summarize";
+  }
+}
+
+async function handleRegenerateResponse(messageId: string) {
+  try {
+    await chatApi.regenerateResponse(sessionId.value, messageId);
+    await loadSession();
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to regenerate";
+  }
+}
+
+async function handleDeleteFromMessage(messageId: string) {
+  if (!confirm("Delete this message and everything after it?")) return;
+  const idx = messages.value.findIndex((m) => m.id === messageId);
+  if (idx < 0) return;
+  try {
+    const toDelete = messages.value.slice(idx).reverse();
+    for (const m of toDelete) {
+      if (!m.id.startsWith("temp-") && !m.id.startsWith("partial-")) {
+        await chatApi.deleteMessage(sessionId.value, m.id);
+      }
+    }
+    messages.value = messages.value.slice(0, idx);
+    if (showBranches.value) await loadBranches();
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to delete";
+    await loadSession();
+  }
+}
+
 const anyPanelOpen = computed(() => showBranches.value || showContextFiles.value);
 
 function closePanel() {
@@ -520,6 +580,11 @@ onUnmounted(() => {
               :is-speaking="tts.speakingMessageId.value === msg.id"
               @speak="tts.speak($event, msg.id)"
               @stop-speak="tts.stop()"
+              @edit="handleEditMessage"
+              @save-to-context="handleSaveToContext"
+              @summarize-branch="handleSummarizeBranch"
+              @delete-branch="handleDeleteFromMessage"
+              @regenerate="handleRegenerateResponse"
             />
 
             <MessageBubble


### PR DESCRIPTION
## Summary

- **Paste detection**: when pasting large text (≥5 lines or ≥500 chars) into chat textarea, it's intercepted and shown as a removable chip with auto-detected language (~17 languages: Python, TS, JS, PHP, Go, Rust, SQL, etc.)
- **Fenced code blocks on send**: pasted blocks are wrapped as ` ```lang ... ``` ` in message content — no backend changes needed
- **Collapsible code blocks**: user messages containing code blocks render with 200px max-height and gradient fade, click to expand
- **Admin + Mobile**: identical pasteDetect utility in both apps, chips UI themed for each (admin: primary colors, mobile: night-eyes amber/stone)
- **Mobile message actions**: edit, summarize branch, regenerate, delete — wired up to existing API endpoints
- **Mobile chat API**: added `editMessage`, `summarizeBranch`, `regenerateResponse` methods
- **Systemd service**: updated to use `start_gpu.sh` with proper kill/timeout signals
- **i18n**: `pastedLines` + `removePasted` keys in ru/en/kk

## NEWS

📎 **Умная вставка кода в чат**

Теперь при вставке большого текста (код, логи, конфиги) в чат — он
автоматически определяется как вложение с языком программирования
(Python, TypeScript, SQL и ещё ~15 языков). Вложение отображается
как компактный чип, который можно удалить до отправки. В истории
чата код показывается в сворачиваемом блоке — как в Claude.ai.
Работает и в админке, и в мобильном приложении.

## Test plan

- [ ] Admin chat: paste a Python snippet (>5 lines) → appears as chip with "Python" label, not in textarea
- [ ] Admin chat: send with only paste, no typed text → message sent with fenced code block
- [ ] Admin chat: paste small text (<5 lines) → normal paste behavior
- [ ] Admin chat: multiple pastes → multiple chips, each removable
- [ ] Admin chat: code block in user message → collapsible with gradient, click to expand
- [ ] Admin CC mode: same paste behavior works
- [ ] Mobile: paste large text → chip appears above textarea
- [ ] Mobile: user message with code block renders with markdown
- [ ] Mobile: message action buttons (edit, summarize, regenerate, delete) work
- [ ] Build: `cd admin && npm run build` ✅
- [ ] Build: `cd mobile && npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)