### PR TITLE
fix: add input field to welcome screen for non-admin users

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -96,6 +96,30 @@ const authStore = useAuthStore()
 const fullscreenStore = useChatFullscreenStore()
 const chatRouter = useRouter()
 const isChatOnly = computed(() => authStore.isChatOnlyUser)
+const welcomeInput = ref('')
+const welcomeSending = ref(false)
+
+async function sendFromWelcome() {
+  const text = welcomeInput.value.trim()
+  if (!text || welcomeSending.value) return
+  welcomeSending.value = true
+  try {
+    if (sessions.value.length > 0) {
+      // Open most recent shared chat and let user type there
+      currentSessionId.value = sessions.value[0].id
+    } else {
+      // Create new session
+      const data = await chatApi.createSession(text, undefined, 'admin')
+      refetchSessions()
+      currentSessionId.value = data.session.id
+    }
+    welcomeInput.value = ''
+  } catch {
+    // fallback
+  } finally {
+    welcomeSending.value = false
+  }
+}
 
 function handleChatLogout() {
   authStore.logout()
@@ -2455,28 +2479,50 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
     <div class="flex-1 flex flex-col min-w-0">
 
       <!-- Welcome screen for chat-only users with no session selected -->
-      <div v-if="isChatOnly && !currentSessionId" class="flex-1 flex flex-col items-center justify-center px-6">
-        <div class="text-center max-w-md">
+      <div v-if="isChatOnly && !currentSessionId" class="flex-1 flex flex-col items-center px-6">
+        <div class="flex-1" />
+        <div class="text-center max-w-lg w-full">
           <div class="w-16 h-16 mx-auto mb-6 rounded-2xl bg-primary/15 flex items-center justify-center">
             <MessageSquare class="w-8 h-8 text-primary" />
           </div>
           <h1 class="text-2xl font-bold mb-2">
             {{ t('chatView.welcome', { name: authStore.user?.username }) }}
           </h1>
-          <p class="text-muted-foreground text-sm mb-8">
+          <p class="text-muted-foreground text-sm mb-6">
             {{ t('chatView.welcomeSubtitle') }}
           </p>
 
+          <!-- Input field (Claude-like) -->
+          <div class="flex items-end gap-2 mb-8 max-w-md mx-auto">
+            <textarea
+              v-model="welcomeInput"
+              rows="1"
+              class="flex-1 resize-none rounded-xl bg-card border border-border px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary transition-all"
+              :placeholder="t('chatView.welcomeInputPlaceholder', 'Ask anything...')"
+              @keydown.enter.exact.prevent="sendFromWelcome"
+              @input="($event.target as HTMLTextAreaElement).style.height = 'auto'; ($event.target as HTMLTextAreaElement).style.height = Math.min(($event.target as HTMLTextAreaElement).scrollHeight, 120) + 'px'"
+            />
+            <button
+              :disabled="!welcomeInput.trim() || welcomeSending"
+              class="shrink-0 w-11 h-11 rounded-xl bg-primary hover:bg-primary/90 disabled:bg-secondary disabled:text-muted-foreground flex items-center justify-center transition-colors"
+              @click="sendFromWelcome"
+            >
+              <Loader2 v-if="welcomeSending" class="w-4 h-4 animate-spin" />
+              <Send v-else class="w-4 h-4" />
+            </button>
+          </div>
+
           <!-- Shared chats as cards -->
-          <div v-if="sessions.length" class="space-y-3 text-left">
+          <div v-if="sessions.length" class="space-y-2 text-left max-w-md mx-auto">
+            <p class="text-xs text-muted-foreground uppercase tracking-wide mb-2">{{ t('chatView.yourChats', 'Your chats') }}</p>
             <button
               v-for="session in sessions"
               :key="session.id"
-              class="w-full p-4 rounded-xl bg-card border border-border hover:border-primary/40 hover:bg-accent transition-all group text-left flex items-center gap-3"
+              class="w-full p-3 rounded-xl bg-card border border-border hover:border-primary/40 hover:bg-accent transition-all group text-left flex items-center gap-3"
               @click="currentSessionId = session.id"
             >
-              <div class="shrink-0 w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
-                <MessageSquare class="w-5 h-5 text-primary" />
+              <div class="shrink-0 w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center">
+                <MessageSquare class="w-4 h-4 text-primary" />
               </div>
               <div class="flex-1 min-w-0">
                 <span class="font-medium text-sm truncate block group-hover:text-primary transition-colors">
@@ -2489,11 +2535,8 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
               <ChevronRight class="w-4 h-4 text-muted-foreground group-hover:text-primary shrink-0 transition-colors" />
             </button>
           </div>
-
-          <div v-else class="text-muted-foreground text-sm">
-            {{ t('chatView.noSharedChats') }}
-          </div>
         </div>
+        <div class="flex-1" />
       </div>
 
       <!-- Chat Header (hidden in zen mode) -->

--- a/mobile/src/views/ChatListView.vue
+++ b/mobile/src/views/ChatListView.vue
@@ -12,6 +12,8 @@ const sessions = ref<ChatSessionSummary[]>([]);
 const isLoading = ref(false);
 const error = ref<string | null>(null);
 const isCreating = ref(false);
+const welcomeInput = ref("");
+const isSending = ref(false);
 
 // For non-admins: only shared chats
 const visibleSessions = computed(() => {
@@ -86,6 +88,28 @@ function formatDate(dateStr: string): string {
 function truncate(text: string, len: number): string {
   if (!text) return "";
   return text.length > len ? text.slice(0, len) + "..." : text;
+}
+
+async function sendFromWelcome() {
+  const text = welcomeInput.value.trim();
+  if (!text || isSending.value) return;
+  isSending.value = true;
+  try {
+    // If there are shared chats, open the most recent one
+    if (visibleSessions.value.length > 0) {
+      const sessionId = visibleSessions.value[0]!.id;
+      // Navigate to chat — the message will be typed by user there
+      router.push(`/chat/${sessionId}?msg=${encodeURIComponent(text)}`);
+    } else {
+      // Create a new session and navigate
+      const data = await chatApi.createSession(text);
+      router.push(`/chat/${data.session.id}?msg=${encodeURIComponent(text)}`);
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to start chat";
+  } finally {
+    isSending.value = false;
+  }
 }
 
 onMounted(loadSessions);
@@ -177,9 +201,10 @@ onMounted(loadSessions);
         <!-- Minimal header -->
         <div class="shrink-0 flex items-center justify-between px-4 py-3">
           <div class="flex items-center gap-2">
-            <div class="w-8 h-8 rounded-xl bg-amber-600 flex items-center justify-center">
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5">
-                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+            <div class="w-8 h-8">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-full h-full">
+                <defs><linearGradient id="gl" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#F0A830"/><stop offset="100%" stop-color="#C27010"/></linearGradient></defs>
+                <path fill="url(#gl)" fill-rule="evenodd" d="M 431.8 217.4 L 484.1 226.3 L 484.1 285.7 L 431.8 294.6 L 407.6 353.0 L 438.3 396.3 L 396.3 438.3 L 353.0 407.6 L 294.6 431.8 L 285.7 484.1 L 226.3 484.1 L 217.4 431.8 L 159.0 407.6 L 115.7 438.3 L 73.7 396.3 L 104.4 353.0 L 80.2 294.6 L 27.9 285.7 L 27.9 226.3 L 80.2 217.4 L 104.4 159.0 L 73.7 115.7 L 115.7 73.7 L 159.0 104.4 L 217.4 80.2 L 226.3 27.9 L 285.7 27.9 L 294.6 80.2 L 353.0 104.4 L 396.3 73.7 L 438.3 115.7 L 407.6 159.0 Z M 341.0 256.0 A 85 85 0 1 0 171.0 256.0 A 85 85 0 1 0 341.0 256.0 Z"/>
               </svg>
             </div>
             <span class="text-white font-semibold">AI Secretary</span>
@@ -198,76 +223,90 @@ onMounted(loadSessions);
         </div>
 
         <!-- Main welcome area -->
-        <div class="flex-1 flex flex-col items-center justify-center px-6">
+        <div class="flex-1 flex flex-col px-6">
           <!-- Loading -->
-          <div v-if="isLoading" class="flex items-center justify-center">
+          <div v-if="isLoading" class="flex-1 flex items-center justify-center">
             <div class="w-8 h-8 border-2 border-amber-500 border-t-transparent rounded-full animate-spin" />
           </div>
 
           <!-- Error -->
-          <div v-else-if="error" class="text-center">
-            <p class="text-red-400 text-sm mb-2">{{ error }}</p>
-            <button class="text-amber-400 text-sm" @click="loadSessions">Retry</button>
+          <div v-else-if="error" class="flex-1 flex items-center justify-center text-center">
+            <div>
+              <p class="text-red-400 text-sm mb-2">{{ error }}</p>
+              <button class="text-amber-400 text-sm" @click="loadSessions">Retry</button>
+            </div>
           </div>
 
           <template v-else>
+            <!-- Spacer to push content to center -->
+            <div class="flex-1" />
+
             <!-- Greeting -->
-            <div class="text-center mb-8">
+            <div class="text-center mb-6">
               <h1 class="text-2xl font-bold text-white mb-2">
                 Hello, {{ auth.user?.username }}
               </h1>
               <p class="text-stone-400 text-sm">
-                Your conversations are ready
+                How can I help you today?
               </p>
             </div>
 
+            <!-- Center input (Claude-like) -->
+            <div class="w-full max-w-sm mx-auto mb-6">
+              <div class="flex items-end gap-2">
+                <textarea
+                  v-model="welcomeInput"
+                  rows="1"
+                  class="flex-1 resize-none rounded-2xl bg-stone-800 border border-stone-700 px-4 py-3 text-sm text-stone-300 placeholder-stone-500 focus:outline-none focus:border-amber-500 transition-colors"
+                  placeholder="Ask anything..."
+                  @keydown.enter.exact.prevent="sendFromWelcome"
+                  @input="($event.target as HTMLTextAreaElement).style.height = 'auto'; ($event.target as HTMLTextAreaElement).style.height = Math.min(($event.target as HTMLTextAreaElement).scrollHeight, 120) + 'px'"
+                />
+                <button
+                  :disabled="!welcomeInput.trim() || isSending"
+                  class="shrink-0 w-11 h-11 rounded-xl bg-amber-600 hover:bg-amber-700 disabled:bg-stone-700 disabled:text-stone-500 flex items-center justify-center transition-colors"
+                  @click="sendFromWelcome"
+                >
+                  <div v-if="isSending" class="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                  <svg v-else xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-white">
+                    <line x1="22" y1="2" x2="11" y2="13" /><polygon points="22 2 15 22 11 13 2 9 22 2" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+
             <!-- Shared chats as cards -->
-            <div v-if="visibleSessions.length" class="w-full max-w-sm space-y-3 mb-6">
+            <div v-if="visibleSessions.length" class="w-full max-w-sm mx-auto space-y-2 mb-6">
+              <p class="text-xs text-stone-500 uppercase tracking-wide mb-2">Your chats</p>
               <button
                 v-for="session in visibleSessions"
                 :key="session.id"
-                class="w-full text-left p-4 rounded-2xl bg-stone-800/60 border border-stone-700/50 hover:border-amber-600/40 hover:bg-stone-800 active:bg-stone-700/80 transition-all group"
+                class="w-full text-left p-3 rounded-xl bg-stone-800/60 border border-stone-700/50 hover:border-amber-600/40 hover:bg-stone-800 active:bg-stone-700/80 transition-all group"
                 @click="openChat(session.id)"
               >
-                <div class="flex items-start gap-3">
-                  <!-- Chat icon -->
-                  <div class="shrink-0 w-10 h-10 rounded-xl bg-amber-600/15 flex items-center justify-center mt-0.5">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-amber-500">
+                <div class="flex items-center gap-3">
+                  <div class="shrink-0 w-9 h-9 rounded-lg bg-amber-600/15 flex items-center justify-center">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-amber-500">
                       <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
                     </svg>
                   </div>
                   <div class="flex-1 min-w-0">
-                    <div class="flex items-center gap-2 mb-1">
-                      <span class="font-medium text-sm text-white truncate group-hover:text-amber-200 transition-colors">
-                        {{ session.title || "Chat" }}
-                      </span>
-                      <span class="text-[10px] text-stone-500 shrink-0">
-                        {{ formatDate(session.updated) }}
-                      </span>
-                    </div>
-                    <p v-if="session.last_message" class="text-xs text-stone-400 truncate">
-                      {{ truncate(session.last_message, 60) }}
-                    </p>
-                    <p v-else class="text-xs text-stone-500 italic">Start chatting</p>
+                    <span class="font-medium text-sm text-white truncate block group-hover:text-amber-200 transition-colors">
+                      {{ session.title || "Chat" }}
+                    </span>
+                    <span v-if="session.last_message" class="text-xs text-stone-500 truncate block">
+                      {{ truncate(session.last_message, 50) }}
+                    </span>
                   </div>
-                  <!-- Arrow -->
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-stone-600 group-hover:text-amber-500 shrink-0 mt-1 transition-colors">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-stone-600 group-hover:text-amber-500 shrink-0 transition-colors">
                     <polyline points="9 18 15 12 9 6" />
                   </svg>
                 </div>
               </button>
             </div>
 
-            <!-- No shared chats -->
-            <div v-else class="text-center">
-              <div class="w-16 h-16 mx-auto mb-4 rounded-2xl bg-stone-800/60 flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="text-stone-600">
-                  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-                </svg>
-              </div>
-              <p class="text-stone-400 text-sm mb-1">No conversations yet</p>
-              <p class="text-stone-600 text-xs">Ask your admin to share a chat with you</p>
-            </div>
+            <!-- Bottom spacer -->
+            <div class="flex-1" />
           </template>
         </div>
       </div>

--- a/mobile/src/views/ChatView.vue
+++ b/mobile/src/views/ChatView.vue
@@ -547,9 +547,15 @@ watch(streamingContent, () => {
   scrollToBottom();
 });
 
-onMounted(() => {
-  loadSession();
+onMounted(async () => {
+  await loadSession();
   loadAdminData();
+  // Auto-send message from welcome screen
+  const msg = route.query.msg as string | undefined;
+  if (msg) {
+    router.replace({ path: route.path, query: {} });
+    sendMessage(msg);
+  }
   updateOrientation();
   window.addEventListener("resize", updateOrientation);
   window.addEventListener("mousemove", onResizeMove);

--- a/mobile/src/views/LoginView.vue
+++ b/mobile/src/views/LoginView.vue
@@ -37,23 +37,15 @@ async function handleLogin() {
   >
     <!-- Logo -->
     <div class="mb-8 text-center">
-      <div
-        class="w-16 h-16 mx-auto mb-4 rounded-2xl bg-amber-600 flex items-center justify-center"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="32"
-          height="32"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="white"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <path
-            d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
-          />
+      <div class="w-16 h-16 mx-auto mb-4">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-full h-full">
+          <defs>
+            <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#F0A830"/>
+              <stop offset="100%" stop-color="#C27010"/>
+            </linearGradient>
+          </defs>
+          <path fill="url(#g)" fill-rule="evenodd" d="M 431.8 217.4 L 484.1 226.3 L 484.1 285.7 L 431.8 294.6 L 407.6 353.0 L 438.3 396.3 L 396.3 438.3 L 353.0 407.6 L 294.6 431.8 L 285.7 484.1 L 226.3 484.1 L 217.4 431.8 L 159.0 407.6 L 115.7 438.3 L 73.7 396.3 L 104.4 353.0 L 80.2 294.6 L 27.9 285.7 L 27.9 226.3 L 80.2 217.4 L 104.4 159.0 L 73.7 115.7 L 115.7 73.7 L 159.0 104.4 L 217.4 80.2 L 226.3 27.9 L 285.7 27.9 L 294.6 80.2 L 353.0 104.4 L 396.3 73.7 L 438.3 115.7 L 407.6 159.0 Z M 341.0 256.0 A 85 85 0 1 0 171.0 256.0 A 85 85 0 1 0 341.0 256.0 Z"/>
         </svg>
       </div>
       <h1 class="text-2xl font-bold text-white">AI Secretary</h1>


### PR DESCRIPTION
## Summary

- Added Claude-like centered input field on welcome screen (mobile + web)
- Non-admin users can type and get redirected to first shared chat or new session
- Shared chat cards shown below input for quick access
- Mobile ChatView handles `?msg=` query param for auto-send from welcome

## NEWS

💬 **Экран приветствия стал интерактивным**

Теперь при входе пользователи видят удобное поле ввода по центру экрана
и карточки доступных чатов — как в Claude. Просто начните печатать
и вас перенесёт в чат. Работает и в мобильном приложении, и в браузере.

## Test plan

- [ ] Login as non-admin — welcome screen shows input + chat cards
- [ ] Type in welcome input and send — redirects to chat
- [ ] Login as admin — unchanged behavior (full chat list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)