### PR TITLE
Phase 4.7b: Extract service init + remove globals (#581)

### DIFF
--- a/modules/core/startup.py
+++ b/modules/core/startup.py
@@ -1,6 +1,7 @@
-"""Core domain startup: seed system roles and default workspace."""
+"""Core domain startup: seed roles/workspace, legacy checks, monitor, shutdown."""
 
 import logging
+from pathlib import Path
 
 
 logger = logging.getLogger(__name__)
@@ -131,3 +132,76 @@ async def seed_default_workspace() -> None:
             logger.info(f"🏢 Workspace: ensured {added} users in default workspace")
     except Exception as e:
         logger.error(f"🏢 Workspace seed failed: {e}")
+
+
+def check_legacy_files() -> None:
+    """Warn about deprecated legacy JSON files."""
+    legacy_files = [
+        ("typical_responses.json", "FAQ"),
+        ("custom_presets.json", "TTS presets"),
+        ("chat_sessions.json", "chat sessions"),
+        ("widget_config.json", "widget config"),
+        ("telegram_config.json", "telegram config"),
+    ]
+    found_legacy = []
+    for filename, description in legacy_files:
+        if Path(filename).exists():
+            found_legacy.append(f"{filename} ({description})")
+
+    if found_legacy:
+        logger.warning("=" * 60)
+        logger.warning("⚠️  DEPRECATED: Найдены legacy JSON файлы:")
+        for f in found_legacy:
+            logger.warning(f"    • {f}")
+        logger.warning("    Данные теперь хранятся в SQLite (data/secretary.db).")
+        logger.warning("    Legacy файлы можно удалить после проверки миграции:")
+        logger.warning("    python scripts/migrate_json_to_db.py")
+        logger.warning("=" * 60)
+
+
+async def init_internet_monitor(container, deployment_mode: str) -> None:
+    """Initialize Internet Monitor + LLM auto-switching (GPU/full mode only)."""
+    if deployment_mode == "cloud":
+        return
+
+    try:
+        from modules.core.internet_monitor import InternetMonitor
+        from modules.llm.startup import create_llm_switch_callback
+
+        internet_monitor = InternetMonitor(check_interval=30)
+        internet_monitor.set_switch_callback(create_llm_switch_callback(container))
+        await internet_monitor.start()
+        container.internet_monitor = internet_monitor
+        logger.info("✅ InternetMonitor started (auto-switching LLM)")
+    except Exception as e:
+        logger.warning(f"⚠️ InternetMonitor not available: {e}")
+
+
+async def graceful_shutdown() -> None:
+    """Stop all running bots and bridge."""
+    # Stop Telegram bots
+    try:
+        from multi_bot_manager import multi_bot_manager
+
+        await multi_bot_manager.stop_all()
+        logger.info("✅ Telegram bots stopped")
+    except Exception as e:
+        logger.warning(f"⚠️ Error stopping Telegram bots: {e}")
+
+    # Stop WhatsApp bots
+    try:
+        from whatsapp_manager import whatsapp_manager
+
+        await whatsapp_manager.stop_all()
+        logger.info("✅ WhatsApp bots stopped")
+    except Exception as e:
+        logger.warning(f"⚠️ Error stopping WhatsApp bots: {e}")
+
+    # Stop Claude bridge
+    try:
+        from bridge_manager import bridge_manager
+
+        await bridge_manager.stop()
+        logger.info("✅ Claude bridge stopped")
+    except Exception as e:
+        logger.warning(f"⚠️ Error stopping Claude bridge: {e}")

--- a/modules/knowledge/startup.py
+++ b/modules/knowledge/startup.py
@@ -1,6 +1,7 @@
-"""Knowledge domain startup: FAQ reload."""
+"""Knowledge domain startup: FAQ reload + Wiki RAG init."""
 
 import logging
+from functools import partial
 
 
 logger = logging.getLogger(__name__)
@@ -14,3 +15,73 @@ async def reload_llm_faq(container) -> None:
     if llm_service and hasattr(llm_service, "reload_faq"):
         faq_dict = await async_faq_manager.get_all()
         llm_service.reload_faq(faq_dict)
+
+
+async def init_wiki_rag(container, deployment_mode: str, task_registry) -> None:
+    """Initialize Wiki RAG service with tiered embedding provider."""
+    from pathlib import Path
+
+    try:
+        from app.services.wiki_rag_service import WikiRAGService
+
+        wiki_rag = WikiRAGService(Path("wiki-pages"))
+        container.wiki_rag_service = wiki_rag
+
+        # Initialize embedding provider (tiered: local > cloud > none)
+        embedding_provider = None
+
+        # Local embeddings (best quality, DEPLOYMENT_MODE=full only)
+        if deployment_mode != "cloud":
+            try:
+                from app.services.embedding_provider import (
+                    LOCAL_EMBEDDINGS_AVAILABLE,
+                    LocalEmbeddingProvider,
+                )
+
+                if LOCAL_EMBEDDINGS_AVAILABLE:
+                    embedding_provider = LocalEmbeddingProvider()
+                    logger.info("✅ Wiki RAG: local embeddings (sentence-transformers)")
+            except Exception as local_err:
+                logger.debug(f"Wiki RAG: local embeddings not available: {local_err}")
+
+        # Cloud embeddings from active LLM provider
+        llm_service = container.llm_service
+        if not embedding_provider and llm_service and hasattr(llm_service, "config"):
+            try:
+                cloud_config = llm_service.config
+                provider_type = cloud_config.get("provider_type", "")
+                api_key = cloud_config.get("api_key", "")
+
+                if provider_type == "gemini" and api_key:
+                    from app.services.embedding_provider import GeminiEmbeddingProvider
+
+                    embedding_provider = GeminiEmbeddingProvider(api_key=api_key)
+                    logger.info("✅ Wiki RAG: cloud embeddings (Gemini)")
+                elif api_key and cloud_config.get("base_url"):
+                    from app.services.embedding_provider import OpenAIEmbeddingProvider
+
+                    embedding_provider = OpenAIEmbeddingProvider(
+                        api_key=api_key,
+                        base_url=cloud_config["base_url"],
+                    )
+                    logger.info("✅ Wiki RAG: cloud embeddings (OpenAI-compatible)")
+            except Exception as cloud_err:
+                logger.debug(f"Wiki RAG: cloud embeddings not available: {cloud_err}")
+
+        if embedding_provider:
+            wiki_rag.set_embedding_provider(embedding_provider)
+            from modules.knowledge.tasks import build_wiki_embeddings
+
+            task_registry.register("wiki-embeddings", partial(build_wiki_embeddings, wiki_rag))
+        else:
+            logger.info("📚 Wiki RAG: BM25 only (no embedding provider)")
+
+        # Load per-collection indexes in background
+        from modules.knowledge.tasks import load_collection_indexes
+
+        task_registry.register(
+            "wiki-collection-indexes", partial(load_collection_indexes, wiki_rag)
+        )
+
+    except Exception as wiki_err:
+        logger.warning(f"⚠️ Wiki RAG service not available: {wiki_err}")

--- a/modules/llm/startup.py
+++ b/modules/llm/startup.py
@@ -1,11 +1,20 @@
-"""LLM domain startup: provider auto-creation, bridge auto-start."""
+"""LLM domain startup: service init, provider auto-creation, bridge auto-start."""
 
 import logging
 import os
-from typing import Optional
+from typing import Any, Optional
 
 
 logger = logging.getLogger(__name__)
+
+# Optional vLLM import
+try:
+    from vllm_llm_service import VLLMLLMService
+
+    VLLM_AVAILABLE = True
+except ImportError:
+    VLLM_AVAILABLE = False
+    VLLMLLMService = None
 
 
 async def get_or_create_default_gemini_provider() -> Optional[dict]:
@@ -41,6 +50,162 @@ async def get_or_create_default_gemini_provider() -> Optional[dict]:
     )
     logger.info(f"Created Gemini provider: {provider['id']}")
     return await async_cloud_provider_manager.get_provider_with_key(provider["id"])
