### PR TITLE
fix: remove empty chat placeholder for non-admin users

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,19 +325,24 @@ DEV_MODE=1                          # Backend proxies to Vite dev server (:5173)
 
 ## Deployment
 
-### Docker Deployment (Production)
+### Server Deployment (Production)
+
+Server: `root@155.212.231.7`, systemd service (not Docker Compose).
 
 ```bash
+ssh root@155.212.231.7
 cd /opt/ai-secretary
-docker compose ps                            # status
-docker compose logs -f ai-secretary          # logs
-docker compose up -d --build                 # rebuild + restart
-docker compose restart ai-secretary          # restart only
-
-# Admin panel rebuild (ALWAYS build from /opt/ai-secretary/admin, not git clone!)
-cd /opt/ai-secretary/admin && npm run build
-docker compose restart ai-secretary          # REQUIRED: re-bind new dist/ inode
+git pull origin main
+cd admin && npm ci && npm run build
+rsync -av --delete admin/dist/ /var/www/admin-ai-sekretar24/  # REQUIRED: nginx serves from /var/www/
+sed -i "s/ai-admin-v[0-9a-z]*/ai-admin-v$(date +%s)/" /var/www/admin-ai-sekretar24/sw.js  # bust SW cache
+systemctl restart ai-secretary               # restart orchestrator
+curl -s http://localhost:8002/health         # health check
 ```
+
+**IMPORTANT**: Nginx serves frontend from `/var/www/admin-ai-sekretar24/`, NOT from `/opt/ai-secretary/admin/dist/`. Always rsync after build.
+
+Webhook auto-deploy: `ai-secretary-webhook.service` triggers on GitHub push.
 
 **Local-only files** (not in git): `.env`, `docker-compose.override.yml`, modified `Dockerfile`, `services/bridge/src/models/`
 
@@ -379,7 +384,7 @@ Check in this order — **infrastructure first**, application logic last:
 
 This project is developed from two machines:
 - **local** — dev workstation with GPU (RTX 3060), full stack
-- **server** — Beget VPS, Docker, cloud LLM only
+- **server** — Beget VPS (`root@155.212.231.7`), systemd service, cloud LLM only
 
 Each machine identifies itself via `~/.claude/projects/.../memory/MEMORY.md` (`## Machine Role` section). **Check your machine role before git operations.**
 

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -3289,14 +3289,8 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
           </div>
         </template>
 
-        <!-- Normal chat: no session selected -->
+        <!-- Normal chat: no session selected — show nothing (sidebar has chat list) -->
         <template v-else-if="!currentSession">
-          <div class="h-full flex items-center justify-center text-muted-foreground">
-            <div class="text-center">
-              <MessageSquare class="w-12 h-12 mx-auto mb-4 opacity-50" />
-              <p>{{ t('chatView.selectOrCreate') }}</p>
-            </div>
-          </div>
         </template>
 
         <template v-else>


### PR DESCRIPTION
## Summary
- Remove "Select a chat or create a new one" placeholder from messages area
- Update welcomeSubtitle i18n text
- Update server deploy docs (rsync to /var/www/)

## Test plan
- [ ] Login as non-admin → no placeholder shown
- [ ] Login as admin → sidebar shows chats, no placeholder in main area

🤖 Generated with [Claude Code](https://claude.com/claude-code)