### PR TITLE
fix: clear stale zen mode on login

### DIFF
--- a/admin/src/stores/auth.ts
+++ b/admin/src/stores/auth.ts
@@ -144,6 +144,9 @@ export const useAuthStore = defineStore('auth', () => {
       await fetchDeploymentMode()
       await fetchPermissions()
 
+      // Clear stale zen mode from localStorage to prevent stuck fullscreen
+      localStorage.removeItem('chat-fullscreen')
+
       return true
     } catch (e) {
       // In dev mode, allow login without backend


### PR DESCRIPTION
Clears chat-fullscreen from localStorage on every login to prevent stuck zen mode between user sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)