### PR TITLE
fix: paste blocks appear after user text, not before

### DIFF
--- a/admin/src/utils/pasteDetect.ts
+++ b/admin/src/utils/pasteDetect.ts
@@ -61,11 +61,11 @@ export function buildMessageContent(text: string, blocks: PastedBlock[]): string
   if (blocks.length === 0) return text
 
   const parts: string[] = []
-  for (const block of blocks) {
-    parts.push(`\`\`\`${block.language}\n${block.content}\n\`\`\``)
-  }
   if (text) {
     parts.push(text)
+  }
+  for (const block of blocks) {
+    parts.push(`\`\`\`${block.language}\n${block.content}\n\`\`\``)
   }
   return parts.join('\n\n')
 }

--- a/mobile/src/utils/pasteDetect.ts
+++ b/mobile/src/utils/pasteDetect.ts
@@ -61,11 +61,11 @@ export function buildMessageContent(text: string, blocks: PastedBlock[]): string
   if (blocks.length === 0) return text
 
   const parts: string[] = []
-  for (const block of blocks) {
-    parts.push(`\`\`\`${block.language}\n${block.content}\n\`\`\``)
-  }
   if (text) {
     parts.push(text)
+  }
+  for (const block of blocks) {
+    parts.push(`\`\`\`${block.language}\n${block.content}\n\`\`\``)
   }
   return parts.join('\n\n')
 }


### PR DESCRIPTION
## Summary

- Reorder `buildMessageContent()` so user's typed text comes first, then pasted code blocks
- Affects both admin and mobile `pasteDetect.ts`
- Before: code blocks → text. After: text → code blocks

## NEWS

🔧 **Вставленный код теперь идёт после текста**

Исправлен порядок: сначала ваш вопрос, потом вставленный код —
как и ожидается при обычном общении с ассистентом.

## Test plan

- [ ] Type "explain this code", paste a snippet → message shows text first, then code block
- [ ] Paste only (no text) → code block sent as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)