### PR TITLE
Phase 4.8: Documentation update (#553)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -71,7 +71,8 @@ Roadmap и план работ для AI Secretary System. Этот файл и�
 **Завершено:** 2026-01-28
 
 **Описание:**
-Разбить orchestrator.py (~170 endpoints) на модульную структуру `app/routers/`.
+Разбить orchestrator.py на модульную структуру `app/routers/`.
+> **Примечание:** Полная декомпозиция завершена в Phase 4 (issue #494): orchestrator.py 4100 → 321 строк. Все endpoints в `modules/*/router*.py`, сервисы в `modules/*/startup.py`, задачи в `modules/*/tasks.py`.
 
 **Задачи:**
 - [x] Создать `app/` структуру с routers, services, models

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -93,8 +93,9 @@ jobs:
 - [ ] Configure branch protection (require CI pass)
 - [ ] Add Dependabot for Python and npm
 
-### 0.2 Code Restructuring [P0]
-**Why:** orchestrator.py is too large (~60 endpoints), hard to maintain
+### 0.2 Code Restructuring [P0] ✅
+**Why:** orchestrator.py was too large — hard to maintain.
+**Status:** Complete. Phase 0.2 extracted 11 routers. Phase 4 (issue #494) completed full decomposition: orchestrator.py 4100 → 321 lines. All endpoints in `modules/*/router*.py`, all service init in `modules/*/startup.py`, all background tasks via `TaskRegistry`. See [Architecture wiki](https://github.com/ShaerWare/AI_Secretary_System/wiki/Architecture) for details.
 
 ```
 AI_Secretary_System/
@@ -136,7 +137,7 @@ AI_Secretary_System/
 │   ├── test_tts.py
 │   └── test_api.py
 │
-├── orchestrator.py             # DEPRECATED → app/main.py
+├── orchestrator.py             # FastAPI entry point (~320 lines, pure wiring)
 └── ...
 ```
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -196,15 +196,22 @@ AI Secretary System - виртуальный секретарь с клонир�
 ### Service Container (Dependency Injection)
 
 ```
-app/dependencies.py → ServiceContainer (Singleton)
+app/dependencies.py → ServiceContainer (Singleton, single source of truth)
 │
-├─ .voice_service        → VoiceCloneService (XTTS Marina)
-├─ .anna_voice_service  → VoiceCloneService (XTTS Anna)
-├─ .piper_service        → PiperTTSService (CPU)
-├─ .llm_service          → LLMService (vLLM или Cloud)
-├─ .stt_service          → UnifiedSTTService (Vosk + Whisper)
-├─ .streaming_tts_manager → StreamingTTSManager
-└─ .faq_manager          → AsyncFAQManager
+├─ .voice_service          → VoiceCloneService (XTTS Marina)
+├─ .anna_voice_service     → VoiceCloneService (XTTS Anna)
+├─ .piper_service          → PiperTTSService (CPU)
+├─ .openvoice_service      → OpenVoiceService (GPU CC 6.1+)
+├─ .llm_service            → CloudLLMService or VLLMLLMService
+├─ .stt_service            → VoskSTTService
+├─ .streaming_tts_manager  → StreamingTTSManager
+├─ .wiki_rag_service       → WikiRAGService
+├─ .gsm_service            → GSMService
+├─ .internet_monitor       → InternetMonitor
+└─ .current_voice_config   → dict (engine + voice)
+
+Populated by domain init functions in modules/*/startup.py
+No global service variables — container is the only state holder
 ```
 
 ### Cloud LLM Factory

--- a/wiki-pages/Architecture.md
+++ b/wiki-pages/Architecture.md
@@ -31,11 +31,11 @@
 
 ## Текущее состояние
 
-### Монолит (исторический)
+### Текущее состояние после Phase 4
 
 | Компонент | Размер | Что содержит |
 |-----------|--------|-------------|
-| `orchestrator.py` | ~4100 строк | FastAPI entry point, инициализация сервисов, legacy endpoints, background tasks, регистрация 28 роутеров |
+| `orchestrator.py` | ~320 строк | Чистый wiring: imports, middleware, регистрация 28 роутеров, вызовы доменных init-функций, static files |
 | `db/models.py` | ~200 строк (фасад) | Реэкспорт моделей из `modules/*/models.py` (54 модели) |
 | `db/integration.py` | ~100 строк (фасад) | Импорт синглтонов и классов из `modules/*/service.py` под старыми именами |
 
@@ -476,7 +476,7 @@ from modules.kanban.service import kanban_service as async_kanban_manager
 
 **Ключевые решения:**
 - `numpy` — lazy import внутри `_cache_full_audio()` (избегает ошибок импорта в cloud mode без GPU)
-- Глобальная переменная `streaming_tts_manager` и все 17 точек использования остаются в `orchestrator.py` (будут перенесены в Phase 4.5)
+- Глобальная переменная `streaming_tts_manager` перенесена в `ServiceContainer` (Phase 4.7b)
 - `synthesize_with_current_voice()` перенесена в `modules/compat/router.py` в Phase 4.3 (переписана на `get_container()`)
 - 5 неиспользуемых импортов удалены из orchestrator (`hashlib`, `re`, `OrderedDict`, `ThreadPoolExecutor`, `numpy`)
 
@@ -589,7 +589,7 @@ from modules.kanban.service import kanban_service as async_kanban_manager
 - `router_logs.py` регистрируется безусловно (доступен во всех режимах)
 - 35 из 52 эндпоинтов были мёртвыми дубликатами (shadowed модульными роутерами, зарегистрированными ранее)
 
-**Результат:** orchestrator.py: 2471 → 1121 строк (−1350). Содержит: импорты, middleware, регистрацию роутеров, глобальные сервисные переменные, startup/shutdown lifecycle, раздачу статических файлов.
+**Результат:** orchestrator.py: 2471 → 1121 строк (−1350). Содержит: импорты, middleware, регистрацию роутеров, startup/shutdown lifecycle, раздачу статических файлов.
 
 ### Phase 4.6: Background tasks → TaskRegistry
 

--- a/wiki-pages/Response-Pipeline.md
+++ b/wiki-pages/Response-Pipeline.md
@@ -193,7 +193,7 @@ Quiz: тип проекта → описание → бизнес-цель → �
 
 ### Публичный виджет (без авторизации)
 
-Эндпоинт: `POST /widget/chat/session/{id}/stream` (`orchestrator.py`)
+Эндпоинт: `POST /widget/chat/session/{id}/stream` (`modules/channels/widget/router_public.py`)
 
 ```
 Сообщение в виджете


### PR DESCRIPTION
## Summary

Update all documentation to reflect Phase 4 completion (orchestrator.py: 4100 → 321 lines).

- **wiki-pages/Architecture.md**: update orchestrator table from "~4100 строк" to "~320 строк", fix outdated global variable references
- **wiki-pages/Response-Pipeline.md**: fix endpoint locations (orchestrator → domain modules)
- **docs/WORKFLOW.md**: update ServiceContainer diagram with all current attributes
- **docs/IMPROVEMENT_PLAN.md**: mark section 0.2 as complete, fix orchestrator description
- **BACKLOG.md**: add Phase 4 completion note to section 0.2
- **GitHub Wiki**: RBAC.md, Deployment-Profiles.md, Database.md, Response-Pipeline.md, Architecture.md updated separately

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)