+
+
+async def init_llm_service(llm_backend: str) -> tuple[Any, str]:
+    """Initialize LLM service with fallback chain.
+
+    Returns (llm_service, updated_llm_backend).
+    """
+    from cloud_llm_service import CloudLLMService
+    from db.integration import async_cloud_provider_manager
+
+    llm_service = None
+
+    # Auto-migrate legacy "gemini" backend to cloud provider system
+    if llm_backend == "gemini":
+        logger.info("🔄 Auto-migrating LLM_BACKEND=gemini to cloud provider...")
+        gemini_provider = await get_or_create_default_gemini_provider()
+        if gemini_provider:
+            llm_backend = f"cloud:{gemini_provider['id']}"
+            os.environ["LLM_BACKEND"] = llm_backend
+            logger.info(f"✅ Migrated to {llm_backend}")
+        else:
+            logger.warning("⚠️ Cannot auto-migrate gemini backend: no GEMINI_API_KEY")
+            llm_backend = "vllm"
+
+    if llm_backend == "vllm" and VLLM_AVAILABLE:
+        logger.info("📦 Загрузка vLLM LLM Service...")
+        try:
+            llm_service = VLLMLLMService()
+            if llm_service.is_available():
+                logger.info("✅ vLLM подключен")
+            else:
+                logger.warning("⚠️ vLLM не отвечает, пробуем облачного провайдера...")
+                gemini_provider = await get_or_create_default_gemini_provider()
+                if gemini_provider:
+                    llm_service = CloudLLMService(gemini_provider)
+                    llm_backend = f"cloud:{gemini_provider['id']}"
+                    os.environ["LLM_BACKEND"] = llm_backend
+                    logger.info(f"✅ Fallback на cloud: {gemini_provider['id']}")
+                else:
+                    logger.warning("⚠️ Нет облачного провайдера для fallback")
+        except Exception as e:
+            logger.warning(f"⚠️ vLLM недоступен ({e}), пробуем облачного провайдера...")
+            gemini_provider = await get_or_create_default_gemini_provider()
+            if gemini_provider:
+                llm_service = CloudLLMService(gemini_provider)
+                llm_backend = f"cloud:{gemini_provider['id']}"
+                os.environ["LLM_BACKEND"] = llm_backend
+                logger.info(f"✅ Fallback на cloud: {gemini_provider['id']}")
+            else:
+                logger.warning("⚠️ Нет облачного провайдера для fallback")
+                llm_service = None
+    elif llm_backend.startswith("cloud:"):
+        provider_id = llm_backend.split(":", 1)[1]
+        logger.info(f"☁️ LLM backend: {llm_backend} (cloud provider)")
+        try:
+            provider_config = await async_cloud_provider_manager.get_provider_with_key(provider_id)
+            if provider_config:
+                llm_service = CloudLLMService(provider_config)
+                logger.info(
+                    f"✅ Cloud LLM: {provider_config.get('name')} "
+                    f"({provider_config.get('provider_type')})"
+                )
+            else:
+                logger.warning(f"⚠️ Cloud provider {provider_id} not found in DB")
+                llm_service = None
+        except Exception as e:
+            logger.warning(f"⚠️ Cloud LLM недоступен ({e})")
+            llm_service = None
+    else:
+        logger.warning(f"⚠️ Unknown LLM_BACKEND={llm_backend}, trying vLLM...")
+        if VLLM_AVAILABLE:
+            try:
+                llm_service = VLLMLLMService()
+                if llm_service.is_available():
+                    llm_backend = "vllm"
+                    logger.info("✅ vLLM подключен (fallback)")
+                else:
+                    llm_service = None
+            except Exception:
+                llm_service = None
+        else:
+            llm_service = None
+
+    return llm_service, llm_backend
+
+
+def create_llm_switch_callback(container):
+    """Create callback for InternetMonitor to switch LLM backend on connectivity change.
+
+    Returns async function(ConnectivityStatus) -> str.
+    The callback writes to container.llm_service and os.environ["LLM_BACKEND"].
+    """
+    from cloud_llm_service import CloudLLMService
+    from db.integration import async_cloud_provider_manager
+
+    async def switch_llm(status) -> str:
+        from modules.core.internet_monitor import ConnectivityStatus
+
+        if status in (ConnectivityStatus.ONLINE, ConnectivityStatus.DEGRADED):
+            # Try cloud provider: claude_bridge first, then default, then any enabled
+            try:
+                providers = await async_cloud_provider_manager.list_providers(enabled_only=True)
+                provider = None
+                # Priority: claude_bridge > is_default > first enabled
+                for p in providers or []:
+                    if p.get("provider_type") == "claude_bridge" and p.get("enabled"):
+                        provider = p
+                        break
+                if not provider:
+                    for p in providers or []:
+                        if p.get("is_default") and p.get("enabled"):
+                            provider = p
+                            break
+                if not provider:
+                    for p in providers or []:
+                        if p.get("enabled"):
+                            provider = p
+                            break
+                if provider:
+                    provider = await async_cloud_provider_manager.get_provider_with_key(
+                        provider["id"]
+                    )
+                if provider:
+                    new_svc = CloudLLMService(provider)
+                    container.llm_service = new_svc
+                    ptype = provider.get("provider_type", "cloud")
+                    backend = f"cloud ({ptype}: {provider.get('name', '?')})"
+                    os.environ["LLM_BACKEND"] = f"cloud:{provider['id']}"
+                    return backend
+            except Exception as e:
+                logger.warning(f"Cloud LLM switch failed: {e}")
+            # Fallback to vLLM even when online
+            if VLLM_AVAILABLE:
+                try:
+                    new_svc = VLLMLLMService()
+                    if new_svc.is_available():
+                        container.llm_service = new_svc
+                        os.environ["LLM_BACKEND"] = "vllm"
+                        return "vllm (cloud unavailable)"
+                except Exception:
+                    pass
+            return os.environ.get("LLM_BACKEND", "unknown")  # keep current
+        else:
+            # Offline — switch to local vLLM
+            if VLLM_AVAILABLE:
+                try:
+                    new_svc = VLLMLLMService()
+                    if new_svc.is_available():
+                        container.llm_service = new_svc
+                        os.environ["LLM_BACKEND"] = "vllm"
+                        return "vllm (offline)"
+                except Exception as e:
+                    logger.error(f"vLLM fallback failed: {e}")
+            return os.environ.get("LLM_BACKEND", "unknown")  # keep current
+
+    return switch_llm
 
 
 async def auto_start_bridge() -> None:

