### PR TITLE
fix: chat-only routing + auto-create chat

### DIFF
--- a/admin/src/router.ts
+++ b/admin/src/router.ts
@@ -215,18 +215,22 @@ router.beforeEach((to, from, next) => {
     }
   } else if (to.name === "login" && authStore.isAuthenticated) {
     // Already logged in, redirect to landing page
-    const landing =
-      authStore.isChatOnlyUser
-        ? "chat"
-        : authStore.hasModule("dashboard") && !authStore.isCloudMode
-          ? "dashboard"
-          : "chat";
+    const isChatUser = authStore.isChatOnlyUser
+      || (authStore.user?.role !== "admin" && Object.keys(authStore.permissions).length === 0);
+    const landing = isChatUser
+      ? "chat"
+      : authStore.hasModule("dashboard") && !authStore.isCloudMode
+        ? "dashboard"
+        : "chat";
     next({ name: landing });
     return;
   }
 
   // Chat-only users can only access /chat
-  if (!isPublicRoute && authStore.isChatOnlyUser && to.name !== "chat") {
+  // Use isChatOnlyUser (permission-based) when loaded, fall back to JWT role
+  const chatOnly = authStore.isChatOnlyUser
+    || (authStore.isAuthenticated && authStore.user?.role !== "admin" && Object.keys(authStore.permissions).length === 0);
+  if (!isPublicRoute && chatOnly && to.name !== "chat") {
     next({ name: "chat" });
     return;
   }

--- a/admin/src/stores/auth.ts
+++ b/admin/src/stores/auth.ts
@@ -30,8 +30,10 @@ export const useAuthStore = defineStore('auth', () => {
   const isAdmin = computed(() => canManage('users'))
   const isCloudMode = computed(() => deploymentMode.value === 'cloud')
   const isChatOnlyUser = computed(() => {
-    if (Object.keys(permissions.value).length === 0) return false
-    return !isAdmin.value
+    // Once permissions loaded, use RBAC check
+    if (Object.keys(permissions.value).length > 0) return !isAdmin.value
+    // Before permissions load, use JWT role as early hint
+    return isAuthenticated.value && user.value?.role !== 'admin'
   })
 
   function hasModule(module: string): boolean {

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -1728,6 +1728,8 @@ onMounted(() => {
   document.addEventListener('keydown', handleEscapeKey)
   if (sessions.value.length > 0) {
     currentSessionId.value = sessions.value[0].id
+  } else if (isChatOnly.value) {
+    createNewChat()
   }
   fetchAllCcSessions()
 })
@@ -1735,6 +1737,10 @@ onMounted(() => {
 watch(sessions, (newSessions) => {
   if (!currentSessionId.value && newSessions.length > 0) {
     currentSessionId.value = newSessions[0].id
+  }
+  // Auto-create chat for chat-only users if all sessions were deleted
+  if (isChatOnly.value && newSessions.length === 0) {
+    createNewChat()
   }
 })
 
@@ -2186,6 +2192,17 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
           <GitFork v-else class="w-4 h-4" />
         </button>
       </template>
+
+      <!-- Chat-only: new chat button -->
+      <button
+        v-if="isChatOnly"
+        :disabled="createSessionMutation.isPending.value"
+        class="w-8 h-8 rounded-lg flex items-center justify-center bg-primary text-primary-foreground hover:bg-primary/90 transition-colors shrink-0"
+        :title="t('chatView.newChat')"
+        @click="createNewChat"
+      >
+        <Plus class="w-4 h-4" />
+      </button>
 
       <!-- Export dropdown (non-CC) -->
       <div v-if="!cc.isActive.value" class="relative shrink-0">


### PR DESCRIPTION
## Summary
- Auto-create chat session when chat-only user has no sessions
- Add "new chat" (+) button to zen activity bar for chat-only users
- Fix route bypass: use JWT role as early hint before permissions load
- Non-admin users can no longer access admin panel by removing `#/chat` from URL

## Test plan
- [ ] Login as non-admin → auto-creates first chat, no empty screen
- [ ] Remove `#/chat` from URL → still redirected to chat
- [ ] "+" button creates new chat in zen mode
- [ ] Admin users unaffected — full navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)