### PR TITLE
fix: show zen activity bar on welcome screen

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -2078,7 +2078,7 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
 
     <!-- Zen Mode: Vertical Activity Bar (left) -->
     <div
-      v-if="fullscreenStore.isFullscreen && currentSession"
+      v-if="fullscreenStore.isFullscreen"
       class="zen-activity-bar zen-glass zen-toolbar-enter flex flex-col items-center py-3 px-1.5 gap-1 border-r border-border/30 z-10"
     >
       <!-- Exit fullscreen (top) -->


### PR DESCRIPTION
## Summary
- Show zen activity bar even when no chat session is selected
- Chat-only users now see controls (voice, export, settings, logout) on the welcome screen

## Test plan
- [ ] Login as non-admin → activity bar visible on welcome/start screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)