--- a/modules/speech/startup.py
+++ b/modules/speech/startup.py
@@ -1,9 +1,132 @@
-"""Speech domain startup: voice preset reload."""
+"""Speech domain startup: TTS/STT service init + voice preset reload."""
 
 import logging
+from typing import Any
 
 
 logger = logging.getLogger(__name__)
+
+# Optional TTS imports (GPU services may not be installed)
+try:
+    from piper_tts_service import PiperTTSService
+
+    PIPER_AVAILABLE = True
+except ImportError:
+    PIPER_AVAILABLE = False
+    PiperTTSService = None
+
+try:
+    from voice_clone_service import VoiceCloneService
+
+    XTTS_AVAILABLE = True
+except ImportError:
+    XTTS_AVAILABLE = False
+    VoiceCloneService = None
+
+try:
+    from openvoice_service import OpenVoiceService
+
+    OPENVOICE_AVAILABLE = True
+except ImportError:
+    OPENVOICE_AVAILABLE = False
+    OpenVoiceService = None
+
+
+def init_tts_services(deployment_mode: str) -> dict[str, Any]:
+    """Initialize TTS services based on deployment mode.
+
+    Returns dict with keys: voice_service, anna_voice_service, piper_service,
+    openvoice_service, current_voice_config.
+    """
+    result: dict[str, Any] = {
+        "voice_service": None,
+        "anna_voice_service": None,
+        "piper_service": None,
+        "openvoice_service": None,
+        "current_voice_config": {"engine": "xtts", "voice": "anna"},
+    }
+
+    if deployment_mode == "cloud":
+        logger.info("☁️ Cloud mode: пропускаем TTS/GPU сервисы")
+        result["current_voice_config"] = {"engine": "none", "voice": "none"}
+        return result
+
+    # Piper TTS (Dmitri, Irina) - CPU, загружаем первым
+    if PIPER_AVAILABLE:
+        logger.info("📦 Загрузка Piper TTS Service (CPU)...")
+        try:
+            result["piper_service"] = PiperTTSService()
+        except Exception as e:
+            logger.warning(f"⚠️ Piper TTS недоступен: {e}")
+    else:
+        logger.info("⏭️ Piper TTS не установлен (пропускаем)")
+
+    # OpenVoice v2 (Марина) - GPU CC 6.1+ (P104-100)
+    if OPENVOICE_AVAILABLE:
+        logger.info("📦 Загрузка OpenVoice TTS Service (GPU CC 6.1+)...")
+        try:
+            result["openvoice_service"] = OpenVoiceService()
+            logger.info("✅ OpenVoice v2 загружен (P104-100)")
+        except Exception as e:
+            logger.warning(f"⚠️ OpenVoice недоступен: {e}")
+    else:
+        logger.info("⏭️ OpenVoice не установлен (пропускаем)")
+
+    # XTTS (Анна) - GPU CC >= 7.0, по умолчанию
+    if XTTS_AVAILABLE:
+        logger.info("📦 Загрузка Voice Clone Service (XTTS - Анна)...")
+        try:
+            svc = VoiceCloneService(voice_samples_dir="./Анна")
+            result["anna_voice_service"] = svc
+            logger.info(f"✅ XTTS (Анна): {len(svc.voice_samples)} образцов")
+        except Exception as e:
+            logger.warning(f"⚠️ XTTS (Анна) недоступен: {e}")
+    else:
+        logger.info("⏭️ XTTS не установлен (пропускаем)")
+
+    # XTTS (Марина) - GPU CC >= 7.0, опционально
+    if XTTS_AVAILABLE:
+        logger.info("📦 Загрузка Voice Clone Service (XTTS - Марина)...")
+        try:
+            svc = VoiceCloneService(voice_samples_dir="./Марина")
+            result["voice_service"] = svc
+            logger.info(f"✅ XTTS (Марина): {len(svc.voice_samples)} образцов")
+        except Exception as e:
+            logger.warning(f"⚠️ XTTS (Марина) недоступен: {e}")
+
+    # Устанавливаем голос по умолчанию
+    if result["anna_voice_service"]:
+        result["current_voice_config"] = {"engine": "xtts", "voice": "anna"}
+        logger.info("🎤 Голос по умолчанию: Анна (XTTS)")
+    elif result["voice_service"]:
+        result["current_voice_config"] = {"engine": "xtts", "voice": "marina"}
+        logger.info("🎤 Голос по умолчанию: Марина (XTTS)")
+    elif result["piper_service"]:
+        result["current_voice_config"] = {"engine": "piper", "voice": "dmitri"}
+        logger.info("🎤 Голос по умолчанию: Дмитрий (Piper)")
+
+    return result
+
+
+def init_stt_service():
+    """Initialize STT (Vosk) service. Returns service instance or None."""
+    try:
+        from stt_service import VoskSTTService
+
+        svc = VoskSTTService(language="ru", model_size="small")
+        logger.info("✅ STT (Vosk) initialized")
+        return svc
+    except Exception as e:
+        logger.warning(f"⚠️ STT not available: {e}")
+        return None
+
+
+def init_streaming_tts_manager():
+    """Create StreamingTTSManager instance."""
+    from modules.speech.streaming import StreamingTTSManager
+
+    logger.info("📦 Инициализация Streaming TTS Manager...")
+    return StreamingTTSManager(max_cache_size=50, cache_ttl=300)
 
 
 async def reload_voice_presets(container) -> None:

--- a/modules/telephony/startup.py
+++ b/modules/telephony/startup.py
@@ -1,0 +1,42 @@
+"""Telephony domain startup: GSM service + voice calls."""
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+async def init_gsm_services(container, deployment_mode: str) -> None:
+    """Initialize GSM telephony service and voice call handler (GPU/full mode only)."""
+    if deployment_mode == "cloud":
+        return
+
+    try:
+        from app.services.gsm_service import GSMService
+
+        gsm_service = GSMService()
+        await gsm_service.initialize()
+        container.gsm_service = gsm_service
+        mode = "mock" if gsm_service.mock_mode else "hardware"
+        logger.info(f"✅ GSM service initialized ({mode} mode)")
+
+        # Start voice call service (auto-answer with AI assistant)
+        try:
+            from app.services.gsm_voice_call import GSMVoiceCallService
+
+            voice_call = GSMVoiceCallService(
+                gsm_service=gsm_service,
+                stt_service=getattr(container, "stt_service", None),
+                tts_service=container.anna_voice_service or container.voice_service,
+                piper_service=container.piper_service,
+                tts_voice="xtts",  # or "piper" for CPU
+                piper_voice="irina",  # irina / dmitri
+                rag_mode="all",  # use all knowledge collections
+            )
+            await voice_call.start()
+            container.gsm_voice_call = voice_call
+            logger.info("✅ GSM Voice Call service started (auto-answer)")
+        except Exception as vc_err:
+            logger.warning(f"⚠️ GSM Voice Call not available: {vc_err}")
+    except Exception as gsm_err:
+        logger.warning(f"⚠️ GSM service not available: {gsm_err}")

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,29 +1,52 @@
 #!/usr/bin/env python3
 """
-Главный оркестратор - координирует все сервисы
-STT (Whisper) -> LLM (vLLM / Cloud) -> TTS (XTTS v2)
+FastAPI entry point — wiring only, all domain logic in modules/.
+
+Service init in modules/*/startup.py, endpoints in modules/*/router*.py,
+background tasks in modules/*/tasks.py, domain services in modules/*/service.py.
 """
 
 import logging
 import os
