### PR TITLE
feat: mobile app admin mode — LLM/RAG, chat CRUD

### DIFF
--- a/mobile/src/api/admin.ts
+++ b/mobile/src/api/admin.ts
@@ -1,0 +1,37 @@
+import { api } from "./client";
+
+export interface CloudProvider {
+  id: number;
+  name: string;
+  provider_type: string;
+  model_name: string;
+  enabled: boolean;
+  is_default: boolean;
+}
+
+export interface KnowledgeCollection {
+  id: number;
+  name: string;
+  slug: string;
+  description?: string;
+  enabled: boolean;
+  document_count: number;
+}
+
+export interface LlmOption {
+  value: string;
+  label: string;
+  type: "vllm" | "cloud";
+}
+
+export const adminApi = {
+  getProviders: () =>
+    api.get<{ providers: CloudProvider[] }>(
+      "/admin/llm/providers?enabled_only=true",
+    ),
+
+  getCollections: () =>
+    api.get<{ collections: KnowledgeCollection[] }>(
+      "/admin/wiki-rag/collections",
+    ),
+};

--- a/mobile/src/api/chat.ts
+++ b/mobile/src/api/chat.ts
@@ -144,6 +144,7 @@ export const chatApi = {
     sessionId: string,
     content: string,
     onChunk: (data: StreamChunk) => void,
+    overrides?: Record<string, unknown>,
   ) => {
     const settings = useSettingsStore();
     const auth = useAuthStore();
@@ -153,6 +154,9 @@ export const chatApi = {
     const body: Record<string, unknown> = { content };
     if (config.instance?.id) {
       body.mobile_instance_id = config.instance.id;
+    }
+    if (overrides) {
+      Object.assign(body, overrides);
     }
 
     fetch(

--- a/mobile/src/components/MessageBubble.vue
+++ b/mobile/src/components/MessageBubble.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
   message: ChatMessage;
   isStreaming?: boolean;
   isSpeaking?: boolean;
+  isAdmin?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -152,49 +153,52 @@ function cancelEdit() {
             </svg>
           </button>
 
-          <!-- Edit -->
-          <button
-            class="p-1.5 rounded text-stone-500 hover:text-stone-300 transition-colors"
-            title="Edit"
-            @click="startEdit"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-            </svg>
-          </button>
+          <!-- Admin-only actions -->
+          <template v-if="isAdmin">
+            <!-- Edit -->
+            <button
+              class="p-1.5 rounded text-stone-500 hover:text-stone-300 transition-colors"
+              title="Edit"
+              @click="startEdit"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+              </svg>
+            </button>
 
-          <!-- Save to context -->
-          <button
-            class="p-1.5 rounded text-stone-500 hover:text-stone-300 transition-colors"
-            title="Save to context"
-            @click="$emit('saveToContext', message.id, message.content)"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48" />
-            </svg>
-          </button>
+            <!-- Save to context -->
+            <button
+              class="p-1.5 rounded text-stone-500 hover:text-stone-300 transition-colors"
+              title="Save to context"
+              @click="$emit('saveToContext', message.id, message.content)"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+              </svg>
+            </button>
 
-          <!-- Summarize branch -->
-          <button
-            class="p-1.5 rounded text-stone-500 hover:text-stone-300 transition-colors"
-            title="Summarize branch"
-            @click="$emit('summarizeBranch', message.id)"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" /><line x1="16" y1="13" x2="8" y2="13" /><line x1="16" y1="17" x2="8" y2="17" /><polyline points="10 9 9 9 8 9" />
-            </svg>
-          </button>
+            <!-- Summarize branch -->
+            <button
+              class="p-1.5 rounded text-stone-500 hover:text-stone-300 transition-colors"
+              title="Summarize branch"
+              @click="$emit('summarizeBranch', message.id)"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" /><line x1="16" y1="13" x2="8" y2="13" /><line x1="16" y1="17" x2="8" y2="17" /><polyline points="10 9 9 9 8 9" />
+              </svg>
+            </button>
 
-          <!-- Delete branch from here -->
-          <button
-            class="p-1.5 rounded text-stone-500 hover:text-red-400 transition-colors"
-            title="Delete branch"
-            @click="$emit('deleteBranch', message.id)"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-            </svg>
-          </button>
+            <!-- Delete branch from here -->
+            <button
+              class="p-1.5 rounded text-stone-500 hover:text-red-400 transition-colors"
+              title="Delete branch"
+              @click="$emit('deleteBranch', message.id)"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+              </svg>
+            </button>
+          </template>
         </div>
 
         <!-- Action buttons for user messages -->
@@ -231,49 +235,52 @@ function cancelEdit() {
             </svg>
           </button>
 
-          <!-- Edit -->
-          <button
-            class="p-1.5 rounded text-amber-300/50 hover:text-amber-200 transition-colors"
-            title="Edit"
-            @click="startEdit"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-            </svg>
-          </button>
+          <!-- Admin-only actions -->
+          <template v-if="isAdmin">
+            <!-- Edit -->
+            <button
+              class="p-1.5 rounded text-amber-300/50 hover:text-amber-200 transition-colors"
+              title="Edit"
+              @click="startEdit"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+              </svg>
+            </button>
 
-          <!-- Regenerate response -->
-          <button
-            class="p-1.5 rounded text-amber-300/50 hover:text-amber-200 transition-colors"
-            title="Regenerate response"
-            @click="$emit('regenerate', message.id)"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="23 4 23 10 17 10" /><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
-            </svg>
-          </button>
+            <!-- Regenerate response -->
+            <button
+              class="p-1.5 rounded text-amber-300/50 hover:text-amber-200 transition-colors"
+              title="Regenerate response"
+              @click="$emit('regenerate', message.id)"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="23 4 23 10 17 10" /><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+              </svg>
+            </button>
 
-          <!-- Summarize branch -->
-          <button
-            class="p-1.5 rounded text-amber-300/50 hover:text-amber-200 transition-colors"
-            title="Summarize branch"
-            @click="$emit('summarizeBranch', message.id)"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" /><line x1="16" y1="13" x2="8" y2="13" /><line x1="16" y1="17" x2="8" y2="17" /><polyline points="10 9 9 9 8 9" />
-            </svg>
-          </button>
+            <!-- Summarize branch -->
+            <button
+              class="p-1.5 rounded text-amber-300/50 hover:text-amber-200 transition-colors"
+              title="Summarize branch"
+              @click="$emit('summarizeBranch', message.id)"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" /><line x1="16" y1="13" x2="8" y2="13" /><line x1="16" y1="17" x2="8" y2="17" /><polyline points="10 9 9 9 8 9" />
+              </svg>
+            </button>
 
-          <!-- Delete branch from here -->
-          <button
-            class="p-1.5 rounded text-amber-300/50 hover:text-red-400 transition-colors"
-            title="Delete branch"
-            @click="$emit('deleteBranch', message.id)"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-            </svg>
-          </button>
+            <!-- Delete branch from here -->
+            <button
+              class="p-1.5 rounded text-amber-300/50 hover:text-red-400 transition-colors"
+              title="Delete branch"
+              @click="$emit('deleteBranch', message.id)"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+              </svg>
+            </button>
+          </template>
         </div>
       </template>
     </div>

--- a/mobile/src/stores/auth.ts
+++ b/mobile/src/stores/auth.ts
@@ -19,6 +19,7 @@ export const useAuthStore = defineStore("auth", () => {
   const error = ref<string | null>(null);
 
   const isAuthenticated = computed(() => !!token.value);
+  const isAdmin = computed(() => user.value?.role === "admin");
 
   async function loadToken() {
     const { value } = await Preferences.get({ key: TOKEN_KEY });
@@ -121,6 +122,7 @@ export const useAuthStore = defineStore("auth", () => {
     isLoading,
     error,
     isAuthenticated,
+    isAdmin,
     loadToken,
     login,
     logout,

--- a/mobile/src/stores/settings.ts
+++ b/mobile/src/stores/settings.ts
@@ -1,24 +1,20 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
-import { Preferences } from "@capacitor/preferences";
 
-const STORAGE_KEY = "server_url";
+const DEFAULT_SERVER_URL = "https://ai-sekretar24.ru";
 
 export const useSettingsStore = defineStore("settings", () => {
-  const serverUrl = ref("");
+  const serverUrl = ref(DEFAULT_SERVER_URL);
   const isLoaded = ref(false);
 
   async function load() {
-    const { value } = await Preferences.get({ key: STORAGE_KEY });
-    serverUrl.value = value || "";
+    serverUrl.value = DEFAULT_SERVER_URL;
     isLoaded.value = true;
   }
 
-  async function setServerUrl(url: string) {
-    // Normalize: strip trailing slash
-    const normalized = url.replace(/\/+$/, "");
-    serverUrl.value = normalized;
-    await Preferences.set({ key: STORAGE_KEY, value: normalized });
+  async function setServerUrl(_url: string) {
+    // Server URL is hardcoded, ignore user input
+    serverUrl.value = DEFAULT_SERVER_URL;
   }
 
   return { serverUrl, isLoaded, load, setServerUrl };

--- a/mobile/src/views/ChatListView.vue
+++ b/mobile/src/views/ChatListView.vue
@@ -10,6 +10,7 @@ const auth = useAuthStore();
 const sessions = ref<ChatSessionSummary[]>([]);
 const isLoading = ref(false);
 const error = ref<string | null>(null);
+const isCreating = ref(false);
 
 async function loadSessions() {
   isLoading.value = true;
@@ -29,6 +30,30 @@ async function loadSessions() {
 
 function openChat(id: string) {
   router.push(`/chat/${id}`);
+}
+
+async function createNewChat() {
+  if (isCreating.value) return;
+  isCreating.value = true;
+  try {
+    const data = await chatApi.createSession();
+    router.push(`/chat/${data.session.id}`);
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to create";
+  } finally {
+    isCreating.value = false;
+  }
+}
+
+async function deleteSession(id: string, event: Event) {
+  event.stopPropagation();
+  if (!confirm("Delete this chat?")) return;
+  try {
+    await chatApi.deleteSession(id);
+    sessions.value = sessions.value.filter((s) => s.id !== id);
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to delete";
+  }
 }
 
 function formatDate(dateStr: string): string {
@@ -158,34 +183,64 @@ onMounted(loadSessions);
             d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
           />
         </svg>
-        <p class="text-sm">No chats yet</p>
+        <p class="text-sm mb-3">No chats yet</p>
+        <button
+          class="px-4 py-2 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-sm transition-colors"
+          @click="createNewChat"
+        >
+          Start a chat
+        </button>
       </div>
 
       <!-- Session list -->
       <div v-else>
-        <button
+        <div
           v-for="session in sessions"
           :key="session.id"
-          class="w-full text-left px-4 py-3 border-b border-stone-800/50 hover:bg-stone-800/50 active:bg-stone-800 transition-colors"
+          class="w-full text-left px-4 py-3 border-b border-stone-800/50 hover:bg-stone-800/50 active:bg-stone-800 transition-colors flex items-center gap-2 cursor-pointer"
           @click="openChat(session.id)"
         >
-          <div class="flex items-center justify-between mb-0.5">
-            <span class="font-medium text-sm text-white truncate mr-2">
-              {{ session.title || "New Chat" }}
-            </span>
-            <span class="text-xs text-stone-500 shrink-0">
-              {{ formatDate(session.updated) }}
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center justify-between mb-0.5">
+              <span class="font-medium text-sm text-white truncate mr-2">
+                {{ session.title || "New Chat" }}
+              </span>
+              <span class="text-xs text-stone-500 shrink-0">
+                {{ formatDate(session.updated) }}
+              </span>
+            </div>
+            <p class="text-xs text-stone-400 truncate">
+              {{ truncate(session.last_message || "", 80) }}
+            </p>
+            <span class="text-xs text-stone-600">
+              {{ session.message_count }} messages
             </span>
           </div>
-          <p class="text-xs text-stone-400 truncate">
-            {{ truncate(session.last_message || "", 80) }}
-          </p>
-          <span class="text-xs text-stone-600">
-            {{ session.message_count }} messages
-          </span>
-        </button>
+          <!-- Delete button -->
+          <button
+            class="shrink-0 p-2 rounded-lg text-stone-600 hover:text-red-400 hover:bg-red-900/20 transition-colors"
+            title="Delete chat"
+            @click="deleteSession(session.id, $event)"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+            </svg>
+          </button>
+        </div>
       </div>
     </div>
 
+    <!-- FAB: New Chat -->
+    <button
+      class="fixed bottom-6 right-6 w-14 h-14 rounded-full bg-amber-600 hover:bg-amber-700 active:bg-amber-800 shadow-lg shadow-amber-900/30 flex items-center justify-center transition-all safe-bottom"
+      :class="isCreating ? 'opacity-50' : ''"
+      :disabled="isCreating"
+      @click="createNewChat"
+    >
+      <div v-if="isCreating" class="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+      <svg v-else xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-white">
+        <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+      </svg>
+    </button>
   </div>
 </template>

--- a/mobile/src/views/ChatView.vue
+++ b/mobile/src/views/ChatView.vue
@@ -4,21 +4,32 @@ import { useRoute, useRouter } from "vue-router";
 import {
   chatApi,
   type ChatMessage,
+  type ChatSession,
   type StreamChunk,
   type BranchNode,
   type ContextFile,
 } from "@/api/chat";
+import {
+  adminApi,
+  type CloudProvider,
+  type KnowledgeCollection,
+  type LlmOption,
+} from "@/api/admin";
+import { useAuthStore } from "@/stores/auth";
 import { useTts } from "@/composables/useTts";
 import MessageBubble from "@/components/MessageBubble.vue";
 import ChatInput from "@/components/ChatInput.vue";
 
 const route = useRoute();
 const router = useRouter();
+const auth = useAuthStore();
 const tts = useTts();
+const isAdmin = computed(() => auth.isAdmin);
 
 const sessionId = computed(() => route.params.id as string);
 const title = ref("Chat");
 const messages = ref<ChatMessage[]>([]);
+const currentSession = ref<ChatSession | null>(null);
 const isLoading = ref(false);
 const isStreaming = ref(false);
 const streamingContent = ref("");
@@ -28,10 +39,36 @@ const messagesContainer = ref<HTMLElement | null>(null);
 // Panels
 const showBranches = ref(false);
 const showContextFiles = ref(false);
+const showSettings = ref(false);
 const branches = ref<BranchNode[]>([]);
 const contextFiles = ref<ContextFile[]>([]);
 const branchesLoading = ref(false);
 const contextFileInputRef = ref<HTMLInputElement | null>(null);
+
+// Admin: LLM & RAG
+const llmProviders = ref<CloudProvider[]>([]);
+const ragCollections = ref<KnowledgeCollection[]>([]);
+const selectedLlm = ref<string>("default");
+const selectedCollectionIds = ref<number[]>([]);
+const showLlmDropdown = ref(false);
+const showRagDropdown = ref(false);
+const showExportDropdown = ref(false);
+const customPrompt = ref("");
+
+const llmOptions = computed<LlmOption[]>(() => {
+  const opts: LlmOption[] = [
+    { value: "default", label: "Default", type: "vllm" },
+    { value: "vllm", label: "vLLM (Local)", type: "vllm" },
+  ];
+  for (const p of llmProviders.value) {
+    opts.push({
+      value: `cloud:${p.id}`,
+      label: `${p.name} (${p.model_name})`,
+      type: "cloud",
+    });
+  }
+  return opts;
+});
 
 // Resizable panel height (portrait) / width (landscape)
 const panelSize = ref(200);
@@ -61,11 +98,9 @@ function onResizeMove(e: TouchEvent | MouseEvent) {
   if (!isResizing.value) return;
   const pos = "touches" in e ? e.touches[0]! : e;
   if (isLandscape.value) {
-    // Dragging left edge → increasing width = startX - currentX
     const delta = resizeStartPos.value - pos.clientX;
     panelSize.value = Math.max(150, Math.min(window.innerWidth * 0.7, resizeStartSize.value + delta));
   } else {
-    // Dragging bottom edge → increasing height
     const delta = pos.clientY - resizeStartPos.value;
     panelSize.value = Math.max(100, Math.min(window.innerHeight * 0.6, resizeStartSize.value + delta));
   }
@@ -75,6 +110,22 @@ function onResizeEnd() {
   isResizing.value = false;
 }
 
+// === Admin data ===
+
+async function loadAdminData() {
+  if (!isAdmin.value) return;
+  try {
+    const [providerData, collectionData] = await Promise.all([
+      adminApi.getProviders(),
+      adminApi.getCollections(),
+    ]);
+    llmProviders.value = providerData.providers;
+    ragCollections.value = collectionData.collections.filter((c) => c.enabled);
+  } catch {
+    // Non-critical — admin features just won't show options
+  }
+}
+
 // === Session ===
 
 async function loadSession() {
@@ -82,11 +133,13 @@ async function loadSession() {
   error.value = null;
   try {
     const data = await chatApi.getSession(sessionId.value);
+    currentSession.value = data.session;
     title.value = data.session.title || "Chat";
     messages.value = data.session.messages.filter(
       (m) => m.is_active !== false,
     );
     contextFiles.value = data.session.context_files || [];
+    customPrompt.value = data.session.system_prompt || "";
     await scrollToBottom();
   } catch (e) {
     error.value = e instanceof Error ? e.message : "Failed to load";
@@ -107,6 +160,18 @@ async function sendMessage(content: string) {
 
   isStreaming.value = true;
   streamingContent.value = "";
+
+  // Build LLM/RAG overrides for admin
+  const overrides: Record<string, unknown> = {};
+  if (isAdmin.value) {
+    if (selectedLlm.value && selectedLlm.value !== "default") {
+      overrides.llm_backend = selectedLlm.value;
+    }
+    if (selectedCollectionIds.value.length > 0) {
+      overrides.rag_mode = "selected";
+      overrides.knowledge_collection_ids = selectedCollectionIds.value;
+    }
+  }
 
   const { abort } = chatApi.streamMessage(
     sessionId.value,
@@ -147,6 +212,7 @@ async function sendMessage(content: string) {
           break;
       }
     },
+    overrides,
   );
 
   abortStream = abort;
@@ -199,6 +265,7 @@ async function loadBranches() {
 
 function toggleBranches() {
   showContextFiles.value = false;
+  showSettings.value = false;
   showBranches.value = !showBranches.value;
   if (showBranches.value) loadBranches();
 }
@@ -276,6 +343,7 @@ const flatBranches = computed(() => flattenBranches(branches.value));
 
 function toggleContextFiles() {
   showBranches.value = false;
+  showSettings.value = false;
   showContextFiles.value = !showContextFiles.value;
 }
 
@@ -316,6 +384,82 @@ async function saveContextFiles() {
   }
 }
 
+// === Settings panel ===
+
+function toggleSettings() {
+  showBranches.value = false;
+  showContextFiles.value = false;
+  showSettings.value = !showSettings.value;
+}
+
+async function saveSystemPrompt() {
+  try {
+    await chatApi.updateSession(sessionId.value, {
+      system_prompt: customPrompt.value,
+    });
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to save prompt";
+  }
+}
+
+// === LLM / RAG dropdowns ===
+
+function selectLlm(value: string) {
+  selectedLlm.value = value;
+  showLlmDropdown.value = false;
+}
+
+function toggleCollection(id: number) {
+  const idx = selectedCollectionIds.value.indexOf(id);
+  if (idx >= 0) {
+    selectedCollectionIds.value.splice(idx, 1);
+  } else {
+    selectedCollectionIds.value.push(id);
+  }
+}
+
+// === Export ===
+
+function copyChatToClipboard() {
+  const text = messages.value
+    .map((m) => `**${m.role === "user" ? "User" : "Assistant"}:**\n${m.content}`)
+    .join("\n\n---\n\n");
+  navigator.clipboard.writeText(text);
+  showExportDropdown.value = false;
+}
+
+function exportChatMarkdown() {
+  const text = `# ${title.value}\n\n` + messages.value
+    .map((m) => `## ${m.role === "user" ? "User" : "Assistant"}\n\n${m.content}`)
+    .join("\n\n---\n\n");
+  downloadFile(`${title.value}.md`, text, "text/markdown");
+  showExportDropdown.value = false;
+}
+
+function exportChatJson() {
+  const data = {
+    title: title.value,
+    exported: new Date().toISOString(),
+    messages: messages.value.map((m) => ({
+      role: m.role,
+      content: m.content,
+      timestamp: m.timestamp,
+    })),
+  };
+  downloadFile(`${title.value}.json`, JSON.stringify(data, null, 2), "application/json");
+  showExportDropdown.value = false;
+}
+
+function downloadFile(name: string, content: string, type: string) {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = name;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 // === Message actions ===
 
 async function handleEditMessage(messageId: string, content: string) {
@@ -333,6 +477,7 @@ function handleSaveToContext(_messageId: string, content: string) {
   saveContextFiles();
   showContextFiles.value = true;
   showBranches.value = false;
+  showSettings.value = false;
 }
 
 async function handleSummarizeBranch(messageId: string) {
@@ -343,6 +488,7 @@ async function handleSummarizeBranch(messageId: string) {
     saveContextFiles();
     showContextFiles.value = true;
     showBranches.value = false;
+    showSettings.value = false;
   } catch (e) {
     error.value = e instanceof Error ? e.message : "Failed to summarize";
   }
@@ -376,11 +522,25 @@ async function handleDeleteFromMessage(messageId: string) {
   }
 }
 
-const anyPanelOpen = computed(() => showBranches.value || showContextFiles.value);
+const anyPanelOpen = computed(() => showBranches.value || showContextFiles.value || showSettings.value);
+const activePanelName = computed(() => {
+  if (showBranches.value) return "Branch Tree";
+  if (showContextFiles.value) return "Context Files";
+  if (showSettings.value) return "Settings";
+  return "";
+});
 
 function closePanel() {
   showBranches.value = false;
   showContextFiles.value = false;
+  showSettings.value = false;
+}
+
+// Close dropdowns on outside click
+function onGlobalClick() {
+  showLlmDropdown.value = false;
+  showRagDropdown.value = false;
+  showExportDropdown.value = false;
 }
 
 watch(streamingContent, () => {
@@ -389,12 +549,14 @@ watch(streamingContent, () => {
 
 onMounted(() => {
   loadSession();
+  loadAdminData();
   updateOrientation();
   window.addEventListener("resize", updateOrientation);
   window.addEventListener("mousemove", onResizeMove);
   window.addEventListener("mouseup", onResizeEnd);
   window.addEventListener("touchmove", onResizeMove, { passive: false });
   window.addEventListener("touchend", onResizeEnd);
+  document.addEventListener("click", onGlobalClick);
 });
 
 onUnmounted(() => {
@@ -403,6 +565,7 @@ onUnmounted(() => {
   window.removeEventListener("mouseup", onResizeEnd);
   window.removeEventListener("touchmove", onResizeMove);
   window.removeEventListener("touchend", onResizeEnd);
+  document.removeEventListener("click", onGlobalClick);
 });
 </script>
 
@@ -412,10 +575,10 @@ onUnmounted(() => {
     <div class="flex-1 flex flex-col min-w-0 min-h-0">
       <!-- Header -->
       <div
-        class="shrink-0 flex items-center gap-2 px-3 py-2.5 border-b border-stone-800 bg-stone-950/95 backdrop-blur"
+        class="shrink-0 flex items-center gap-1.5 px-2 py-2.5 border-b border-stone-800 bg-stone-950/95 backdrop-blur"
       >
         <button
-          class="text-stone-400 hover:text-white transition-colors"
+          class="text-stone-400 hover:text-white transition-colors p-1"
           @click="router.back()"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -426,53 +589,169 @@ onUnmounted(() => {
           {{ title }}
         </h1>
 
-        <!-- Toolbar buttons -->
-        <button
-          class="p-1.5 rounded-lg transition-colors"
-          :class="showContextFiles ? 'bg-amber-600/20 text-amber-400' : 'text-stone-400 hover:text-white'"
-          title="Context files"
-          @click="toggleContextFiles"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48" />
-          </svg>
-        </button>
+        <!-- Admin toolbar buttons -->
+        <template v-if="isAdmin">
+          <!-- LLM Selector -->
+          <div class="relative" @click.stop>
+            <button
+              class="p-1.5 rounded-lg transition-colors"
+              :class="selectedLlm !== 'default' ? 'bg-amber-600/20 text-amber-400' : 'text-stone-400 hover:text-white'"
+              title="LLM Provider"
+              @click="showLlmDropdown = !showLlmDropdown; showRagDropdown = false; showExportDropdown = false"
+            >
+              <!-- Brain icon -->
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 2a8 8 0 0 0-8 8c0 3.5 2 6 5 7.5V21h6v-3.5c3-1.5 5-4 5-7.5a8 8 0 0 0-8-8z" />
+              </svg>
+            </button>
+            <!-- LLM Dropdown -->
+            <div
+              v-if="showLlmDropdown"
+              class="absolute right-0 top-full mt-1 bg-stone-900 border border-stone-700 rounded-xl shadow-xl z-50 min-w-[200px] py-1 max-h-[300px] overflow-y-auto"
+            >
+              <button
+                v-for="opt in llmOptions"
+                :key="opt.value"
+                class="w-full text-left px-3 py-2 text-xs hover:bg-stone-800 transition-colors flex items-center gap-2"
+                :class="selectedLlm === opt.value ? 'text-amber-400' : 'text-stone-300'"
+                @click="selectLlm(opt.value)"
+              >
+                <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="opt.type === 'cloud' ? 'bg-blue-400' : 'bg-green-400'" />
+                {{ opt.label }}
+                <svg v-if="selectedLlm === opt.value" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="ml-auto shrink-0">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              </button>
+            </div>
+          </div>
 
-        <button
-          class="p-1.5 rounded-lg transition-colors"
-          :class="showBranches ? 'bg-amber-600/20 text-amber-400' : 'text-stone-400 hover:text-white'"
-          title="Branch tree"
-          @click="toggleBranches"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="6" y1="3" x2="6" y2="15" />
-            <circle cx="18" cy="6" r="3" />
-            <circle cx="6" cy="18" r="3" />
-            <path d="M18 9a9 9 0 0 1-9 9" />
-          </svg>
-        </button>
+          <!-- RAG Collections -->
+          <div v-if="ragCollections.length" class="relative" @click.stop>
+            <button
+              class="p-1.5 rounded-lg transition-colors"
+              :class="selectedCollectionIds.length ? 'bg-amber-600/20 text-amber-400' : 'text-stone-400 hover:text-white'"
+              title="Knowledge Base"
+              @click="showRagDropdown = !showRagDropdown; showLlmDropdown = false; showExportDropdown = false"
+            >
+              <!-- BookOpen icon -->
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" /><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+              </svg>
+            </button>
+            <!-- RAG Dropdown -->
+            <div
+              v-if="showRagDropdown"
+              class="absolute right-0 top-full mt-1 bg-stone-900 border border-stone-700 rounded-xl shadow-xl z-50 min-w-[220px] py-1 max-h-[300px] overflow-y-auto"
+            >
+              <label
+                v-for="col in ragCollections"
+                :key="col.id"
+                class="flex items-center gap-2 px-3 py-2 text-xs hover:bg-stone-800 transition-colors cursor-pointer"
+                :class="selectedCollectionIds.includes(col.id) ? 'text-amber-400' : 'text-stone-300'"
+              >
+                <input
+                  type="checkbox"
+                  :checked="selectedCollectionIds.includes(col.id)"
+                  class="accent-amber-500"
+                  @change="toggleCollection(col.id)"
+                />
+                <span class="flex-1">{{ col.name }}</span>
+                <span class="text-stone-600 text-[10px]">{{ col.document_count }} docs</span>
+              </label>
+            </div>
+          </div>
 
-        <button
-          class="p-1.5 rounded-lg text-stone-400 hover:text-white transition-colors"
-          title="New branch"
-          @click="createNewBranch"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="12" y1="5" x2="12" y2="19" />
-            <line x1="5" y1="12" x2="19" y2="12" />
-          </svg>
-        </button>
+          <!-- Settings (system prompt) -->
+          <button
+            class="p-1.5 rounded-lg transition-colors"
+            :class="showSettings ? 'bg-amber-600/20 text-amber-400' : 'text-stone-400 hover:text-white'"
+            title="Session settings"
+            @click="toggleSettings"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+          </button>
 
-        <button
-          class="p-1.5 rounded-lg text-stone-400 hover:text-red-400 transition-colors"
-          title="Delete branch"
-          @click="deleteBranch"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <polyline points="3 6 5 6 21 6" />
-            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-          </svg>
-        </button>
+          <!-- Export -->
+          <div class="relative" @click.stop>
+            <button
+              class="p-1.5 rounded-lg text-stone-400 hover:text-white transition-colors"
+              title="Export"
+              @click="showExportDropdown = !showExportDropdown; showLlmDropdown = false; showRagDropdown = false"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="7 10 12 15 17 10" /><line x1="12" y1="15" x2="12" y2="3" />
+              </svg>
+            </button>
+            <!-- Export Dropdown -->
+            <div
+              v-if="showExportDropdown"
+              class="absolute right-0 top-full mt-1 bg-stone-900 border border-stone-700 rounded-xl shadow-xl z-50 min-w-[160px] py-1"
+            >
+              <button class="w-full text-left px-3 py-2 text-xs text-stone-300 hover:bg-stone-800 transition-colors" @click="copyChatToClipboard">
+                Copy to clipboard
+              </button>
+              <button class="w-full text-left px-3 py-2 text-xs text-stone-300 hover:bg-stone-800 transition-colors" @click="exportChatMarkdown">
+                Export Markdown
+              </button>
+              <button class="w-full text-left px-3 py-2 text-xs text-stone-300 hover:bg-stone-800 transition-colors" @click="exportChatJson">
+                Export JSON
+              </button>
+            </div>
+          </div>
+        </template>
+
+        <!-- Toolbar buttons (admin: all, non-admin: none of branch/context) -->
+        <template v-if="isAdmin">
+          <button
+            class="p-1.5 rounded-lg transition-colors"
+            :class="showContextFiles ? 'bg-amber-600/20 text-amber-400' : 'text-stone-400 hover:text-white'"
+            title="Context files"
+            @click="toggleContextFiles"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+            </svg>
+          </button>
+
+          <button
+            class="p-1.5 rounded-lg transition-colors"
+            :class="showBranches ? 'bg-amber-600/20 text-amber-400' : 'text-stone-400 hover:text-white'"
+            title="Branch tree"
+            @click="toggleBranches"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="6" y1="3" x2="6" y2="15" />
+              <circle cx="18" cy="6" r="3" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M18 9a9 9 0 0 1-9 9" />
+            </svg>
+          </button>
+
+          <button
+            class="p-1.5 rounded-lg text-stone-400 hover:text-white transition-colors"
+            title="New branch"
+            @click="createNewBranch"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+          </button>
+
+          <button
+            class="p-1.5 rounded-lg text-stone-400 hover:text-red-400 transition-colors"
+            title="Delete branch"
+            @click="deleteBranch"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="3 6 5 6 21 6" />
+              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+            </svg>
+          </button>
+        </template>
       </div>
 
       <!-- Portrait: panel drops down below header -->
@@ -545,6 +824,28 @@ onUnmounted(() => {
               </div>
             </div>
           </template>
+
+          <!-- Settings panel -->
+          <template v-if="showSettings">
+            <div class="px-3 py-2 text-xs font-medium text-stone-400 uppercase tracking-wide">
+              Session Settings
+            </div>
+            <div class="px-3 pb-3">
+              <label class="block text-xs text-stone-400 mb-1">System Prompt</label>
+              <textarea
+                v-model="customPrompt"
+                rows="5"
+                class="w-full bg-stone-950 text-stone-200 text-xs rounded-lg p-2 border border-stone-700 focus:border-amber-500 focus:outline-none resize-y min-h-[80px]"
+                placeholder="Custom system prompt for this session..."
+              />
+              <button
+                class="mt-2 w-full py-1.5 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium transition-colors"
+                @click="saveSystemPrompt"
+              >
+                Save prompt
+              </button>
+            </div>
+          </template>
         </div>
 
         <!-- Resize handle (portrait: horizontal bar at bottom of panel) -->
@@ -578,6 +879,7 @@ onUnmounted(() => {
               :key="msg.id"
               :message="msg"
               :is-speaking="tts.speakingMessageId.value === msg.id"
+              :is-admin="isAdmin"
               @speak="tts.speak($event, msg.id)"
               @stop-speak="tts.stop()"
               @edit="handleEditMessage"
@@ -591,6 +893,7 @@ onUnmounted(() => {
               v-if="isStreaming && streamingContent"
               :message="{ id: 'streaming', role: 'assistant', content: streamingContent, timestamp: new Date().toISOString() }"
               :is-streaming="true"
+              :is-admin="isAdmin"
             />
 
             <div v-if="isStreaming && !streamingContent" class="flex justify-start px-4 mb-3">
@@ -655,7 +958,7 @@ onUnmounted(() => {
         <!-- Panel header with close -->
         <div class="shrink-0 flex items-center justify-between px-3 py-2 border-b border-stone-800">
           <span class="text-xs font-medium text-stone-400 uppercase tracking-wide">
-            {{ showBranches ? 'Branch Tree' : 'Context Files' }}
+            {{ activePanelName }}
           </span>
           <button class="text-stone-500 hover:text-white transition-colors" @click="closePanel">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -717,6 +1020,25 @@ onUnmounted(() => {
                 </svg>
               </button>
             </div>
+          </div>
+        </template>
+
+        <!-- Settings (landscape) -->
+        <template v-if="showSettings">
+          <div class="px-3 py-3">
+            <label class="block text-xs text-stone-400 mb-1">System Prompt</label>
+            <textarea
+              v-model="customPrompt"
+              rows="8"
+              class="w-full bg-stone-950 text-stone-200 text-xs rounded-lg p-2 border border-stone-700 focus:border-amber-500 focus:outline-none resize-y min-h-[80px]"
+              placeholder="Custom system prompt for this session..."
+            />
+            <button
+              class="mt-2 w-full py-1.5 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium transition-colors"
+              @click="saveSystemPrompt"
+            >
+              Save prompt
+            </button>
           </div>
         </template>
       </div>

--- a/mobile/src/views/LoginView.vue
+++ b/mobile/src/views/LoginView.vue
@@ -10,17 +10,11 @@ const auth = useAuthStore();
 const settings = useSettingsStore();
 const mobileConfig = useMobileConfigStore();
 
-const serverUrl = ref("");
 const username = ref("");
 const password = ref("");
-const step = ref<"server" | "login">("server");
 
 onMounted(async () => {
   await settings.load();
-  if (settings.serverUrl) {
-    serverUrl.value = settings.serverUrl;
-    step.value = "login";
-  }
   await auth.loadToken();
   if (auth.isAuthenticated && !auth.isTokenExpired()) {
     await mobileConfig.load();
@@ -28,23 +22,12 @@ onMounted(async () => {
   }
 });
 
-async function setServer() {
-  const url = serverUrl.value.trim();
-  if (!url) return;
-  await settings.setServerUrl(url);
-  step.value = "login";
-}
-
 async function handleLogin() {
   const ok = await auth.login(username.value, password.value);
   if (ok) {
     await mobileConfig.load();
     router.replace("/chats");
   }
-}
-
-function changeServer() {
-  step.value = "server";
 }
 </script>
 
@@ -77,36 +60,8 @@ function changeServer() {
       <p class="text-stone-400 text-sm mt-1">Your personal assistant</p>
     </div>
 
-    <!-- Server URL step -->
-    <div v-if="step === 'server'" class="w-full max-w-sm space-y-4">
-      <div>
-        <label class="block text-sm text-stone-400 mb-1.5">Server URL</label>
-        <input
-          v-model="serverUrl"
-          type="url"
-          placeholder="https://your-server.com"
-          class="w-full rounded-xl bg-stone-800 border border-stone-700 px-4 py-3 text-white placeholder-stone-500 focus:outline-none focus:border-amber-500"
-          @keyup.enter="setServer"
-        />
-      </div>
-      <button
-        :disabled="!serverUrl.trim()"
-        class="w-full py-3 rounded-xl bg-amber-600 hover:bg-amber-700 disabled:bg-stone-700 disabled:text-stone-500 text-white font-medium transition-colors"
-        @click="setServer"
-      >
-        Continue
-      </button>
-    </div>
-
-    <!-- Login step -->
-    <div v-else class="w-full max-w-sm space-y-4">
-      <button
-        class="text-sm text-stone-400 hover:text-stone-300 mb-2"
-        @click="changeServer"
-      >
-        {{ settings.serverUrl }}
-      </button>
-
+    <!-- Login form -->
+    <div class="w-full max-w-sm space-y-4">
       <div>
         <label class="block text-sm text-stone-400 mb-1.5">Username</label>
         <input

--- a/mobile/src/views/SettingsView.vue
+++ b/mobile/src/views/SettingsView.vue
@@ -1,23 +1,9 @@
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
 import { useRouter } from "vue-router";
-import { useSettingsStore } from "@/stores/settings";
 import { useAuthStore } from "@/stores/auth";
 
 const router = useRouter();
-const settings = useSettingsStore();
 const auth = useAuthStore();
-
-const serverUrl = ref("");
-
-onMounted(() => {
-  serverUrl.value = settings.serverUrl;
-});
-
-async function save() {
-  await settings.setServerUrl(serverUrl.value);
-  router.back();
-}
 
 async function handleLogout() {
   await auth.logout();
@@ -75,29 +61,6 @@ async function handleLogout() {
               Logout
             </button>
           </div>
-        </div>
-      </div>
-
-      <!-- Server -->
-      <div>
-        <h2 class="text-sm font-medium text-stone-400 mb-3 uppercase tracking-wider">
-          Server
-        </h2>
-        <div class="bg-stone-800/50 rounded-xl p-4 space-y-3">
-          <div>
-            <label class="block text-sm text-stone-400 mb-1">URL</label>
-            <input
-              v-model="serverUrl"
-              type="url"
-              class="w-full rounded-lg bg-stone-950 border border-stone-700 px-3 py-2 text-sm text-white focus:outline-none focus:border-amber-500"
-            />
-          </div>
-          <button
-            class="w-full py-2 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-sm font-medium transition-colors"
-            @click="save"
-          >
-            Save
-          </button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- **Admin settings panel** in mobile ChatView: LLM provider selection, RAG collection toggle, custom system prompt
- **Chat management**: create new chat (button in empty state + header), delete chats from list
- **Role-based UI**: message actions (edit, save to context, summarize) visible only to admin users
- **Hardcoded server URL**: removed configurable server URL step from login flow, always uses production endpoint
- **New API client**: `admin.ts` for providers and collections endpoints
- **Stream overrides**: `chat.ts` supports per-message LLM/RAG overrides via `overrides` param

## NEWS

📱 **Мобильное приложение: режим администратора**

Админы теперь могут прямо в чате мобильного приложения переключать LLM-провайдера, подключать базы знаний (RAG) и задавать кастомный системный промпт. Также добавлено создание и удаление чатов. Обычным пользователям доступен упрощённый интерфейс без лишних кнопок.

## Test plan

- [ ] Admin login → settings gear icon visible in chat header
- [ ] Open settings → LLM providers and RAG collections load
- [ ] Select different LLM → message sent with override
- [ ] Regular user login → no settings icon, no edit/context/summarize buttons
- [ ] Chat list → create new chat button works
- [ ] Chat list → delete chat removes it
- [ ] Login flow has no server URL step

🤖 Generated with [Claude Code](https://claude.com/claude-code)