### PR TITLE
fix: fullscreen panels in zen mode

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -3542,6 +3542,7 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
       <!-- Branch Tree Panel -->
       <template v-if="showBranchTree">
         <div
+          v-if="!fullscreenStore.isFullscreen"
           class="w-1.5 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors flex-shrink-0"
           @mousedown="startBranchResize"
           @touchstart="startBranchTouchResize"
@@ -3549,7 +3550,8 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
         <BranchTree
           :branches="branchTree"
           :session-id="currentSessionId || ''"
-          :style="{ width: branchTreeWidth + 'px' }"
+          :class="fullscreenStore.isFullscreen ? 'fixed inset-0 z-50' : ''"
+          :style="fullscreenStore.isFullscreen ? {} : { width: branchTreeWidth + 'px' }"
           @switch="onBranchSwitch"
           @scroll-to="onBranchScrollTo"
           @new-branch="startNewBranch"
@@ -3579,9 +3581,9 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
         />
       </template>
 
-      <!-- Settings Panel (slide-out right / fullscreen on mobile) -->
+      <!-- Settings Panel (slide-out right / fullscreen on mobile and zen) -->
       <div
-        v-if="showSettings"
+        v-if="showSettings && !fullscreenStore.isFullscreen"
         class="hidden md:block w-1.5 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors flex-shrink-0"
         @mousedown="startSettingsResize"
         @touchstart="startSettingsTouchResize"
@@ -3594,7 +3596,12 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
       />
       <div
         v-if="showSettings"
-        class="fixed inset-0 z-50 md:relative md:inset-auto md:z-0 border-l border-border bg-card flex flex-col flex-shrink-0 overflow-hidden settings-panel"
+        :class="[
+          'border-l border-border bg-card flex flex-col flex-shrink-0 overflow-hidden settings-panel',
+          fullscreenStore.isFullscreen
+            ? 'fixed inset-0 z-50'
+            : 'fixed inset-0 z-50 md:relative md:inset-auto md:z-0'
+        ]"
         :style="{ '--settings-w': settingsWidth + 'px' }"
       >
         <!-- Panel header -->


### PR DESCRIPTION
## Summary
- Settings panel: fullscreen overlay in zen mode (was half-width side panel)
- Branch tree: fullscreen overlay in zen mode
- Resize handles hidden in zen mode

## Test plan
- [ ] Zen mode: open settings → fullscreen overlay
- [ ] Zen mode: open branch tree → fullscreen overlay
- [ ] Normal mode: panels still work as side panels with resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)