-from functools import partial
 from pathlib import Path
-from typing import Optional
 
 import uvicorn
 from fastapi import FastAPI, Request
-from fastapi.responses import (
-    RedirectResponse,
-    Response,
-)
+from fastapi.responses import RedirectResponse, Response
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 
 from app.cors_middleware import DynamicCORSMiddleware
 from app.rate_limiter import limiter
+from app.security_headers import SECURITY_HEADERS_ENABLED, SecurityHeadersMiddleware
 
-# Modular routers
-from app.routers import (
+
+# Deployment mode: "full" (default), "cloud" (no GPU/hardware), "local" (explicit full)
+DEPLOYMENT_MODE = os.getenv("DEPLOYMENT_MODE", "full").lower()
+if DEPLOYMENT_MODE not in ("full", "cloud", "local"):
+    DEPLOYMENT_MODE = "full"
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="AI Secretary Orchestrator", version="1.0.0")
+
+# Rate limiting
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+# CORS
+CORS_ORIGINS_RAW = os.getenv("CORS_ORIGINS", "*")
+CORS_ORIGINS = (
+    ["*"]
+    if CORS_ORIGINS_RAW == "*"
+    else [o.strip() for o in CORS_ORIGINS_RAW.split(",") if o.strip()]
+)
+app.add_middleware(DynamicCORSMiddleware, static_origins=CORS_ORIGINS)
+app.add_middleware(SecurityHeadersMiddleware, enabled=SECURITY_HEADERS_ENABLED)
+
+# --- Router registration ---
+from app.routers import (  # noqa: E402
     amocrm,
     audit,
     auth,
@@ -53,145 +76,45 @@ from app.routers import (
     workspace,
     yoomoney_webhook,
 )
-from app.security_headers import (
-    SECURITY_HEADERS_ENABLED,
-    SecurityHeadersMiddleware,
-)
-
-# Cloud LLM service for multi-provider support
-from cloud_llm_service import CloudLLMService
-from db.integration import (
-    async_cloud_provider_manager,
-    init_database,
-    shutdown_database,
-)
-
-
-# Database integration
-
-
-# Multi-bot manager
-try:
-    from piper_tts_service import PiperTTSService
-
-    PIPER_AVAILABLE = True
-except ImportError:
-    PIPER_AVAILABLE = False
-    PiperTTSService = None
-
-
-try:
-    from stt_service import STTService
-
-    STT_AVAILABLE = True
-except ImportError:
-    STT_AVAILABLE = False
-    STTService = None
-
-
-# Импорты наших сервисов
-try:
-    from voice_clone_service import VoiceCloneService
-
-    XTTS_AVAILABLE = True
-except ImportError:
-    XTTS_AVAILABLE = False
-    VoiceCloneService = None
-
-
-# vLLM импорт (опциональный - локальная Llama через vLLM)
-try:
-    from vllm_llm_service import VLLMLLMService
-
-    VLLM_AVAILABLE = True
-except ImportError:
-    VLLM_AVAILABLE = False
-    VLLMLLMService = None
-
-# OpenVoice импорт (опциональный - для GPU P104-100)
-try:
-    from openvoice_service import OpenVoiceService
-
-    OPENVOICE_AVAILABLE = True
-except ImportError:
-    OPENVOICE_AVAILABLE = False
-    OpenVoiceService = None
-
-# Определяем какой LLM backend использовать
-LLM_BACKEND = os.getenv("LLM_BACKEND", "vllm").lower()  # "vllm" or "cloud:{provider_id}"
-
-# Deployment mode: "full" (default), "cloud" (no GPU/hardware), "local" (explicit full)
-DEPLOYMENT_MODE = os.getenv("DEPLOYMENT_MODE", "full").lower()
-if DEPLOYMENT_MODE not in ("full", "cloud", "local"):
-    DEPLOYMENT_MODE = "full"
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
-
-
-from modules.speech.streaming import StreamingTTSManager  # noqa: E402
-
-
-# Глобальный менеджер streaming TTS
-streaming_tts_manager: Optional[StreamingTTSManager] = None
-
-app = FastAPI(title="AI Secretary Orchestrator", version="1.0.0")
-
-# Rate limiting
-app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
-
-# CORS для доступа из браузера
-# Static origins from env (comma-separated), default to "*" for development.
-# Widget allowed_domains are added dynamically from the database.
-CORS_ORIGINS_RAW = os.getenv("CORS_ORIGINS", "*")
-CORS_ORIGINS = (
-    ["*"]
-    if CORS_ORIGINS_RAW == "*"
-    else [origin.strip() for origin in CORS_ORIGINS_RAW.split(",") if origin.strip()]
-)
-app.add_middleware(DynamicCORSMiddleware, static_origins=CORS_ORIGINS)
-
-# Security headers
-app.add_middleware(SecurityHeadersMiddleware, enabled=SECURITY_HEADERS_ENABLED)
-
-# Include modular routers
-# NOTE: These routers use the ServiceContainer from app.dependencies
-# which is populated in startup_event
-
-# Always-available routers (all deployment modes)
-app.include_router(auth.router)
-app.include_router(audit.router)
-app.include_router(faq.router)
-app.include_router(llm.router)
-app.include_router(chat.router)
-app.include_router(telegram.router)
-app.include_router(whatsapp.router)
-app.include_router(usage.router)
-app.include_router(widget.router)
-app.include_router(mobile.router)
-app.include_router(bot_sales.router)
-app.include_router(github_webhook.router)
-app.include_router(yoomoney_webhook.router)
-app.include_router(legal.router)
-app.include_router(backup.router)
-app.include_router(wiki_rag.router)
-app.include_router(amocrm.router)
-app.include_router(amocrm.webhook_router)
-app.include_router(woocommerce.router)
-app.include_router(github_repos.router)
-app.include_router(claude_code.router)
-app.include_router(kanban.router)
-app.include_router(roles.router)
-app.include_router(workspace.router)
-
-# Core health + legacy/compat endpoints (Phase 4.3)
+from modules.channels.widget.router_public import router as widget_public_router  # noqa: E402
 from modules.compat.router import router as compat_router  # noqa: E402
 from modules.core.router_health import router as health_router  # noqa: E402
+from modules.monitoring.router_logs import router as logs_router  # noqa: E402
 
 
+# Always-available routers (all deployment modes)
+_ALWAYS_ROUTERS = [
+    auth,
+    audit,
+    faq,
+    llm,
+    chat,
+    telegram,
+    whatsapp,
+    usage,
+    widget,
+    mobile,
+    bot_sales,
+    github_webhook,
+    yoomoney_webhook,
+    legal,
+    backup,
+    wiki_rag,
+    woocommerce,
+    github_repos,
+    claude_code,
+    kanban,
+    roles,
+    workspace,
+]
+for _r in _ALWAYS_ROUTERS:
+    app.include_router(_r.router)
+app.include_router(amocrm.router)
+app.include_router(amocrm.webhook_router)
 app.include_router(health_router)
 app.include_router(compat_router)
+app.include_router(logs_router)
+app.include_router(widget_public_router)
 
 # Hardware/GPU routers — skip in cloud mode
 if DEPLOYMENT_MODE != "cloud":
@@ -202,284 +125,71 @@ if DEPLOYMENT_MODE != "cloud":
         app.include_router(stt.router)
     if tts is not None:
         app.include_router(tts.router)
-    # Finetune routers (Phase 4.4) — GPU-only
     from modules.llm.router_finetune import router as llm_finetune_router
+    from modules.llm.router_models import router as models_router
     from modules.speech.router_finetune import router as tts_finetune_router
+    from modules.speech.router_voices import router as voices_router
 
     app.include_router(llm_finetune_router)
     app.include_router(tts_finetune_router)
-    # Voice + model management (Phase 4.5) — GPU-only
-    from modules.llm.router_models import router as models_router
-    from modules.speech.router_voices import router as voices_router
-
     app.include_router(voices_router)
     app.include_router(models_router)
 
-# Logs router (available in all modes)
-from modules.monitoring.router_logs import router as logs_router  # noqa: E402
-
-
-app.include_router(logs_router)
-
-# Widget public endpoints
-from modules.channels.widget.router_public import router as widget_public_router  # noqa: E402
-
-
-app.include_router(widget_public_router)
-
-# Task registry for background tasks (session cleanup, vacuum, syncs)
+# Task registry for background tasks
 from modules.core.tasks import TaskRegistry  # noqa: E402
 
 
 task_registry = TaskRegistry()
 
-# Глобальные сервисы
-voice_service: Optional["VoiceCloneService"] = None  # XTTS (Марина) - GPU CC >= 7.0
-anna_voice_service: Optional["VoiceCloneService"] = None  # XTTS (Анна) - GPU CC >= 7.0
-piper_service: Optional["PiperTTSService"] = None  # Piper (Dmitri, Irina) - CPU
-openvoice_service: Optional["OpenVoiceService"] = None  # OpenVoice v2 (Марина) - GPU CC 6.1+
-stt_service: Optional["STTService"] = None
-llm_service = None  # VLLMLLMService or CloudLLMService instance
-
-# Конфигурация текущего голоса
-# engine: "xtts" (Марина/Анна на GPU CC>=7.0), "piper" (Dmitri/Irina на CPU), "openvoice" (Марина на GPU CC 6.1+)
-# По умолчанию используем Гулю (XTTS) если доступна, иначе Piper
-current_voice_config = {
-    "engine": "xtts",
-    "voice": "anna",  # anna / marina / dmitri / irina / marina_openvoice
-}
-
-# Папка для временных файлов
-TEMP_DIR = Path("./temp")
-TEMP_DIR.mkdir(exist_ok=True)
-
-# Папка для логов звонков
-CALLS_LOG_DIR = Path("./calls_log")
-CALLS_LOG_DIR.mkdir(exist_ok=True)
+# Working directories
+Path("./temp").mkdir(exist_ok=True)
+Path("./calls_log").mkdir(exist_ok=True)
 
 
 @app.on_event("startup")
 async def startup_event():
-    """Инициализация всех сервисов при старте"""
-    global \
-        voice_service, \
-        anna_voice_service, \
-        piper_service, \
-        openvoice_service, \
-        stt_service, \
-        llm_service, \
-        streaming_tts_manager, \
-        LLM_BACKEND
-
+    """Initialize all services via domain startup modules."""
     logger.info(f"🚀 Запуск AI Secretary Orchestrator (mode={DEPLOYMENT_MODE})")
 
-    # Initialize database first
+    from app.dependencies import get_container
+    from db.integration import init_database
+
     await init_database()
 
-    # Seed system roles and default workspace
-    from modules.core.startup import seed_default_workspace, seed_system_roles
+    from modules.core.startup import check_legacy_files, seed_default_workspace, seed_system_roles
 
     await seed_system_roles()
     await seed_default_workspace()
 
     try:
-        # TTS/STT services — skip entirely in cloud mode
-        global current_voice_config
-        if DEPLOYMENT_MODE == "cloud":
-            logger.info("☁️ Cloud mode: пропускаем TTS/STT/GPU сервисы")
-            piper_service = None
-            openvoice_service = None
-            anna_voice_service = None
-            voice_service = None
-            stt_service = None
-            current_voice_config = {"engine": "none", "voice": "none"}
-        else:
-            # Инициализация Piper TTS (Dmitri, Irina) - CPU, загружаем первым
-            if PIPER_AVAILABLE:
-                logger.info("📦 Загрузка Piper TTS Service (CPU)...")
-                try:
-                    piper_service = PiperTTSService()
-                except Exception as e:
-                    logger.warning(f"⚠️ Piper TTS недоступен: {e}")
-                    piper_service = None
-            else:
-                logger.info("⏭️ Piper TTS не установлен (пропускаем)")
-                piper_service = None
+        # TTS/STT services
+        from modules.speech.startup import (
+            init_streaming_tts_manager,
+            init_stt_service,
+            init_tts_services,
+        )
 
-            # Инициализация OpenVoice v2 (Марина) - GPU CC 6.1+ (P104-100)
-            if OPENVOICE_AVAILABLE:
-                logger.info("📦 Загрузка OpenVoice TTS Service (GPU CC 6.1+)...")
-                try:
-                    openvoice_service = OpenVoiceService()
-                    logger.info("✅ OpenVoice v2 загружен (P104-100)")
-                except Exception as e:
-                    logger.warning(f"⚠️ OpenVoice недоступен: {e}")
-                    openvoice_service = None
-            else:
-                logger.info("⏭️ OpenVoice не установлен (пропускаем)")
-                openvoice_service = None
+        tts_result = init_tts_services(DEPLOYMENT_MODE)
+        stt_service = init_stt_service()
+        streaming_tts_manager = init_streaming_tts_manager()
 
-            # Инициализация XTTS (Анна) - GPU CC >= 7.0, по умолчанию
-            if XTTS_AVAILABLE:
-                logger.info("📦 Загрузка Voice Clone Service (XTTS - Анна)...")
-                try:
-                    anna_voice_service = VoiceCloneService(voice_samples_dir="./Анна")
-                    logger.info(f"✅ XTTS (Анна): {len(anna_voice_service.voice_samples)} образцов")
-                except Exception as e:
-                    logger.warning(f"⚠️ XTTS (Анна) недоступен: {e}")
-                    anna_voice_service = None
-            else:
-                logger.info("⏭️ XTTS не установлен (пропускаем)")
-                anna_voice_service = None
+        # LLM service
+        from modules.llm.startup import init_llm_service
 
-            # Инициализация XTTS (Марина) - GPU CC >= 7.0, опционально
-            if XTTS_AVAILABLE:
-                logger.info("📦 Загрузка Voice Clone Service (XTTS - Марина)...")
-                try:
-                    voice_service = VoiceCloneService(voice_samples_dir="./Марина")
-                    logger.info(f"✅ XTTS (Марина): {len(voice_service.voice_samples)} образцов")
-                except Exception as e:
-                    logger.warning(f"⚠️ XTTS (Марина) недоступен: {e}")
-                    voice_service = None
-            else:
-                voice_service = None
+        llm_backend = os.getenv("LLM_BACKEND", "vllm").lower()
+        llm_service, llm_backend = await init_llm_service(llm_backend)
+        os.environ["LLM_BACKEND"] = llm_backend
 
-            # Устанавливаем голос по умолчанию
-            if anna_voice_service:
-                current_voice_config = {"engine": "xtts", "voice": "anna"}
-                logger.info("🎤 Голос по умолчанию: Анна (XTTS)")
-            elif voice_service:
-                current_voice_config = {"engine": "xtts", "voice": "marina"}
-                logger.info("🎤 Голос по умолчанию: Марина (XTTS)")
-            elif piper_service:
-                current_voice_config = {"engine": "piper", "voice": "dmitri"}
-                logger.info("🎤 Голос по умолчанию: Дмитрий (Piper)")
-
-        # Инициализация LLM Service (vLLM или Cloud)
-        from modules.llm.startup import get_or_create_default_gemini_provider
-
-        # Auto-migrate legacy "gemini" backend to cloud provider system
-        if LLM_BACKEND == "gemini":
-            logger.info("🔄 Auto-migrating LLM_BACKEND=gemini to cloud provider...")
-            gemini_provider = await get_or_create_default_gemini_provider()
-            if gemini_provider:
-                LLM_BACKEND = f"cloud:{gemini_provider['id']}"
-                os.environ["LLM_BACKEND"] = LLM_BACKEND
-                logger.info(f"✅ Migrated to {LLM_BACKEND}")
-            else:
-                logger.warning("⚠️ Cannot auto-migrate gemini backend: no GEMINI_API_KEY")
-                LLM_BACKEND = "vllm"
-
-        if LLM_BACKEND == "vllm" and VLLM_AVAILABLE:
-            logger.info("📦 Загрузка vLLM LLM Service...")
-            try:
-                llm_service = VLLMLLMService()
-                if llm_service.is_available():
-                    logger.info("✅ vLLM подключен")
-                else:
-                    logger.warning("⚠️ vLLM не отвечает, пробуем облачного провайдера...")
-                    gemini_provider = await get_or_create_default_gemini_provider()
-                    if gemini_provider:
-                        llm_service = CloudLLMService(gemini_provider)
-                        LLM_BACKEND = f"cloud:{gemini_provider['id']}"
-                        os.environ["LLM_BACKEND"] = LLM_BACKEND
-                        logger.info(f"✅ Fallback на cloud: {gemini_provider['id']}")
-                    else:
-                        logger.warning("⚠️ Нет облачного провайдера для fallback")
-            except Exception as e:
-                logger.warning(f"⚠️ vLLM недоступен ({e}), пробуем облачного провайдера...")
-                gemini_provider = await get_or_create_default_gemini_provider()
-                if gemini_provider:
-                    llm_service = CloudLLMService(gemini_provider)
-                    LLM_BACKEND = f"cloud:{gemini_provider['id']}"
-                    os.environ["LLM_BACKEND"] = LLM_BACKEND
-                    logger.info(f"✅ Fallback на cloud: {gemini_provider['id']}")
-                else:
-                    logger.warning("⚠️ Нет облачного провайдера для fallback")
-                    llm_service = None
-        elif LLM_BACKEND.startswith("cloud:"):
-            provider_id = LLM_BACKEND.split(":", 1)[1]
-            logger.info(f"☁️ LLM backend: {LLM_BACKEND} (cloud provider)")
-            try:
-                provider_config = await async_cloud_provider_manager.get_provider_with_key(
-                    provider_id
-                )
-                if provider_config:
-                    llm_service = CloudLLMService(provider_config)
-                    logger.info(
-                        f"✅ Cloud LLM: {provider_config.get('name')} "
-                        f"({provider_config.get('provider_type')})"
-                    )
-                else:
-                    logger.warning(f"⚠️ Cloud provider {provider_id} not found in DB")
-                    llm_service = None
-            except Exception as e:
-                logger.warning(f"⚠️ Cloud LLM недоступен ({e})")
-                llm_service = None
-        else:
-            logger.warning(f"⚠️ Unknown LLM_BACKEND={LLM_BACKEND}, trying vLLM...")
-            if VLLM_AVAILABLE:
-                try:
-                    llm_service = VLLMLLMService()
-                    if llm_service.is_available():
-                        LLM_BACKEND = "vllm"
-                        logger.info("✅ vLLM подключен (fallback)")
-                    else:
-                        llm_service = None
-                except Exception:
-                    llm_service = None
-            else:
-                llm_service = None
-
-        # Инициализация Streaming TTS Manager
-        logger.info("📦 Инициализация Streaming TTS Manager...")
-        streaming_tts_manager = StreamingTTSManager(max_cache_size=50, cache_ttl=300)
-
-        # STT (Vosk) для голосовых звонков
-        try:
-            from stt_service import VoskSTTService
-
-            stt_service = VoskSTTService(language="ru", model_size="small")
-            logger.info("✅ STT (Vosk) initialized")
-        except Exception as stt_err:
-            logger.warning(f"⚠️ STT not available: {stt_err}")
-            stt_service = None
-
-        # Check for deprecated legacy JSON files
-        legacy_files = [
-            ("typical_responses.json", "FAQ"),
-            ("custom_presets.json", "TTS presets"),
-            ("chat_sessions.json", "chat sessions"),
-            ("widget_config.json", "widget config"),
-            ("telegram_config.json", "telegram config"),
-        ]
-        found_legacy = []
-        for filename, description in legacy_files:
-            if Path(filename).exists():
-                found_legacy.append(f"{filename} ({description})")
-
-        if found_legacy:
-            logger.warning("=" * 60)
-            logger.warning("⚠️  DEPRECATED: Найдены legacy JSON файлы:")
-            for f in found_legacy:
-                logger.warning(f"    • {f}")
-            logger.warning("    Данные теперь хранятся в SQLite (data/secretary.db).")
-            logger.warning("    Legacy файлы можно удалить после проверки миграции:")
-            logger.warning("    python scripts/migrate_json_to_db.py")
-            logger.warning("=" * 60)
-
-        # Populate service container for modular routers
-        from app.dependencies import get_container
-
+        # Populate service container
         container = get_container()
-        container.voice_service = voice_service
-        container.anna_voice_service = anna_voice_service
-        container.piper_service = piper_service
-        container.openvoice_service = openvoice_service
+        container.voice_service = tts_result["voice_service"]
+        container.anna_voice_service = tts_result["anna_voice_service"]
+        container.piper_service = tts_result["piper_service"]
+        container.openvoice_service = tts_result["openvoice_service"]
+        container.current_voice_config = tts_result["current_voice_config"]
         container.stt_service = stt_service
         container.llm_service = llm_service
         container.streaming_tts_manager = streaming_tts_manager
-        container.current_voice_config = current_voice_config
 
         # Reload FAQ and voice presets from DB
         from modules.knowledge.startup import reload_llm_faq
@@ -488,197 +198,32 @@ async def startup_event():
         await reload_llm_faq(container)
         await reload_voice_presets(container)
 
-        # Initialize GSM telephony service (skip in cloud mode)
-        if DEPLOYMENT_MODE != "cloud":
-            try:
-                from app.services.gsm_service import GSMService
+        # GSM telephony (GPU/full mode only)
+        from modules.telephony.startup import init_gsm_services
 
-                gsm_service = GSMService()
-                await gsm_service.initialize()
-                container.gsm_service = gsm_service
-                mode = "mock" if gsm_service.mock_mode else "hardware"
-                logger.info(f"✅ GSM service initialized ({mode} mode)")
+        await init_gsm_services(container, DEPLOYMENT_MODE)
 
-                # Start voice call service (auto-answer with AI assistant)
-                try:
-                    from app.services.gsm_voice_call import GSMVoiceCallService
+        # Internet Monitor + LLM auto-switching
+        from modules.core.startup import init_internet_monitor
 
-                    voice_call = GSMVoiceCallService(
-                        gsm_service=gsm_service,
-                        stt_service=getattr(container, "stt_service", None),
-                        tts_service=container.anna_voice_service or container.voice_service,
-                        piper_service=container.piper_service,
-                        tts_voice="xtts",  # or "piper" for CPU
-                        piper_voice="irina",  # irina / dmitri
-                        rag_mode="all",  # use all knowledge collections
-                    )
-                    await voice_call.start()
-                    container.gsm_voice_call = voice_call
-                    logger.info("✅ GSM Voice Call service started (auto-answer)")
-                except Exception as vc_err:
-                    logger.warning(f"⚠️ GSM Voice Call not available: {vc_err}")
-            except Exception as gsm_err:
-                logger.warning(f"⚠️ GSM service not available: {gsm_err}")
+        await init_internet_monitor(container, DEPLOYMENT_MODE)
 
-        # Initialize Internet Monitor + LLM auto-switching (skip in cloud mode)
-        if DEPLOYMENT_MODE != "cloud":
-            try:
-                from modules.core.internet_monitor import ConnectivityStatus, InternetMonitor
+        # Wiki RAG service
+        from modules.knowledge.startup import init_wiki_rag
 
-                async def _switch_llm(status: ConnectivityStatus) -> str:
-                    """Switch LLM backend based on internet connectivity."""
-                    global llm_service, LLM_BACKEND
-                    if status in (ConnectivityStatus.ONLINE, ConnectivityStatus.DEGRADED):
-                        # Try cloud provider: claude_bridge first, then default, then any enabled
-                        try:
-                            providers = await async_cloud_provider_manager.list_providers(
-                                enabled_only=True
-                            )
-                            provider = None
-                            # Priority: claude_bridge > is_default > first enabled
-                            for p in providers or []:
-                                if p.get("provider_type") == "claude_bridge" and p.get("enabled"):
-                                    provider = p
-                                    break
-                            if not provider:
-                                for p in providers or []:
-                                    if p.get("is_default") and p.get("enabled"):
-                                        provider = p
-                                        break
-                            if not provider:
-                                for p in providers or []:
-                                    if p.get("enabled"):
-                                        provider = p
-                                        break
-                            if provider:
-                                provider = await async_cloud_provider_manager.get_provider_with_key(
-                                    provider["id"]
-                                )
-                            if provider:
-                                new_svc = CloudLLMService(provider)
-                                llm_service = new_svc
-                                container.llm_service = new_svc
-                                ptype = provider.get("provider_type", "cloud")
-                                backend = f"cloud ({ptype}: {provider.get('name', '?')})"
-                                LLM_BACKEND = f"cloud:{provider['id']}"
-                                return backend
-                        except Exception as e:
-                            logger.warning(f"Cloud LLM switch failed: {e}")
-                        # Fallback to vLLM even when online
-                        if VLLM_AVAILABLE:
-                            try:
-                                new_svc = VLLMLLMService()
-                                if new_svc.is_available():
-                                    llm_service = new_svc
-                                    container.llm_service = new_svc
-                                    LLM_BACKEND = "vllm"
-                                    return "vllm (cloud unavailable)"
-                            except Exception:
-                                pass
-                        return LLM_BACKEND  # keep current
-                    else:
-                        # Offline — switch to local vLLM
-                        if VLLM_AVAILABLE:
-                            try:
-                                new_svc = VLLMLLMService()
-                                if new_svc.is_available():
-                                    llm_service = new_svc
-                                    container.llm_service = new_svc
-                                    LLM_BACKEND = "vllm"
-                                    return "vllm (offline)"
-                            except Exception as e:
-                                logger.error(f"vLLM fallback failed: {e}")
-                        return LLM_BACKEND  # keep current
+        await init_wiki_rag(container, DEPLOYMENT_MODE, task_registry)
 
-                internet_monitor = InternetMonitor(check_interval=30)
-                internet_monitor.set_switch_callback(_switch_llm)
-                await internet_monitor.start()
-                container.internet_monitor = internet_monitor
-                logger.info("✅ InternetMonitor started (auto-switching LLM)")
-            except Exception as im_err:
-                logger.warning(f"⚠️ InternetMonitor not available: {im_err}")
-
-        # Initialize Wiki RAG service
-        try:
-            from app.services.wiki_rag_service import WikiRAGService
-
-            wiki_rag = WikiRAGService(Path("wiki-pages"))
-            container.wiki_rag_service = wiki_rag
-
-            # Initialize embedding provider for Wiki RAG (tiered: local > cloud > none)
-            embedding_provider = None
-
-            # Phase 3: Local embeddings (best quality, DEPLOYMENT_MODE=full only)
-            if DEPLOYMENT_MODE != "cloud":
-                try:
-                    from app.services.embedding_provider import (
-                        LOCAL_EMBEDDINGS_AVAILABLE,
-                        LocalEmbeddingProvider,
-                    )
-
-                    if LOCAL_EMBEDDINGS_AVAILABLE:
-                        embedding_provider = LocalEmbeddingProvider()
-                        logger.info("✅ Wiki RAG: local embeddings (sentence-transformers)")
-                except Exception as local_err:
-                    logger.debug(f"Wiki RAG: local embeddings not available: {local_err}")
-
-            # Phase 2: Cloud embeddings from active LLM provider
-            if not embedding_provider and llm_service and hasattr(llm_service, "config"):
-                try:
-                    cloud_config = llm_service.config
-                    provider_type = cloud_config.get("provider_type", "")
-                    api_key = cloud_config.get("api_key", "")
-
-                    if provider_type == "gemini" and api_key:
-                        from app.services.embedding_provider import GeminiEmbeddingProvider
-
-                        embedding_provider = GeminiEmbeddingProvider(api_key=api_key)
-                        logger.info("✅ Wiki RAG: cloud embeddings (Gemini)")
-                    elif api_key and cloud_config.get("base_url"):
-                        from app.services.embedding_provider import OpenAIEmbeddingProvider
-
-                        embedding_provider = OpenAIEmbeddingProvider(
-                            api_key=api_key,
-                            base_url=cloud_config["base_url"],
-                        )
-                        logger.info("✅ Wiki RAG: cloud embeddings (OpenAI-compatible)")
-                except Exception as cloud_err:
-                    logger.debug(f"Wiki RAG: cloud embeddings not available: {cloud_err}")
-
-            if embedding_provider:
-                wiki_rag.set_embedding_provider(embedding_provider)
-                # Build embeddings in background (registered via TaskRegistry below)
-                from modules.knowledge.tasks import build_wiki_embeddings
-
-                task_registry.register("wiki-embeddings", partial(build_wiki_embeddings, wiki_rag))
-            else:
-                logger.info("📚 Wiki RAG: BM25 only (no embedding provider)")
-
-            # Load per-collection indexes in background
-            from modules.knowledge.tasks import load_collection_indexes
-
-            task_registry.register(
-                "wiki-collection-indexes", partial(load_collection_indexes, wiki_rag)
-            )
-
-        except Exception as wiki_err:
-            logger.warning(f"⚠️ Wiki RAG service not available: {wiki_err}")
+        check_legacy_files()
 
         logger.info("✅ Service container populated for modular routers")
 
-        # Auto-start Telegram bots that were running before restart
+        # Auto-start bots and bridge
         from modules.channels.telegram.startup import auto_start_bots as auto_start_telegram
-
-        await auto_start_telegram()
-
-        # Auto-start WhatsApp bots that were running before restart
         from modules.channels.whatsapp.startup import auto_start_bots as auto_start_whatsapp
-
-        await auto_start_whatsapp()
-
-        # Auto-start bridge if enabled claude_bridge provider exists
         from modules.llm.startup import auto_start_bridge
 
+        await auto_start_telegram()
+        await auto_start_whatsapp()
         await auto_start_bridge()
 
         # Register background tasks via TaskRegistry
@@ -693,11 +238,9 @@ async def startup_event():
         task_registry.register(
             "kanban-sync", sync_kanban_issues, interval=15 * 60, initial_delay=60
         )
-        # WooCommerce: cron-style schedule (daily 23:00 UTC), manages own timing internally
         task_registry.register("woocommerce-sync", woocommerce_daily_sync)
 
         await task_registry.start_all()
-
         logger.info("✅ Основные сервисы загружены успешно")
 
     except Exception as e:
@@ -707,53 +250,26 @@ async def startup_event():
 
 @app.on_event("shutdown")
 async def shutdown_event():
-    """Cleanup on shutdown"""
+    """Cleanup on shutdown."""
     logger.info("🛑 Shutting down AI Secretary Orchestrator")
     await task_registry.cancel_all()
 
-    # Stop Telegram bots
-    try:
-        from multi_bot_manager import multi_bot_manager
+    from modules.core.startup import graceful_shutdown
 
-        await multi_bot_manager.stop_all()
-        logger.info("✅ Telegram bots stopped")
-    except Exception as e:
-        logger.warning(f"⚠️ Error stopping Telegram bots: {e}")
+    await graceful_shutdown()
 
-    # Stop WhatsApp bots
-    try:
-        from whatsapp_manager import whatsapp_manager
-
-        await whatsapp_manager.stop_all()
-        logger.info("✅ WhatsApp bots stopped")
-    except Exception as e:
-        logger.warning(f"⚠️ Error stopping WhatsApp bots: {e}")
-
-    # Stop Claude bridge
-    try:
-        from bridge_manager import bridge_manager
-
-        await bridge_manager.stop()
-        logger.info("✅ Claude bridge stopped")
-    except Exception as e:
-        logger.warning(f"⚠️ Error stopping Claude bridge: {e}")
+    from db.integration import shutdown_database
 
     await shutdown_database()
     logger.info("✅ Shutdown complete")
 
 
-# ============== Admin Web Interface ==============
-# Vue 3 admin panel served from /admin (see Static Files section below)
-
-
-# Remaining admin endpoints extracted in Phase 4.5
-# ============== Static Files for Vue Admin ==============
+# --- Static Files for Vue Admin ---
 
 DEV_MODE = os.getenv("DEV_MODE", "").lower() in ("1", "true", "yes")
 VITE_DEV_URL = os.getenv("VITE_DEV_URL", "http://localhost:5173")
 
 if DEV_MODE:
-    # Dev mode: proxy to Vite dev server for hot reload
     import httpx
 
     @app.api_route("/admin/{path:path}", methods=["GET", "HEAD"])


### PR DESCRIPTION
## Summary

- **All inline service initialization** extracted from `startup_event()` into domain `startup.py` modules:
  - `modules/speech/startup.py` — `init_tts_services()`, `init_stt_service()`, `init_streaming_tts_manager()`
  - `modules/llm/startup.py` — `init_llm_service()` (full fallback chain), `create_llm_switch_callback()` (InternetMonitor callback factory)
  - `modules/knowledge/startup.py` — `init_wiki_rag()` (tiered embedding provider + task registration)
  - `modules/core/startup.py` — `init_internet_monitor()`, `check_legacy_files()`, `graceful_shutdown()`
  - `modules/telephony/startup.py` — `init_gsm_services()` (GSM + voice calls)
- **8 global service variables removed** from orchestrator.py (`voice_service`, `anna_voice_service`, `piper_service`, `openvoice_service`, `stt_service`, `llm_service`, `streaming_tts_manager`, `current_voice_config`)
- **`ServiceContainer`** (`app/dependencies.py`) is now the single source of truth — no more dual state
- **`_switch_llm` callback** refactored: closure factory in `modules/llm/startup.py`, writes only to `container.llm_service` + `os.environ["LLM_BACKEND"]` (no globals)
- **Optional imports** (`VLLM_AVAILABLE`, `PIPER_AVAILABLE`, etc.) moved to domain startup modules
- **orchestrator.py**: 805 → 321 lines (−60%) — pure wiring, zero domain logic

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `ruff format` — formatted
- [x] `pytest tests/` — 65 tests passed
- [ ] Manual: Docker deploy + `curl /health`
- [ ] Manual: verify bot auto-start, LLM init, FAQ/presets reload
- [ ] Manual: verify InternetMonitor callback (if applicable)

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)