### PR TITLE
fix: clear query cache on login to prevent stale chat data

### DIFF
--- a/admin/src/views/LoginView.vue
+++ b/admin/src/views/LoginView.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
+import { useQueryClient } from '@tanstack/vue-query'
 import { useAuthStore } from '@/stores/auth'
 import { useToastStore } from '@/stores/toast'
 
 const router = useRouter()
 const route = useRoute()
+const queryClient = useQueryClient()
 const authStore = useAuthStore()
 const toastStore = useToastStore()
 
@@ -92,6 +94,8 @@ async function handleSubmit() {
     const success = await authStore.login(username.value, password.value)
 
     if (success) {
+      // Clear stale query cache so ChatView fetches fresh data with new token
+      queryClient.clear()
       toastStore.success('Добро пожаловать!', `Вы вошли как ${username.value}`)
       const redirect = (route.query.redirect as string) || '/'
       router.push(redirect)


### PR DESCRIPTION
## Summary

- Clear TanStack Query cache (`queryClient.clear()`) on successful login in `LoginView.vue`
- Prevents stale cached responses (empty/401) from pre-auth state being served to ChatView
- Matches existing `queryClient.clear()` pattern used in logout handlers (ChatView:102, App.vue:121)

## NEWS

🔧 **Исправлен баг с загрузкой чатов после входа**

Раньше после логина в чат иногда приходилось обновлять страницу, чтобы увидеть свои чаты. Теперь всё загружается сразу — кэш очищается при входе, и данные подтягиваются с актуальным токеном.

## Test plan

- [ ] Login → chat list loads immediately without page refresh
- [ ] Logout → login again → chats visible
- [ ] Token expiry → re-login → fresh data

🤖 Generated with [Claude Code](https://claude.com/claude-code)