### PR TITLE
feat: document upload in chat — PDF, Excel, Word, text

### DIFF
--- a/admin/src/api/chat.ts
+++ b/admin/src/api/chat.ts
@@ -3,13 +3,14 @@ import { api, createSSE, getAuthHeaders } from './client'
 export interface ChatImage {
   id: string
   url: string
-  thumb_url: string
+  thumb_url?: string | null
   ocr_text?: string | null
   width: number
   height: number
   original_name: string
   size?: number
   mime_type?: string
+  is_image?: boolean
 }
 
 export interface ChatMessage {

--- a/admin/src/plugins/i18n.ts
+++ b/admin/src/plugins/i18n.ts
@@ -370,8 +370,8 @@ const messages = {
       zenSettings: "Настройки чата",
       pastedLines: "{count} строк",
       removePasted: "Удалить вложение",
-      uploadImage: "Загрузить изображение",
-      removeImage: "Удалить изображение",
+      attachFile: "Прикрепить файл",
+      removeImage: "Удалить вложение",
       claudeCode: {
         enable: "Включить Claude Code",
         disable: "Выключить Claude Code",
@@ -1705,8 +1705,8 @@ const messages = {
       zenSettings: "Chat settings",
       pastedLines: "{count} lines",
       removePasted: "Remove attachment",
-      uploadImage: "Upload image",
-      removeImage: "Remove image",
+      attachFile: "Attach file",
+      removeImage: "Remove attachment",
       claudeCode: {
         enable: "Enable Claude Code",
         disable: "Disable Claude Code",
@@ -3040,8 +3040,8 @@ const messages = {
       zenSettings: "Чат параметрлері",
       pastedLines: "{count} жол",
       removePasted: "Тіркемені жою",
-      uploadImage: "Сурет жүктеу",
-      removeImage: "Суретті жою",
+      attachFile: "Файл тіркеу",
+      removeImage: "Тіркемені жою",
       claudeCode: {
         enable: "Claude Code қосу",
         disable: "Claude Code өшіру",

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -76,8 +76,7 @@ import {
   Minimize2,
   Globe,
   Server,
-  Search,
-  ImagePlus
+  Search
 } from 'lucide-vue-next'
 import { useSidebarCollapse } from '@/composables/useSidebarCollapse'
 import { useClaudeCode } from '@/composables/useClaudeCode'
@@ -202,7 +201,6 @@ async function handleImageUpload(e: Event) {
   isUploadingImage.value = true
   try {
     for (const file of Array.from(files)) {
-      if (!file.type.startsWith('image/')) continue
       const { image } = await chatApi.uploadImage(currentSessionId.value, file)
       pendingImages.value.push(image)
     }
@@ -2915,29 +2913,41 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
           inputPosition === 'bottom' ? 'border-t border-border order-last' + (fullscreenStore.isFullscreen ? '' : ' pb-24') : 'border-b border-border'
         ]"
       >
-        <!-- Pending image previews -->
+        <!-- Pending file previews -->
         <div v-if="pendingImages.length" class="flex flex-wrap gap-2 mb-2 max-w-3xl mx-auto">
-          <div
-            v-for="img in pendingImages"
-            :key="img.id"
-            class="relative group/img"
-          >
-            <img
-              :src="img.thumb_url"
-              :alt="img.original_name"
-              class="h-20 rounded-lg border border-border object-cover"
-            />
-            <button
-              class="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-destructive text-white flex items-center justify-center opacity-0 group-hover/img:opacity-100 transition-opacity"
-              :title="t('chatView.removeImage')"
-              @click="removePendingImage(img.id)"
-            >
-              <X class="w-3 h-3" />
-            </button>
-            <div v-if="img.ocr_text" class="absolute bottom-0.5 right-0.5 bg-black/60 text-white text-[10px] px-1 rounded">
-              OCR
+          <template v-for="img in pendingImages" :key="img.id">
+            <!-- Image thumbnail -->
+            <div v-if="img.is_image !== false && img.thumb_url" class="relative group/img">
+              <img
+                :src="img.thumb_url"
+                :alt="img.original_name"
+                class="h-20 rounded-lg border border-border object-cover"
+              />
+              <button
+                class="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-destructive text-white flex items-center justify-center opacity-0 group-hover/img:opacity-100 transition-opacity"
+                :title="t('chatView.removeImage')"
+                @click="removePendingImage(img.id)"
+              >
+                <X class="w-3 h-3" />
+              </button>
+              <div v-if="img.ocr_text" class="absolute bottom-0.5 right-0.5 bg-black/60 text-white text-[10px] px-1 rounded">
+                OCR
+              </div>
             </div>
-          </div>
+            <!-- Document chip -->
+            <div v-else class="flex items-center gap-1.5 px-2.5 py-1.5 bg-secondary rounded-lg border border-border text-xs">
+              <FileText class="w-3.5 h-3.5 text-primary shrink-0" />
+              <span class="font-medium max-w-[150px] truncate">{{ img.original_name }}</span>
+              <span v-if="img.ocr_text" class="text-green-500">✓</span>
+              <button
+                class="ml-1 p-0.5 rounded hover:bg-destructive/20 text-muted-foreground hover:text-destructive transition-colors"
+                :title="t('chatView.removeImage')"
+                @click="removePendingImage(img.id)"
+              >
+                <X class="w-3 h-3" />
+              </button>
+            </div>
+          </template>
         </div>
         <!-- Pasted blocks chips -->
         <div v-if="pastedBlocks.length" class="flex flex-wrap gap-2 mb-2 max-w-3xl mx-auto">
@@ -2976,20 +2986,20 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
             @input="onInputAutoResize"
             @paste="onPaste"
           />
-          <!-- Image upload button -->
+          <!-- File upload button (images + documents) -->
           <button
             :disabled="isStreaming || isUploadingImage || !currentSessionId"
             class="p-3 rounded-lg bg-secondary hover:bg-secondary/80 transition-colors disabled:opacity-50"
-            :title="t('chatView.uploadImage')"
+            :title="t('chatView.attachFile')"
             @click="imageInputRef?.click()"
           >
             <Loader2 v-if="isUploadingImage" class="w-5 h-5 animate-spin" />
-            <ImagePlus v-else class="w-5 h-5" />
+            <Paperclip v-else class="w-5 h-5" />
           </button>
           <input
             ref="imageInputRef"
             type="file"
-            accept="image/jpeg,image/png,image/webp,image/gif"
+            accept="image/jpeg,image/png,image/webp,image/gif,.pdf,.xlsx,.xls,.docx,.doc,.txt,.csv,.md,.json,.xml,.html,.log,.yaml,.yml"
             multiple
             class="hidden"
             @change="handleImageUpload"
@@ -3248,19 +3258,33 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
 
               <!-- Normal mode -->
               <template v-else>
-                <!-- Image attachments -->
+                <!-- File attachments (images + documents) -->
                 <div v-if="message.metadata?.images?.length" class="flex flex-wrap gap-2 mb-2">
-                  <div v-for="img in message.metadata.images" :key="img.id" class="relative group/img">
-                    <img
-                      :src="img.thumb_url || img.url"
-                      :alt="img.original_name || 'image'"
-                      class="rounded-lg max-h-48 cursor-pointer hover:opacity-90 transition-opacity"
-                      @click="fullscreenImage = img.url"
-                    />
-                    <div v-if="img.ocr_text" class="absolute bottom-1 right-1 bg-black/60 text-white text-[10px] px-1.5 py-0.5 rounded">
-                      OCR
+                  <template v-for="img in message.metadata.images" :key="img.id">
+                    <!-- Image -->
+                    <div v-if="img.is_image !== false && img.thumb_url" class="relative group/img">
+                      <img
+                        :src="img.thumb_url || img.url"
+                        :alt="img.original_name || 'image'"
+                        class="rounded-lg max-h-48 cursor-pointer hover:opacity-90 transition-opacity"
+                        @click="fullscreenImage = img.url"
+                      />
+                      <div v-if="img.ocr_text" class="absolute bottom-1 right-1 bg-black/60 text-white text-[10px] px-1.5 py-0.5 rounded">
+                        OCR
+                      </div>
                     </div>
-                  </div>
+                    <!-- Document -->
+                    <a
+                      v-else
+                      :href="img.url"
+                      target="_blank"
+                      class="flex items-center gap-1.5 px-2.5 py-1.5 bg-secondary/50 rounded-lg border border-border text-xs hover:bg-secondary transition-colors"
+                    >
+                      <FileText class="w-3.5 h-3.5 text-primary shrink-0" />
+                      <span class="font-medium max-w-[200px] truncate">{{ img.original_name }}</span>
+                      <Download class="w-3 h-3 text-muted-foreground" />
+                    </a>
+                  </template>
                 </div>
                 <div class="chat-markdown break-words" v-html="renderMarkdown(message.content, message.id)"></div>
                 <div class="flex items-center gap-2 mt-2 text-xs text-muted-foreground">
@@ -3657,7 +3681,7 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
                 @click="triggerContextFileUpload"
               >
                 <Paperclip class="w-3.5 h-3.5" />
-                {{ t('chatView.uploadFile') }}
+                {{ t('chatView.attachFile') }}
               </button>
               <button
                 class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs bg-secondary rounded-lg hover:bg-secondary/80 transition-colors"

--- a/modules/chat/image_service.py
+++ b/modules/chat/image_service.py
@@ -1,6 +1,7 @@
-"""Chat image service: upload, OCR, storage, cleanup."""
+"""Chat file service: upload images/documents, OCR/text extraction, storage, cleanup."""
 
 import hashlib
+import io
 import logging
 import shutil
 import time
@@ -18,98 +19,288 @@ except ImportError:
     pytesseract = None  # type: ignore[assignment]
     PYTESSERACT_AVAILABLE = False
 
+try:
+    import pdfplumber
+
+    PDFPLUMBER_AVAILABLE = True
+except ImportError:
+    pdfplumber = None  # type: ignore[assignment]
+    PDFPLUMBER_AVAILABLE = False
+
+try:
+    import openpyxl
+
+    OPENPYXL_AVAILABLE = True
+except ImportError:
+    openpyxl = None  # type: ignore[assignment]
+    OPENPYXL_AVAILABLE = False
+
+try:
+    import docx as python_docx
+
+    DOCX_AVAILABLE = True
+except ImportError:
+    python_docx = None  # type: ignore[assignment]
+    DOCX_AVAILABLE = False
+
 logger = logging.getLogger(__name__)
 
 IMAGES_DIR = Path("data/chat_images")
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
-ALLOWED_MIME_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
 THUMB_MAX_WIDTH = 400
 
+IMAGE_MIME_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
+DOCUMENT_MIME_TYPES = {
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",  # xlsx
+    "application/vnd.ms-excel",  # xls
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # docx
+    "application/msword",  # doc
+    "text/plain",
+    "text/csv",
+    "text/markdown",
+    "text/html",
+    "application/json",
+    "application/xml",
+    "text/xml",
+}
+ALLOWED_MIME_TYPES = IMAGE_MIME_TYPES | DOCUMENT_MIME_TYPES
 
-def _generate_image_id() -> str:
+# Extension overrides for ambiguous types
+_EXT_MAP = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+    "image/gif": "gif",
+    "application/pdf": "pdf",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+    "application/vnd.ms-excel": "xls",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+    "application/msword": "doc",
+    "text/plain": "txt",
+    "text/csv": "csv",
+    "text/markdown": "md",
+    "text/html": "html",
+    "application/json": "json",
+    "application/xml": "xml",
+    "text/xml": "xml",
+}
+
+
+def _generate_file_id() -> str:
     ts = str(time.time())
-    return f"img_{int(time.time() * 1000)}_{hashlib.md5(ts.encode()).hexdigest()[:6]}"
+    return f"file_{int(time.time() * 1000)}_{hashlib.md5(ts.encode()).hexdigest()[:6]}"
 
 
 def _session_dir(session_id: str) -> Path:
-    """Get/create directory for session images."""
+    """Get/create directory for session files."""
     d = IMAGES_DIR / session_id
     d.mkdir(parents=True, exist_ok=True)
     return d
 
 
-def _get_extension(content_type: str) -> str:
-    return {
-        "image/jpeg": "jpg",
-        "image/png": "png",
-        "image/webp": "webp",
-        "image/gif": "gif",
-    }.get(content_type, "jpg")
+def _get_extension(content_type: str, original_name: str) -> str:
+    """Get file extension from MIME type or original filename."""
+    if content_type in _EXT_MAP:
+        return _EXT_MAP[content_type]
+    # Fallback to original extension
+    ext = Path(original_name).suffix.lstrip(".")
+    return ext if ext else "bin"
 
 
-async def upload_image(
+def _is_image(content_type: str) -> bool:
+    return content_type in IMAGE_MIME_TYPES
+
+
+# --- Text extraction ---
+
+
+def _extract_text_from_pdf(file_data: bytes) -> Optional[str]:
+    """Extract text from PDF using pdfplumber."""
+    if not PDFPLUMBER_AVAILABLE:
+        return None
+    try:
+        with pdfplumber.open(io.BytesIO(file_data)) as pdf:
+            pages = []
+            for page in pdf.pages[:50]:  # Limit to 50 pages
+                text = page.extract_text()
+                if text:
+                    pages.append(text)
+            return "\n\n".join(pages) if pages else None
+    except Exception as e:
+        logger.warning(f"PDF extraction failed: {e}")
+        return None
+
+
+def _extract_text_from_xlsx(file_data: bytes) -> Optional[str]:
+    """Extract text from Excel using openpyxl."""
+    if not OPENPYXL_AVAILABLE:
+        return None
+    try:
+        wb = openpyxl.load_workbook(io.BytesIO(file_data), read_only=True, data_only=True)
+        parts = []
+        for sheet_name in wb.sheetnames[:10]:  # Limit to 10 sheets
+            ws = wb[sheet_name]
+            rows = []
+            for row in ws.iter_rows(max_row=500, values_only=True):  # Limit to 500 rows
+                cells = [str(c) if c is not None else "" for c in row]
+                if any(cells):
+                    rows.append("\t".join(cells))
+            if rows:
+                parts.append(f"[Sheet: {sheet_name}]\n" + "\n".join(rows))
+        wb.close()
+        return "\n\n".join(parts) if parts else None
+    except Exception as e:
+        logger.warning(f"Excel extraction failed: {e}")
+        return None
+
+
+def _extract_text_from_docx(file_data: bytes) -> Optional[str]:
+    """Extract text from Word document using python-docx."""
+    if not DOCX_AVAILABLE:
+        return None
+    try:
+        doc = python_docx.Document(io.BytesIO(file_data))
+        paragraphs = [p.text for p in doc.paragraphs if p.text.strip()]
+        return "\n\n".join(paragraphs) if paragraphs else None
+    except Exception as e:
+        logger.warning(f"DOCX extraction failed: {e}")
+        return None
+
+
+def _extract_text_from_plaintext(file_data: bytes) -> Optional[str]:
+    """Extract text from plain text files (txt, csv, md, json, xml, html)."""
+    try:
+        text = file_data.decode("utf-8")
+        return text.strip() if text.strip() else None
+    except UnicodeDecodeError:
+        try:
+            text = file_data.decode("cp1251")
+            return text.strip() if text.strip() else None
+        except Exception:
+            return None
+
+
+def extract_document_text(file_data: bytes, content_type: str, original_name: str) -> Optional[str]:
+    """Extract text from a document file based on its type."""
+    ext = Path(original_name).suffix.lower()
+
+    if content_type == "application/pdf" or ext == ".pdf":
+        return _extract_text_from_pdf(file_data)
+
+    if content_type in (
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.ms-excel",
+    ) or ext in (".xlsx", ".xls"):
+        return _extract_text_from_xlsx(file_data)
+
+    if content_type in (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/msword",
+    ) or ext in (".docx", ".doc"):
+        return _extract_text_from_docx(file_data)
+
+    # Plain text variants
+    if content_type.startswith("text/") or ext in (
+        ".txt",
+        ".csv",
+        ".md",
+        ".json",
+        ".xml",
+        ".html",
+        ".log",
+        ".yaml",
+        ".yml",
+        ".ini",
+        ".cfg",
+        ".toml",
+    ):
+        return _extract_text_from_plaintext(file_data)
+
+    return None
+
+
+# --- Upload ---
+
+
+async def upload_file(
     session_id: str,
     file_data: bytes,
     content_type: str,
     original_name: str,
 ) -> dict:
-    """Save image, generate thumbnail, run OCR. Returns metadata dict."""
+    """Save file, generate thumbnail (for images), extract text. Returns metadata dict."""
     if len(file_data) > MAX_FILE_SIZE:
         raise ValueError(f"File too large: {len(file_data)} > {MAX_FILE_SIZE}")
 
     if content_type not in ALLOWED_MIME_TYPES:
-        raise ValueError(f"Unsupported type: {content_type}")
+        # Try to detect by extension
+        ext = Path(original_name).suffix.lower()
+        text_exts = {".txt", ".csv", ".md", ".json", ".xml", ".html", ".log", ".yaml", ".yml"}
+        if ext not in text_exts:
+            raise ValueError(f"Unsupported type: {content_type}")
 
-    image_id = _generate_image_id()
-    ext = _get_extension(content_type)
+    file_id = _generate_file_id()
+    ext = _get_extension(content_type, original_name)
     session_dir = _session_dir(session_id)
 
     # Save original
-    original_path = session_dir / f"{image_id}.{ext}"
-    original_path.write_bytes(file_data)
+    saved_path = session_dir / f"{file_id}.{ext}"
+    saved_path.write_bytes(file_data)
 
-    # Open with Pillow for dimensions + thumbnail + OCR
-    img = Image.open(original_path)
-    width, height = img.size
+    is_img = _is_image(content_type)
+    width = 0
+    height = 0
+    extracted_text: Optional[str] = None
 
-    # Generate thumbnail
-    thumb_path = session_dir / f"{image_id}_thumb.jpg"
-    thumb = img.copy()
-    if width > THUMB_MAX_WIDTH:
-        ratio = THUMB_MAX_WIDTH / width
-        thumb = thumb.resize((THUMB_MAX_WIDTH, int(height * ratio)), Image.LANCZOS)
-    if thumb.mode in ("RGBA", "P"):
-        thumb = thumb.convert("RGB")
-    thumb.save(thumb_path, "JPEG", quality=80)
+    if is_img:
+        # Image: dimensions + thumbnail + OCR
+        img = Image.open(saved_path)
+        width, height = img.size
 
-    # OCR
-    ocr_text: Optional[str] = None
-    if PYTESSERACT_AVAILABLE:
-        try:
-            # Use Russian + English
-            ocr_img = img.convert("RGB") if img.mode != "RGB" else img
-            raw = pytesseract.image_to_string(ocr_img, lang="rus+eng", timeout=15)
-            ocr_text = raw.strip() if raw and raw.strip() else None
-        except Exception as e:
-            logger.warning(f"OCR failed for {original_name}: {e}")
+        # Generate thumbnail
+        thumb_path = session_dir / f"{file_id}_thumb.jpg"
+        thumb = img.copy()
+        if width > THUMB_MAX_WIDTH:
+            ratio = THUMB_MAX_WIDTH / width
+            thumb = thumb.resize((THUMB_MAX_WIDTH, int(height * ratio)), Image.LANCZOS)
+        if thumb.mode in ("RGBA", "P"):
+            thumb = thumb.convert("RGB")
+        thumb.save(thumb_path, "JPEG", quality=80)
+
+        # OCR
+        if PYTESSERACT_AVAILABLE:
+            try:
+                ocr_img = img.convert("RGB") if img.mode != "RGB" else img
+                raw = pytesseract.image_to_string(ocr_img, lang="rus+eng", timeout=15)
+                extracted_text = raw.strip() if raw and raw.strip() else None
+            except Exception as e:
+                logger.warning(f"OCR failed for {original_name}: {e}")
+    else:
+        # Document: text extraction
+        extracted_text = extract_document_text(file_data, content_type, original_name)
 
     return {
-        "id": image_id,
-        "filename": f"{image_id}.{ext}",
+        "id": file_id,
+        "filename": f"{file_id}.{ext}",
         "original_name": original_name,
         "size": len(file_data),
         "width": width,
         "height": height,
-        "ocr_text": ocr_text,
+        "ocr_text": extracted_text,
         "mime_type": content_type,
+        "is_image": is_img,
     }
 
 
+# Keep backward compatibility alias
+upload_image = upload_file
+
+
 def get_image_path(session_id: str, filename: str) -> Optional[Path]:
-    """Get full path to an image file, or None if not found."""
+    """Get full path to a file, or None if not found."""
     path = IMAGES_DIR / session_id / filename
     if path.exists() and path.is_file():
-        # Security: ensure path is within IMAGES_DIR
         try:
             path.resolve().relative_to(IMAGES_DIR.resolve())
             return path
@@ -119,18 +310,18 @@ def get_image_path(session_id: str, filename: str) -> Optional[Path]:
 
 
 def delete_session_images(session_id: str) -> int:
-    """Delete all images for a session. Returns number of files deleted."""
+    """Delete all files for a session. Returns number of files deleted."""
     session_dir = IMAGES_DIR / session_id
     if not session_dir.exists():
         return 0
     count = sum(1 for f in session_dir.iterdir() if f.is_file())
     shutil.rmtree(session_dir, ignore_errors=True)
-    logger.info(f"Deleted {count} images for session {session_id}")
+    logger.info(f"Deleted {count} files for session {session_id}")
     return count
 
 
 def delete_images_by_metadata(session_id: str, metadata: dict) -> int:
-    """Delete specific images referenced in message metadata."""
+    """Delete specific files referenced in message metadata."""
     images = metadata.get("images", [])
     if not images:
         return 0

--- a/modules/chat/router.py
+++ b/modules/chat/router.py
@@ -1504,46 +1504,54 @@ async def admin_get_shareable_users(user: User = Depends(require_permission("cha
 
 
 @router.post("/sessions/{session_id}/upload-image")
-async def admin_upload_chat_image(
+async def admin_upload_chat_file(
     session_id: str,
     file: UploadFile = File(...),
     user: User = Depends(require_permission("chat", "edit")),
 ):
-    """Upload an image for a chat session, run OCR, return metadata."""
-    from modules.chat.image_service import ALLOWED_MIME_TYPES, MAX_FILE_SIZE, upload_image
+    """Upload a file (image or document) for a chat session, extract text, return metadata."""
+    from modules.chat.image_service import ALLOWED_MIME_TYPES, MAX_FILE_SIZE, upload_file
 
     await _check_write_access(session_id, user)
 
     content_type = file.content_type or "application/octet-stream"
-    if content_type not in ALLOWED_MIME_TYPES:
-        raise HTTPException(status_code=400, detail=f"Unsupported image type: {content_type}")
-
     file_data = await file.read()
+    original_name = file.filename or "file"
+
     if len(file_data) > MAX_FILE_SIZE:
         raise HTTPException(status_code=400, detail="File too large (max 10MB)")
 
+    # Allow by MIME type or by known extension
+    from pathlib import Path as _Path
+
+    ext = _Path(original_name).suffix.lower()
+    text_exts = {".txt", ".csv", ".md", ".json", ".xml", ".html", ".log", ".yaml", ".yml"}
+    if content_type not in ALLOWED_MIME_TYPES and ext not in text_exts:
+        raise HTTPException(status_code=400, detail=f"Unsupported file type: {content_type}")
+
     try:
-        image_meta = await upload_image(
-            session_id, file_data, content_type, file.filename or "image.jpg"
-        )
+        file_meta = await upload_file(session_id, file_data, content_type, original_name)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    # Cache OCR text for when the message is sent
-    if image_meta.get("ocr_text"):
-        _pending_image_ocr[image_meta["id"]] = image_meta["ocr_text"]
+    # Cache extracted text for when the message is sent
+    if file_meta.get("ocr_text"):
+        _pending_image_ocr[file_meta["id"]] = file_meta["ocr_text"]
 
     return {
         "image": {
-            "id": image_meta["id"],
-            "url": f"/admin/chat/images/{session_id}/{image_meta['filename']}",
-            "thumb_url": f"/admin/chat/images/{session_id}/{image_meta['id']}_thumb.jpg",
-            "ocr_text": image_meta.get("ocr_text"),
-            "width": image_meta["width"],
-            "height": image_meta["height"],
-            "original_name": image_meta["original_name"],
-            "size": image_meta["size"],
-            "mime_type": image_meta["mime_type"],
+            "id": file_meta["id"],
+            "url": f"/admin/chat/images/{session_id}/{file_meta['filename']}",
+            "thumb_url": f"/admin/chat/images/{session_id}/{file_meta['id']}_thumb.jpg"
+            if file_meta.get("is_image")
+            else None,
+            "ocr_text": file_meta.get("ocr_text"),
+            "width": file_meta.get("width", 0),
+            "height": file_meta.get("height", 0),
+            "original_name": file_meta["original_name"],
+            "size": file_meta["size"],
+            "mime_type": file_meta["mime_type"],
+            "is_image": file_meta.get("is_image", False),
         }
     }
 
@@ -1562,14 +1570,8 @@ async def serve_chat_image(
         raise HTTPException(status_code=404, detail="Image not found")
 
     # Determine media type
-    suffix = path.suffix.lower()
-    media_types = {
-        ".jpg": "image/jpeg",
-        ".jpeg": "image/jpeg",
-        ".png": "image/png",
-        ".webp": "image/webp",
-        ".gif": "image/gif",
-    }
-    media_type = media_types.get(suffix, "application/octet-stream")
+    import mimetypes
+
+    media_type = mimetypes.guess_type(str(path))[0] or "application/octet-stream"
 
     return FileResponse(path, media_type=media_type)

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,8 +55,10 @@ redis>=5.0.0
 # Wiki RAG
 snowballstemmer>=2.2.0  # Russian/English stemming for BM25 search
 
-# Document text extraction (Telegram file uploads)
+# Document text extraction (Telegram file uploads + chat attachments)
 pdfplumber>=0.10.0
+openpyxl>=3.1.0
+python-docx>=1.0.0
 
 # OCR for chat image uploads (optional — requires tesseract-ocr system package)
 pytesseract>=0.3.10


### PR DESCRIPTION
## Summary

- Extend chat file upload: now accepts PDF, XLSX/XLS, DOCX/DOC, TXT, CSV, MD, JSON, XML, HTML, YAML, LOG
- Text extracted from documents and injected into LLM context (same as OCR for images)
- PDF: pdfplumber (up to 50 pages), Excel: openpyxl (10 sheets × 500 rows), Word: python-docx, Text: UTF-8/CP1251
- Frontend: Paperclip icon, documents shown as chips (not thumbnails), download links in messages
- Dependencies: `openpyxl>=3.1.0`, `python-docx>=1.0.0`

## NEWS

📄 **Загрузка документов в чат**

Кроме фото теперь можно загружать PDF, Excel, Word и текстовые файлы.
Текст из документов автоматически извлекается и отправляется ассистенту —
можно задать вопрос по содержимому файла. Все вложения хранятся вместе
с чатом и удаляются при его удалении.

## Test plan

- [ ] Upload PDF → text extracted, sent to LLM, file shown as chip/download link
- [ ] Upload XLSX → sheet data extracted as TSV
- [ ] Upload DOCX → paragraphs extracted
- [ ] Upload TXT/CSV/JSON → content read directly
- [ ] Upload image → still works with OCR and thumbnail
- [ ] Mixed: upload image + PDF + text in same message
- [ ] Document >10MB → rejected with error
- [ ] Delete session → files cleaned up from disk
- [ ] Build: `cd admin && npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)