### PR TITLE
feat: image upload in chat with OCR text extraction

### DIFF
--- a/admin/src/api/chat.ts
+++ b/admin/src/api/chat.ts
@@ -1,5 +1,17 @@
 import { api, createSSE, getAuthHeaders } from './client'
 
+export interface ChatImage {
+  id: string
+  url: string
+  thumb_url: string
+  ocr_text?: string | null
+  width: number
+  height: number
+  original_name: string
+  size?: number
+  mime_type?: string
+}
+
 export interface ChatMessage {
   id: string
   role: 'user' | 'assistant' | 'system'
@@ -8,6 +20,9 @@ export interface ChatMessage {
   edited?: boolean
   parent_id?: string | null
   is_active?: boolean
+  metadata?: {
+    images?: ChatImage[]
+  } | null
 }
 
 export interface SiblingInfo {
@@ -179,7 +194,8 @@ export const chatApi = {
     content: string,
     onChunk: (data: { type: string; content?: string; message?: ChatMessage; token_usage?: TokenUsage; query?: string; name?: string; found?: boolean }) => void,
     llmOverride?: { llm_backend?: string; system_prompt?: string },
-    widgetInstanceId?: string
+    widgetInstanceId?: string,
+    imageIds?: string[]
   ) => {
     const controller = new AbortController()
 
@@ -189,6 +205,9 @@ export const chatApi = {
     }
     if (widgetInstanceId) {
       body.widget_instance_id = widgetInstanceId
+    }
+    if (imageIds?.length) {
+      body.image_ids = imageIds
     }
 
     fetch(`/admin/chat/sessions/${sessionId}/stream`, {
@@ -278,4 +297,8 @@ export const chatApi = {
 
   getShareableUsers: () =>
     api.get<{ users: ShareableUser[] }>('/admin/chat/shareable-users'),
+
+  // Image upload
+  uploadImage: (sessionId: string, file: File) =>
+    api.upload<{ image: ChatImage }>(`/admin/chat/sessions/${sessionId}/upload-image`, file),
 }

--- a/admin/src/plugins/i18n.ts
+++ b/admin/src/plugins/i18n.ts
@@ -370,6 +370,8 @@ const messages = {
       zenSettings: "Настройки чата",
       pastedLines: "{count} строк",
       removePasted: "Удалить вложение",
+      uploadImage: "Загрузить изображение",
+      removeImage: "Удалить изображение",
       claudeCode: {
         enable: "Включить Claude Code",
         disable: "Выключить Claude Code",
@@ -1703,6 +1705,8 @@ const messages = {
       zenSettings: "Chat settings",
       pastedLines: "{count} lines",
       removePasted: "Remove attachment",
+      uploadImage: "Upload image",
+      removeImage: "Remove image",
       claudeCode: {
         enable: "Enable Claude Code",
         disable: "Disable Claude Code",
@@ -3036,6 +3040,8 @@ const messages = {
       zenSettings: "Чат параметрлері",
       pastedLines: "{count} жол",
       removePasted: "Тіркемені жою",
+      uploadImage: "Сурет жүктеу",
+      removeImage: "Суретті жою",
       claudeCode: {
         enable: "Claude Code қосу",
         disable: "Claude Code өшіру",

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -23,7 +23,7 @@ import 'prismjs/components/prism-diff'
 import 'prismjs/components/prism-markdown'
 import 'prismjs/components/prism-jsx'
 import 'prismjs/components/prism-tsx'
-import { chatApi, ttsApi, llmApi, sttApi, wikiRagApi, type ChatSession, type ChatMessage, type ChatSessionSummary, type CloudProvider, type BranchNode, type SiblingInfo, type TokenUsage } from '@/api'
+import { chatApi, ttsApi, llmApi, sttApi, wikiRagApi, type ChatSession, type ChatMessage, type ChatImage, type ChatSessionSummary, type CloudProvider, type BranchNode, type SiblingInfo, type TokenUsage } from '@/api'
 import BranchTree from '@/components/BranchTree.vue'
 import ChatShareDialog from '@/components/ChatShareDialog.vue'
 import ArtifactPanel, { type Artifact } from '@/components/ArtifactPanel.vue'
@@ -76,7 +76,8 @@ import {
   Minimize2,
   Globe,
   Server,
-  Search
+  Search,
+  ImagePlus
 } from 'lucide-vue-next'
 import { useSidebarCollapse } from '@/composables/useSidebarCollapse'
 import { useClaudeCode } from '@/composables/useClaudeCode'
@@ -159,6 +160,25 @@ const { width: artifactWidth, startResize: startArtifactResize, startTouchResize
 const pastedBlocks = ref<PastedBlock[]>([])
 
 function onPaste(e: ClipboardEvent) {
+  // Handle pasted images
+  const items = e.clipboardData?.items
+  if (items && currentSessionId.value) {
+    for (const item of Array.from(items)) {
+      if (item.type.startsWith('image/')) {
+        e.preventDefault()
+        const file = item.getAsFile()
+        if (file) {
+          isUploadingImage.value = true
+          chatApi.uploadImage(currentSessionId.value, file)
+            .then(({ image }) => pendingImages.value.push(image))
+            .catch(err => toastStore.error(String(err)))
+            .finally(() => { isUploadingImage.value = false })
+        }
+        return
+      }
+    }
+  }
+  // Handle pasted text
   const text = e.clipboardData?.getData('text/plain')
   if (!text || !shouldTreatAsPaste(text)) return
   e.preventDefault()
@@ -168,6 +188,38 @@ function onPaste(e: ClipboardEvent) {
 function removePastedBlock(id: string) {
   pastedBlocks.value = pastedBlocks.value.filter(b => b.id !== id)
 }
+
+// Pending image uploads
+const pendingImages = ref<ChatImage[]>([])
+const isUploadingImage = ref(false)
+const imageInputRef = ref<HTMLInputElement | null>(null)
+
+async function handleImageUpload(e: Event) {
+  const input = e.target as HTMLInputElement
+  const files = input.files
+  if (!files?.length || !currentSessionId.value) return
+
+  isUploadingImage.value = true
+  try {
+    for (const file of Array.from(files)) {
+      if (!file.type.startsWith('image/')) continue
+      const { image } = await chatApi.uploadImage(currentSessionId.value, file)
+      pendingImages.value.push(image)
+    }
+  } catch (err) {
+    toastStore.error(String(err))
+  } finally {
+    isUploadingImage.value = false
+    input.value = ''
+  }
+}
+
+function removePendingImage(id: string) {
+  pendingImages.value = pendingImages.value.filter(i => i.id !== id)
+}
+
+// Fullscreen image viewer
+const fullscreenImage = ref<string | null>(null)
 
 // Artifact viewer state
 const showArtifact = ref(false)
@@ -991,11 +1043,14 @@ async function deleteCcSession(ccSessionId: string, title: string, event: Event)
 function sendMessage() {
   const hasText = inputMessage.value.trim().length > 0
   const hasPaste = pastedBlocks.value.length > 0
-  if ((!hasText && !hasPaste) || !currentSessionId.value || isStreaming.value) return
+  const hasImages = pendingImages.value.length > 0
+  if ((!hasText && !hasPaste && !hasImages) || !currentSessionId.value || isStreaming.value) return
 
   const content = buildMessageContent(inputMessage.value.trim(), pastedBlocks.value)
+  const imageIds = pendingImages.value.map(i => i.id)
   inputMessage.value = ''
   pastedBlocks.value = []
+  pendingImages.value = []
   if (messageInputRef.value) messageInputRef.value.style.height = 'auto'
 
   // Show user message immediately (optimistic)
@@ -1063,7 +1118,7 @@ function sendMessage() {
       refetchSessions()
       nextTick(() => messageInputRef.value?.focus())
     }
-  }, llmOverride)
+  }, llmOverride, undefined, imageIds.length ? imageIds : undefined)
 }
 
 function ccSendMessage() {
@@ -2860,6 +2915,30 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
           inputPosition === 'bottom' ? 'border-t border-border order-last' + (fullscreenStore.isFullscreen ? '' : ' pb-24') : 'border-b border-border'
         ]"
       >
+        <!-- Pending image previews -->
+        <div v-if="pendingImages.length" class="flex flex-wrap gap-2 mb-2 max-w-3xl mx-auto">
+          <div
+            v-for="img in pendingImages"
+            :key="img.id"
+            class="relative group/img"
+          >
+            <img
+              :src="img.thumb_url"
+              :alt="img.original_name"
+              class="h-20 rounded-lg border border-border object-cover"
+            />
+            <button
+              class="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-destructive text-white flex items-center justify-center opacity-0 group-hover/img:opacity-100 transition-opacity"
+              :title="t('chatView.removeImage')"
+              @click="removePendingImage(img.id)"
+            >
+              <X class="w-3 h-3" />
+            </button>
+            <div v-if="img.ocr_text" class="absolute bottom-0.5 right-0.5 bg-black/60 text-white text-[10px] px-1 rounded">
+              OCR
+            </div>
+          </div>
+        </div>
         <!-- Pasted blocks chips -->
         <div v-if="pastedBlocks.length" class="flex flex-wrap gap-2 mb-2 max-w-3xl mx-auto">
           <div
@@ -2897,6 +2976,24 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
             @input="onInputAutoResize"
             @paste="onPaste"
           />
+          <!-- Image upload button -->
+          <button
+            :disabled="isStreaming || isUploadingImage || !currentSessionId"
+            class="p-3 rounded-lg bg-secondary hover:bg-secondary/80 transition-colors disabled:opacity-50"
+            :title="t('chatView.uploadImage')"
+            @click="imageInputRef?.click()"
+          >
+            <Loader2 v-if="isUploadingImage" class="w-5 h-5 animate-spin" />
+            <ImagePlus v-else class="w-5 h-5" />
+          </button>
+          <input
+            ref="imageInputRef"
+            type="file"
+            accept="image/jpeg,image/png,image/webp,image/gif"
+            multiple
+            class="hidden"
+            @change="handleImageUpload"
+          />
           <!-- Microphone button -->
           <button
             :disabled="isStreaming || isTranscribing"
@@ -2915,7 +3012,7 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
           </button>
           <!-- Send button -->
           <button
-            :disabled="(!inputMessage.trim() && !pastedBlocks.length) || isStreaming || isRecording"
+            :disabled="(!inputMessage.trim() && !pastedBlocks.length && !pendingImages.length) || isStreaming || isRecording"
             class="p-3 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors"
             @click="sendMessage"
           >
@@ -3151,6 +3248,20 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
 
               <!-- Normal mode -->
               <template v-else>
+                <!-- Image attachments -->
+                <div v-if="message.metadata?.images?.length" class="flex flex-wrap gap-2 mb-2">
+                  <div v-for="img in message.metadata.images" :key="img.id" class="relative group/img">
+                    <img
+                      :src="img.thumb_url || img.url"
+                      :alt="img.original_name || 'image'"
+                      class="rounded-lg max-h-48 cursor-pointer hover:opacity-90 transition-opacity"
+                      @click="fullscreenImage = img.url"
+                    />
+                    <div v-if="img.ocr_text" class="absolute bottom-1 right-1 bg-black/60 text-white text-[10px] px-1.5 py-0.5 rounded">
+                      OCR
+                    </div>
+                  </div>
+                </div>
                 <div class="chat-markdown break-words" v-html="renderMarkdown(message.content, message.id)"></div>
                 <div class="flex items-center gap-2 mt-2 text-xs text-muted-foreground">
                   <span>{{ formatTime(message.timestamp) }}</span>
@@ -3588,6 +3699,18 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
     :open="showShareDialog"
     @close="showShareDialog = false"
   />
+
+  <!-- Fullscreen image viewer -->
+  <div
+    v-if="fullscreenImage"
+    class="fixed inset-0 z-[100] bg-black/90 flex items-center justify-center cursor-pointer"
+    @click="fullscreenImage = null"
+  >
+    <img :src="fullscreenImage" class="max-w-[90vw] max-h-[90vh] object-contain rounded-lg" />
+    <button class="absolute top-4 right-4 p-2 rounded-full bg-white/10 hover:bg-white/20 text-white">
+      <X class="w-6 h-6" />
+    </button>
+  </div>
 </template>
 
 <style scoped>

--- a/db/repositories/chat.py
+++ b/db/repositories/chat.py
@@ -314,6 +314,7 @@ class ChatRepository(BaseRepository[ChatSession]):
         role: str,
         content: str,
         parent_id: Optional[str] = None,
+        extra_data: Optional[str] = None,
     ) -> Optional[dict]:
         """Add message to session. Auto-detects parent if not provided."""
         result = await self.session.execute(
@@ -341,6 +342,7 @@ class ChatRepository(BaseRepository[ChatSession]):
             created=datetime.utcnow(),
             parent_id=parent_id,
             is_active=True,
+            extra_data=extra_data,
         )
 
         self.session.add(message)

--- a/modules/chat/image_service.py
+++ b/modules/chat/image_service.py
@@ -1,0 +1,146 @@
+"""Chat image service: upload, OCR, storage, cleanup."""
+
+import hashlib
+import logging
+import shutil
+import time
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image
+
+
+try:
+    import pytesseract
+
+    PYTESSERACT_AVAILABLE = True
+except ImportError:
+    pytesseract = None  # type: ignore[assignment]
+    PYTESSERACT_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+IMAGES_DIR = Path("data/chat_images")
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+ALLOWED_MIME_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
+THUMB_MAX_WIDTH = 400
+
+
+def _generate_image_id() -> str:
+    ts = str(time.time())
+    return f"img_{int(time.time() * 1000)}_{hashlib.md5(ts.encode()).hexdigest()[:6]}"
+
+
+def _session_dir(session_id: str) -> Path:
+    """Get/create directory for session images."""
+    d = IMAGES_DIR / session_id
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _get_extension(content_type: str) -> str:
+    return {
+        "image/jpeg": "jpg",
+        "image/png": "png",
+        "image/webp": "webp",
+        "image/gif": "gif",
+    }.get(content_type, "jpg")
+
+
+async def upload_image(
+    session_id: str,
+    file_data: bytes,
+    content_type: str,
+    original_name: str,
+) -> dict:
+    """Save image, generate thumbnail, run OCR. Returns metadata dict."""
+    if len(file_data) > MAX_FILE_SIZE:
+        raise ValueError(f"File too large: {len(file_data)} > {MAX_FILE_SIZE}")
+
+    if content_type not in ALLOWED_MIME_TYPES:
+        raise ValueError(f"Unsupported type: {content_type}")
+
+    image_id = _generate_image_id()
+    ext = _get_extension(content_type)
+    session_dir = _session_dir(session_id)
+
+    # Save original
+    original_path = session_dir / f"{image_id}.{ext}"
+    original_path.write_bytes(file_data)
+
+    # Open with Pillow for dimensions + thumbnail + OCR
+    img = Image.open(original_path)
+    width, height = img.size
+
+    # Generate thumbnail
+    thumb_path = session_dir / f"{image_id}_thumb.jpg"
+    thumb = img.copy()
+    if width > THUMB_MAX_WIDTH:
+        ratio = THUMB_MAX_WIDTH / width
+        thumb = thumb.resize((THUMB_MAX_WIDTH, int(height * ratio)), Image.LANCZOS)
+    if thumb.mode in ("RGBA", "P"):
+        thumb = thumb.convert("RGB")
+    thumb.save(thumb_path, "JPEG", quality=80)
+
+    # OCR
+    ocr_text: Optional[str] = None
+    if PYTESSERACT_AVAILABLE:
+        try:
+            # Use Russian + English
+            ocr_img = img.convert("RGB") if img.mode != "RGB" else img
+            raw = pytesseract.image_to_string(ocr_img, lang="rus+eng", timeout=15)
+            ocr_text = raw.strip() if raw and raw.strip() else None
+        except Exception as e:
+            logger.warning(f"OCR failed for {original_name}: {e}")
+
+    return {
+        "id": image_id,
+        "filename": f"{image_id}.{ext}",
+        "original_name": original_name,
+        "size": len(file_data),
+        "width": width,
+        "height": height,
+        "ocr_text": ocr_text,
+        "mime_type": content_type,
+    }
+
+
+def get_image_path(session_id: str, filename: str) -> Optional[Path]:
+    """Get full path to an image file, or None if not found."""
+    path = IMAGES_DIR / session_id / filename
+    if path.exists() and path.is_file():
+        # Security: ensure path is within IMAGES_DIR
+        try:
+            path.resolve().relative_to(IMAGES_DIR.resolve())
+            return path
+        except ValueError:
+            return None
+    return None
+
+
+def delete_session_images(session_id: str) -> int:
+    """Delete all images for a session. Returns number of files deleted."""
+    session_dir = IMAGES_DIR / session_id
+    if not session_dir.exists():
+        return 0
+    count = sum(1 for f in session_dir.iterdir() if f.is_file())
+    shutil.rmtree(session_dir, ignore_errors=True)
+    logger.info(f"Deleted {count} images for session {session_id}")
+    return count
+
+
+def delete_images_by_metadata(session_id: str, metadata: dict) -> int:
+    """Delete specific images referenced in message metadata."""
+    images = metadata.get("images", [])
+    if not images:
+        return 0
+    count = 0
+    session_dir = IMAGES_DIR / session_id
+    for img in images:
+        filename = img.get("filename", "")
+        image_id = img.get("id", "")
+        for f in [session_dir / filename, session_dir / f"{image_id}_thumb.jpg"]:
+            if f.exists():
+                f.unlink(missing_ok=True)
+                count += 1
+    return count

--- a/modules/chat/models.py
+++ b/modules/chat/models.py
@@ -137,6 +137,9 @@ class ChatMessage(Base):
     edited: Mapped[bool] = mapped_column(Boolean, default=False)
     created: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
+    # JSON metadata (images, etc.)
+    extra_data: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
     # Branching fields
     parent_id: Mapped[Optional[str]] = mapped_column(
         String(50),
@@ -163,7 +166,7 @@ class ChatMessage(Base):
     __table_args__ = (Index("ix_chat_messages_session_created", "session_id", "created"),)
 
     def to_dict(self) -> dict:
-        return {
+        result = {
             "id": self.id,
             "role": self.role,
             "content": self.content,
@@ -172,6 +175,12 @@ class ChatMessage(Base):
             "parent_id": self.parent_id,
             "is_active": self.is_active,
         }
+        if self.extra_data:
+            try:
+                result["metadata"] = json.loads(self.extra_data)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return result
 
 
 class ChatSessionShare(Base):

--- a/modules/chat/router.py
+++ b/modules/chat/router.py
@@ -6,8 +6,8 @@ import logging
 from datetime import datetime, timedelta
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile
+from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel
 
 from app.dependencies import get_container
@@ -61,6 +61,9 @@ KNOWLEDGE_SEARCH_TOOL = {
     },
 }
 MAX_TOOL_ITERATIONS = 5
+
+# Temporary cache for OCR text from uploaded images (upload → send are two separate requests)
+_pending_image_ocr: dict[str, str] = {}
 
 _AGENTIC_RAG_SUFFIX = (
     "\n\nУ тебя есть инструмент knowledge_search для поиска по базе знаний. "
@@ -363,6 +366,7 @@ class LLMOverrideConfig(BaseModel):
 
 class SendMessageRequest(BaseModel):
     content: str
+    image_ids: Optional[list[str]] = None
     llm_override: Optional[LLMOverrideConfig] = None
     widget_instance_id: Optional[str] = None
     mobile_instance_id: Optional[str] = None
@@ -617,8 +621,44 @@ async def admin_send_chat_message(
     if not llm_service:
         raise HTTPException(status_code=503, detail="LLM service not available")
 
-    # Добавляем сообщение пользователя
-    user_msg = await chat_service.add_message(session_id, "user", msg_request.content)
+    # Добавляем сообщение пользователя (with image metadata if any)
+    extra_data_json_ns = None
+    image_ocr_parts_ns: list[str] = []
+    if msg_request.image_ids:
+        from modules.chat.image_service import IMAGES_DIR
+
+        images_meta_ns = []
+        for img_id in msg_request.image_ids:
+            session_dir = IMAGES_DIR / session_id
+            if not session_dir.exists():
+                continue
+            for f in session_dir.iterdir():
+                if f.name.startswith(img_id) and not f.name.endswith("_thumb.jpg"):
+                    images_meta_ns.append(
+                        {
+                            "id": img_id,
+                            "filename": f.name,
+                            "url": f"/admin/chat/images/{session_id}/{f.name}",
+                            "thumb_url": f"/admin/chat/images/{session_id}/{img_id}_thumb.jpg",
+                        }
+                    )
+                    break
+            ocr = _pending_image_ocr.pop(img_id, None)
+            if ocr:
+                image_ocr_parts_ns.append(ocr)
+        if images_meta_ns:
+            extra_data_json_ns = json.dumps({"images": images_meta_ns}, ensure_ascii=False)
+
+    llm_content_ns = msg_request.content
+    if image_ocr_parts_ns:
+        ocr_block = "\n\n".join(f"[Текст с изображения]:\n{ocr}" for ocr in image_ocr_parts_ns)
+        llm_content_ns = (
+            f"{msg_request.content}\n\n{ocr_block}" if msg_request.content else ocr_block
+        )
+
+    user_msg = await chat_service.add_message(
+        session_id, "user", llm_content_ns, extra_data=extra_data_json_ns
+    )
 
     # Получаем историю для LLM
     # Session prompt takes priority; fallback to LLM service default
@@ -826,8 +866,44 @@ async def admin_stream_chat_message(
     if not active_llm:
         raise HTTPException(status_code=503, detail="LLM service not available")
 
-    # Добавляем сообщение пользователя
-    user_msg = await chat_service.add_message(session_id, "user", msg_request.content)
+    # Добавляем сообщение пользователя (with image metadata if any)
+    extra_data_json = None
+    image_ocr_parts: list[str] = []
+
+    if msg_request.image_ids:
+        from modules.chat.image_service import IMAGES_DIR
+
+        images_meta = []
+        for img_id in msg_request.image_ids:
+            session_dir = IMAGES_DIR / session_id
+            if not session_dir.exists():
+                continue
+            for f in session_dir.iterdir():
+                if f.name.startswith(img_id) and not f.name.endswith("_thumb.jpg"):
+                    images_meta.append(
+                        {
+                            "id": img_id,
+                            "filename": f.name,
+                            "url": f"/admin/chat/images/{session_id}/{f.name}",
+                            "thumb_url": f"/admin/chat/images/{session_id}/{img_id}_thumb.jpg",
+                        }
+                    )
+                    break
+            ocr = _pending_image_ocr.pop(img_id, None)
+            if ocr:
+                image_ocr_parts.append(ocr)
+        if images_meta:
+            extra_data_json = json.dumps({"images": images_meta}, ensure_ascii=False)
+
+    # Build content: user text + OCR from images
+    llm_content = msg_request.content
+    if image_ocr_parts:
+        ocr_block = "\n\n".join(f"[Текст с изображения]:\n{ocr}" for ocr in image_ocr_parts)
+        llm_content = f"{msg_request.content}\n\n{ocr_block}" if msg_request.content else ocr_block
+
+    user_msg = await chat_service.add_message(
+        session_id, "user", llm_content, extra_data=extra_data_json
+    )
 
     # Получаем историю для LLM
     # Priority: widget prompt > session prompt > LLM service default
@@ -1422,3 +1498,78 @@ async def admin_get_shareable_users(user: User = Depends(require_permission("cha
     """Список пользователей для шаринга"""
     users = await chat_share_service.list_shareable_users(exclude_user_id=user.id)
     return {"users": users}
+
+
+# ============== Image Endpoints ==============
+
+
+@router.post("/sessions/{session_id}/upload-image")
+async def admin_upload_chat_image(
+    session_id: str,
+    file: UploadFile = File(...),
+    user: User = Depends(require_permission("chat", "edit")),
+):
+    """Upload an image for a chat session, run OCR, return metadata."""
+    from modules.chat.image_service import ALLOWED_MIME_TYPES, MAX_FILE_SIZE, upload_image
+
+    await _check_write_access(session_id, user)
+
+    content_type = file.content_type or "application/octet-stream"
+    if content_type not in ALLOWED_MIME_TYPES:
+        raise HTTPException(status_code=400, detail=f"Unsupported image type: {content_type}")
+
+    file_data = await file.read()
+    if len(file_data) > MAX_FILE_SIZE:
+        raise HTTPException(status_code=400, detail="File too large (max 10MB)")
+
+    try:
+        image_meta = await upload_image(
+            session_id, file_data, content_type, file.filename or "image.jpg"
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    # Cache OCR text for when the message is sent
+    if image_meta.get("ocr_text"):
+        _pending_image_ocr[image_meta["id"]] = image_meta["ocr_text"]
+
+    return {
+        "image": {
+            "id": image_meta["id"],
+            "url": f"/admin/chat/images/{session_id}/{image_meta['filename']}",
+            "thumb_url": f"/admin/chat/images/{session_id}/{image_meta['id']}_thumb.jpg",
+            "ocr_text": image_meta.get("ocr_text"),
+            "width": image_meta["width"],
+            "height": image_meta["height"],
+            "original_name": image_meta["original_name"],
+            "size": image_meta["size"],
+            "mime_type": image_meta["mime_type"],
+        }
+    }
+
+
+@router.get("/images/{session_id}/{filename}")
+async def serve_chat_image(
+    session_id: str,
+    filename: str,
+    user: User = Depends(require_permission("chat", "view")),
+):
+    """Serve an uploaded chat image (auth-gated)."""
+    from modules.chat.image_service import get_image_path
+
+    path = get_image_path(session_id, filename)
+    if not path:
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    # Determine media type
+    suffix = path.suffix.lower()
+    media_types = {
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".png": "image/png",
+        ".webp": "image/webp",
+        ".gif": "image/gif",
+    }
+    media_type = media_types.get(suffix, "application/octet-stream")
+
+    return FileResponse(path, media_type=media_type)

--- a/modules/chat/service.py
+++ b/modules/chat/service.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional
 from db.database import AsyncSessionLocal
 from db.repositories import ChatRepository, ChatShareRepository, UserRepository
 from db.retry import retry_on_busy
+from modules.chat.image_service import delete_session_images
 
 
 logger = logging.getLogger(__name__)
@@ -117,13 +118,15 @@ class ChatService:
         owner_id: Optional[int] = None,
         workspace_id: Optional[int] = None,
     ) -> bool:
-        """Delete session."""
+        """Delete session and its images."""
         async with AsyncSessionLocal() as session:
             repo = ChatRepository(session)
             result = await repo.delete_session(
                 session_id, owner_id=owner_id, workspace_id=workspace_id
             )
             await session.commit()
+            if result:
+                delete_session_images(session_id)
             return result
 
     @retry_on_busy()
@@ -133,13 +136,16 @@ class ChatService:
         owner_id: Optional[int] = None,
         workspace_id: Optional[int] = None,
     ) -> int:
-        """Delete multiple sessions by ID list."""
+        """Delete multiple sessions and their images."""
         async with AsyncSessionLocal() as session:
             repo = ChatRepository(session)
             result = await repo.delete_sessions_bulk(
                 session_ids, owner_id=owner_id, workspace_id=workspace_id
             )
             await session.commit()
+            if result:
+                for sid in session_ids:
+                    delete_session_images(sid)
             return result
 
     async def list_sessions_grouped(
@@ -169,11 +175,14 @@ class ChatService:
         role: str,
         content: str,
         parent_id: Optional[str] = None,
+        extra_data: Optional[str] = None,
     ) -> Optional[dict]:
         """Add message to session."""
         async with AsyncSessionLocal() as session:
             repo = ChatRepository(session)
-            result = await repo.add_message(session_id, role, content, parent_id=parent_id)
+            result = await repo.add_message(
+                session_id, role, content, parent_id=parent_id, extra_data=extra_data
+            )
             await session.commit()
             return result
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,5 +58,8 @@ snowballstemmer>=2.2.0  # Russian/English stemming for BM25 search
 # Document text extraction (Telegram file uploads)
 pdfplumber>=0.10.0
 
+# OCR for chat image uploads (optional — requires tesseract-ocr system package)
+pytesseract>=0.3.10
+
 # Docker management (for starting vLLM from container)
 docker>=7.0.0

--- a/scripts/migrate_add_extra_data_to_chat_messages.py
+++ b/scripts/migrate_add_extra_data_to_chat_messages.py
@@ -1,0 +1,49 @@
+"""
+Add extra_data column to chat_messages for image metadata.
+
+Usage:
+    python scripts/migrate_add_extra_data_to_chat_messages.py
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+
+DB_PATH = Path(__file__).parent.parent / "data" / "secretary.db"
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    """Add extra_data TEXT column to chat_messages if not exists."""
+    cols = [row[1] for row in conn.execute("PRAGMA table_info(chat_messages)").fetchall()]
+    if "extra_data" in cols:
+        print("Column extra_data already exists — skipping")
+        return
+    conn.execute("ALTER TABLE chat_messages ADD COLUMN extra_data TEXT")
+    print("Added extra_data column to chat_messages")
+
+
+def main() -> None:
+    if not DB_PATH.exists():
+        print(f"Database not found: {DB_PATH}")
+        sys.exit(1)
+
+    conn = sqlite3.connect(str(DB_PATH))
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute("PRAGMA busy_timeout=5000")
+
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        migrate(conn)
+        conn.commit()
+        print("Migration completed successfully")
+    except Exception as e:
+        conn.rollback()
+        print(f"Migration failed: {e}")
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Image upload**: JPEG/PNG/WebP/GIF up to 10MB, stored in `data/chat_images/{session_id}/`
- **OCR**: pytesseract extracts text (Russian + English), injected into LLM message as `[Текст с изображения]` block
- **Lifecycle**: images deleted when session is deleted (via `ChatService.delete_session` hooks)
- **Frontend**: upload button, clipboard paste, thumbnail preview, fullscreen viewer, OCR badge
- **DB**: `extra_data` TEXT column on `chat_messages` (JSON metadata for images)
- **Migration**: `scripts/migrate_add_extra_data_to_chat_messages.py`
- **Dependency**: `pytesseract>=0.3.10` (optional — requires `tesseract-ocr` system package)
- **i18n**: `uploadImage` + `removeImage` keys in ru/en/kk

## NEWS

🖼️ **Загрузка фото в чат с распознаванием текста**

Теперь в чат можно загружать изображения — фото документов, скриншоты,
сканы. Система автоматически распознаёт текст (OCR) и отправляет его
ассистенту вместе с вашим вопросом. Можно вставлять через Ctrl+V
или кнопку загрузки. Фото хранятся ровно столько, сколько живёт чат —
при удалении чата удаляются и все вложения.

## Test plan

- [ ] Upload JPEG via button → thumbnail preview appears, send → image in message bubble
- [ ] Paste image from clipboard (Ctrl+V) → same flow
- [ ] Upload image with text → OCR badge appears, LLM receives extracted text
- [ ] Delete chat session → `data/chat_images/{session_id}/` directory removed
- [ ] Bulk delete sessions → images cleaned up for all
- [ ] Click image thumbnail in message → fullscreen overlay
- [ ] Upload >10MB file → error message
- [ ] Upload non-image file → rejected
- [ ] Send with only image (no text) → works
- [ ] Migration script: `python scripts/migrate_add_extra_data_to_chat_messages.py`
- [ ] Build: `cd admin && npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)