### PR TITLE
feat: mobile app — Russian localization, non-admin UX

### DIFF
--- a/mobile/src/components/ChatInput.vue
+++ b/mobile/src/components/ChatInput.vue
@@ -95,7 +95,7 @@ function removePastedBlock(id: string) {
         :disabled="disabled"
         rows="1"
         class="flex-1 resize-none rounded-xl bg-stone-800 border border-stone-700 px-4 py-2.5 text-sm text-stone-300 placeholder-stone-500 focus:outline-none focus:border-amber-500 transition-colors"
-        placeholder="Message..."
+        placeholder="Сообщение..."
         @keydown="handleKeydown"
         @input="autoResize"
         @paste="onPaste"

--- a/mobile/src/views/ChatListView.vue
+++ b/mobile/src/views/ChatListView.vue
@@ -30,10 +30,29 @@ async function loadSessions() {
       (a, b) =>
         new Date(b.updated).getTime() - new Date(a.updated).getTime(),
     );
+    // Non-admin: auto-create chat and go straight to it
+    if (!isAdmin.value) {
+      await autoOpenChat();
+    }
   } catch (e) {
     error.value = e instanceof Error ? e.message : "Failed to load";
   } finally {
     isLoading.value = false;
+  }
+}
+
+async function autoOpenChat() {
+  // If there are visible sessions, open the most recent one
+  if (visibleSessions.value.length > 0) {
+    router.replace(`/chat/${visibleSessions.value[0]!.id}`);
+    return;
+  }
+  // Otherwise create a new session and open it
+  try {
+    const data = await chatApi.createSession();
+    router.replace(`/chat/${data.session.id}`);
+  } catch {
+    // fallback — stay on the list
   }
 }
 
@@ -121,7 +140,7 @@ onMounted(loadSessions);
     <template v-if="isAdmin">
       <!-- Header -->
       <div class="shrink-0 flex items-center justify-between px-4 py-3 border-b border-stone-800">
-        <h1 class="text-lg font-semibold text-white">Chats</h1>
+        <h1 class="text-lg font-semibold text-white">Чаты</h1>
         <div class="flex items-center gap-3">
           <button class="text-stone-400 hover:text-white transition-colors" @click="$router.push('/settings')">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -150,8 +169,8 @@ onMounted(loadSessions);
           <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="mb-3 opacity-50">
             <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
           </svg>
-          <p class="text-sm mb-3">No chats yet</p>
-          <button class="px-4 py-2 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-sm transition-colors" @click="createNewChat">Start a chat</button>
+          <p class="text-sm mb-3">Пока нет чатов</p>
+          <button class="px-4 py-2 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-sm transition-colors" @click="createNewChat">Начать чат</button>
         </div>
         <div v-else>
           <div
@@ -162,7 +181,7 @@ onMounted(loadSessions);
           >
             <div class="flex-1 min-w-0">
               <div class="flex items-center justify-between mb-0.5">
-                <span class="font-medium text-sm text-white truncate mr-2">{{ session.title || "New Chat" }}</span>
+                <span class="font-medium text-sm text-white truncate mr-2">{{ session.title || "Новый чат" }}</span>
                 <span class="text-xs text-stone-500 shrink-0">{{ formatDate(session.updated) }}</span>
               </div>
               <p class="text-xs text-stone-400 truncate">{{ truncate(session.last_message || "", 80) }}</p>
@@ -244,10 +263,10 @@ onMounted(loadSessions);
             <!-- Greeting -->
             <div class="text-center mb-6">
               <h1 class="text-2xl font-bold text-white mb-2">
-                Hello, {{ auth.user?.username }}
+                Привет, {{ auth.user?.username }}
               </h1>
               <p class="text-stone-400 text-sm">
-                How can I help you today?
+                Чем могу помочь?
               </p>
             </div>
 
@@ -258,7 +277,7 @@ onMounted(loadSessions);
                   v-model="welcomeInput"
                   rows="1"
                   class="flex-1 resize-none rounded-2xl bg-stone-800 border border-stone-700 px-4 py-3 text-sm text-stone-300 placeholder-stone-500 focus:outline-none focus:border-amber-500 transition-colors"
-                  placeholder="Ask anything..."
+                  placeholder="Напишите сообщение..."
                   @keydown.enter.exact.prevent="sendFromWelcome"
                   @input="($event.target as HTMLTextAreaElement).style.height = 'auto'; ($event.target as HTMLTextAreaElement).style.height = Math.min(($event.target as HTMLTextAreaElement).scrollHeight, 120) + 'px'"
                 />
@@ -275,9 +294,31 @@ onMounted(loadSessions);
               </div>
             </div>
 
+            <!-- Action buttons -->
+            <div class="w-full max-w-sm mx-auto flex gap-2 mb-6">
+              <button
+                class="flex-1 py-2.5 rounded-xl bg-amber-600 hover:bg-amber-700 active:bg-amber-800 text-white text-sm font-medium transition-colors flex items-center justify-center gap-2"
+                :disabled="isCreating"
+                @click="createNewChat"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+                </svg>
+                Новый чат
+              </button>
+              <button
+                class="py-2.5 px-4 rounded-xl bg-stone-800 hover:bg-stone-700 active:bg-stone-600 text-stone-300 text-sm transition-colors flex items-center justify-center gap-2"
+                @click="$router.push('/settings')"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+                </svg>
+              </button>
+            </div>
+
             <!-- Shared chats as cards -->
             <div v-if="visibleSessions.length" class="w-full max-w-sm mx-auto space-y-2 mb-6">
-              <p class="text-xs text-stone-500 uppercase tracking-wide mb-2">Your chats</p>
+              <p class="text-xs text-stone-500 uppercase tracking-wide mb-2">Ваши чаты</p>
               <button
                 v-for="session in visibleSessions"
                 :key="session.id"
@@ -292,7 +333,7 @@ onMounted(loadSessions);
                   </div>
                   <div class="flex-1 min-w-0">
                     <span class="font-medium text-sm text-white truncate block group-hover:text-amber-200 transition-colors">
-                      {{ session.title || "Chat" }}
+                      {{ session.title || "Чат" }}
                     </span>
                     <span v-if="session.last_message" class="text-xs text-stone-500 truncate block">
                       {{ truncate(session.last_message, 50) }}

--- a/mobile/src/views/ChatView.vue
+++ b/mobile/src/views/ChatView.vue
@@ -44,6 +44,7 @@ const branches = ref<BranchNode[]>([]);
 const contextFiles = ref<ContextFile[]>([]);
 const branchesLoading = ref(false);
 const contextFileInputRef = ref<HTMLInputElement | null>(null);
+const settingsTab = ref<"files" | "prompt">("files");
 
 // Admin: LLM & RAG
 const llmProviders = ref<CloudProvider[]>([]);
@@ -341,12 +342,6 @@ const flatBranches = computed(() => flattenBranches(branches.value));
 
 // === Context Files ===
 
-function toggleContextFiles() {
-  showBranches.value = false;
-  showSettings.value = false;
-  showContextFiles.value = !showContextFiles.value;
-}
-
 function triggerFileUpload() {
   contextFileInputRef.value?.click();
 }
@@ -584,6 +579,7 @@ onUnmounted(() => {
         class="shrink-0 flex items-center gap-1.5 px-2 py-2.5 border-b border-stone-800 bg-stone-950/95 backdrop-blur"
       >
         <button
+          v-if="isAdmin"
           class="text-stone-400 hover:text-white transition-colors p-1"
           @click="router.back()"
         >
@@ -591,8 +587,12 @@ onUnmounted(() => {
             <polyline points="15 18 9 12 15 6" />
           </svg>
         </button>
+        <svg v-if="!isAdmin" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-6 h-6 shrink-0">
+          <defs><linearGradient id="hg" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#F0A830"/><stop offset="100%" stop-color="#C27010"/></linearGradient></defs>
+          <path fill="url(#hg)" fill-rule="evenodd" d="M 431.8 217.4 L 484.1 226.3 L 484.1 285.7 L 431.8 294.6 L 407.6 353.0 L 438.3 396.3 L 396.3 438.3 L 353.0 407.6 L 294.6 431.8 L 285.7 484.1 L 226.3 484.1 L 217.4 431.8 L 159.0 407.6 L 115.7 438.3 L 73.7 396.3 L 104.4 353.0 L 80.2 294.6 L 27.9 285.7 L 27.9 226.3 L 80.2 217.4 L 104.4 159.0 L 73.7 115.7 L 115.7 73.7 L 159.0 104.4 L 217.4 80.2 L 226.3 27.9 L 285.7 27.9 L 294.6 80.2 L 353.0 104.4 L 396.3 73.7 L 438.3 115.7 L 407.6 159.0 Z M 341.0 256.0 A 85 85 0 1 0 171.0 256.0 A 85 85 0 1 0 341.0 256.0 Z"/>
+        </svg>
         <h1 class="text-sm font-medium text-white truncate flex-1">
-          {{ title }}
+          {{ isAdmin ? title : 'AI Секретарь' }}
         </h1>
 
         <!-- Admin toolbar buttons -->
@@ -711,14 +711,14 @@ onUnmounted(() => {
 
         <!-- Toolbar buttons — available to all users -->
         <button
-          v-if="isAdmin"
           class="p-1.5 rounded-lg transition-colors"
-          :class="showContextFiles ? 'bg-amber-600/20 text-amber-400' : 'text-stone-400 hover:text-white'"
-          title="Context files"
-          @click="toggleContextFiles"
+          :class="showSettings ? 'bg-amber-600/20 text-amber-400' : 'text-stone-400 hover:text-white'"
+          title="Настройки чата"
+          @click="toggleSettings"
         >
+          <!-- Settings gear icon -->
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+            <circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
           </svg>
         </button>
 
@@ -755,6 +755,17 @@ onUnmounted(() => {
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <polyline points="3 6 5 6 21 6" />
             <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+          </svg>
+        </button>
+
+        <!-- Logout -->
+        <button
+          class="p-1.5 rounded-lg text-stone-400 hover:text-red-400 transition-colors"
+          title="Выйти"
+          @click="auth.logout(); router.replace('/login')"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" /><polyline points="16 17 21 12 16 7" /><line x1="21" y1="12" x2="9" y2="12" />
           </svg>
         </button>
       </div>
@@ -830,26 +841,70 @@ onUnmounted(() => {
             </div>
           </template>
 
-          <!-- Settings panel -->
+          <!-- Settings panel with tabs -->
           <template v-if="showSettings">
-            <div class="px-3 py-2 text-xs font-medium text-stone-400 uppercase tracking-wide">
-              Session Settings
-            </div>
-            <div class="px-3 pb-3">
-              <label class="block text-xs text-stone-400 mb-1">System Prompt</label>
-              <textarea
-                v-model="customPrompt"
-                rows="5"
-                class="w-full bg-stone-950 text-stone-200 text-xs rounded-lg p-2 border border-stone-700 focus:border-amber-500 focus:outline-none resize-y min-h-[80px]"
-                placeholder="Custom system prompt for this session..."
-              />
+            <!-- Tabs -->
+            <div class="flex border-b border-stone-700">
               <button
-                class="mt-2 w-full py-1.5 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium transition-colors"
-                @click="saveSystemPrompt"
+                class="flex-1 px-3 py-2 text-xs font-medium uppercase tracking-wide transition-colors"
+                :class="settingsTab === 'files' ? 'text-amber-400 border-b-2 border-amber-400' : 'text-stone-500 hover:text-stone-300'"
+                @click="settingsTab = 'files'"
               >
-                Save prompt
+                Файлы ({{ contextFiles.length }})
+              </button>
+              <button
+                class="flex-1 px-3 py-2 text-xs font-medium uppercase tracking-wide transition-colors"
+                :class="settingsTab === 'prompt' ? 'text-amber-400 border-b-2 border-amber-400' : 'text-stone-500 hover:text-stone-300'"
+                @click="settingsTab = 'prompt'"
+              >
+                Промпт
               </button>
             </div>
+
+            <!-- Files tab -->
+            <template v-if="settingsTab === 'files'">
+              <div class="px-3 py-2 flex items-center justify-between">
+                <span class="text-xs text-stone-400">Контекстные файлы</span>
+                <button class="text-xs text-amber-400 hover:text-amber-300 transition-colors" @click="triggerFileUpload">
+                  + Добавить
+                </button>
+              </div>
+              <input ref="contextFileInputRef" type="file" multiple accept=".txt,.md,.json,.csv,.xml,.yaml,.yml,.log,.py,.js,.ts,.html,.css" class="hidden" @change="handleFileUpload" />
+              <div v-if="!contextFiles.length" class="px-3 py-3 text-sm text-stone-500">Нет файлов</div>
+              <div v-else class="pb-2">
+                <div v-for="(file, index) in contextFiles" :key="index" class="flex items-center gap-2 px-3 py-1.5 hover:bg-stone-800/50">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-stone-500 shrink-0">
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" />
+                  </svg>
+                  <span class="text-xs text-stone-300 truncate flex-1">{{ file.name }}</span>
+                  <span class="text-[10px] text-stone-500">{{ Math.round(file.content.length / 1024) || '<1' }}KB</span>
+                  <button class="text-stone-500 hover:text-red-400 transition-colors" @click="removeContextFile(index)">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </template>
+
+            <!-- Prompt tab -->
+            <template v-if="settingsTab === 'prompt'">
+              <div class="px-3 py-3">
+                <label class="block text-xs text-stone-400 mb-1">Системный промпт</label>
+                <textarea
+                  v-model="customPrompt"
+                  rows="5"
+                  class="w-full bg-stone-950 text-stone-200 text-xs rounded-lg p-2 border border-stone-700 focus:border-amber-500 focus:outline-none resize-y min-h-[80px]"
+                  placeholder="Пользовательский промпт для этой сессии..."
+                />
+                <button
+                  class="mt-2 w-full py-1.5 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium transition-colors"
+                  @click="saveSystemPrompt"
+                >
+                  Сохранить
+                </button>
+              </div>
+            </template>
           </template>
         </div>
 
@@ -1030,21 +1085,59 @@ onUnmounted(() => {
 
         <!-- Settings (landscape) -->
         <template v-if="showSettings">
-          <div class="px-3 py-3">
-            <label class="block text-xs text-stone-400 mb-1">System Prompt</label>
-            <textarea
-              v-model="customPrompt"
-              rows="8"
-              class="w-full bg-stone-950 text-stone-200 text-xs rounded-lg p-2 border border-stone-700 focus:border-amber-500 focus:outline-none resize-y min-h-[80px]"
-              placeholder="Custom system prompt for this session..."
-            />
+          <div class="flex border-b border-stone-700">
             <button
-              class="mt-2 w-full py-1.5 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium transition-colors"
-              @click="saveSystemPrompt"
+              class="flex-1 px-3 py-2 text-xs font-medium uppercase tracking-wide transition-colors"
+              :class="settingsTab === 'files' ? 'text-amber-400 border-b-2 border-amber-400' : 'text-stone-500 hover:text-stone-300'"
+              @click="settingsTab = 'files'"
             >
-              Save prompt
+              Файлы ({{ contextFiles.length }})
+            </button>
+            <button
+              class="flex-1 px-3 py-2 text-xs font-medium uppercase tracking-wide transition-colors"
+              :class="settingsTab === 'prompt' ? 'text-amber-400 border-b-2 border-amber-400' : 'text-stone-500 hover:text-stone-300'"
+              @click="settingsTab = 'prompt'"
+            >
+              Промпт
             </button>
           </div>
+          <template v-if="settingsTab === 'files'">
+            <div class="px-3 py-2 flex justify-end">
+              <button class="text-xs text-amber-400 hover:text-amber-300 transition-colors" @click="triggerFileUpload">+ Добавить</button>
+            </div>
+            <div v-if="!contextFiles.length" class="px-3 py-3 text-sm text-stone-500">Нет файлов</div>
+            <div v-else class="flex-1 overflow-y-auto pb-2">
+              <div v-for="(file, index) in contextFiles" :key="index" class="flex items-center gap-2 px-3 py-1.5 hover:bg-stone-800/50">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-stone-500 shrink-0">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><polyline points="14 2 14 8 20 8" />
+                </svg>
+                <span class="text-xs text-stone-300 truncate flex-1">{{ file.name }}</span>
+                <span class="text-[10px] text-stone-500">{{ Math.round(file.content.length / 1024) || '<1' }}KB</span>
+                <button class="text-stone-500 hover:text-red-400 transition-colors" @click="removeContextFile(index)">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </template>
+          <template v-if="settingsTab === 'prompt'">
+            <div class="px-3 py-3">
+              <label class="block text-xs text-stone-400 mb-1">Системный промпт</label>
+              <textarea
+                v-model="customPrompt"
+                rows="8"
+                class="w-full bg-stone-950 text-stone-200 text-xs rounded-lg p-2 border border-stone-700 focus:border-amber-500 focus:outline-none resize-y min-h-[80px]"
+                placeholder="Пользовательский промпт для этой сессии..."
+              />
+              <button
+                class="mt-2 w-full py-1.5 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium transition-colors"
+                @click="saveSystemPrompt"
+              >
+                Сохранить
+              </button>
+            </div>
+          </template>
         </template>
       </div>
     </template>

--- a/mobile/src/views/LoginView.vue
+++ b/mobile/src/views/LoginView.vue
@@ -48,14 +48,14 @@ async function handleLogin() {
           <path fill="url(#g)" fill-rule="evenodd" d="M 431.8 217.4 L 484.1 226.3 L 484.1 285.7 L 431.8 294.6 L 407.6 353.0 L 438.3 396.3 L 396.3 438.3 L 353.0 407.6 L 294.6 431.8 L 285.7 484.1 L 226.3 484.1 L 217.4 431.8 L 159.0 407.6 L 115.7 438.3 L 73.7 396.3 L 104.4 353.0 L 80.2 294.6 L 27.9 285.7 L 27.9 226.3 L 80.2 217.4 L 104.4 159.0 L 73.7 115.7 L 115.7 73.7 L 159.0 104.4 L 217.4 80.2 L 226.3 27.9 L 285.7 27.9 L 294.6 80.2 L 353.0 104.4 L 396.3 73.7 L 438.3 115.7 L 407.6 159.0 Z M 341.0 256.0 A 85 85 0 1 0 171.0 256.0 A 85 85 0 1 0 341.0 256.0 Z"/>
         </svg>
       </div>
-      <h1 class="text-2xl font-bold text-white">AI Secretary</h1>
-      <p class="text-stone-400 text-sm mt-1">Your personal assistant</p>
+      <h1 class="text-2xl font-bold text-white">AI Секретарь</h1>
+      <p class="text-stone-400 text-sm mt-1">Ваш персональный ассистент</p>
     </div>
 
     <!-- Login form -->
     <div class="w-full max-w-sm space-y-4">
       <div>
-        <label class="block text-sm text-stone-400 mb-1.5">Username</label>
+        <label class="block text-sm text-stone-400 mb-1.5">Логин</label>
         <input
           v-model="username"
           type="text"
@@ -65,7 +65,7 @@ async function handleLogin() {
         />
       </div>
       <div>
-        <label class="block text-sm text-stone-400 mb-1.5">Password</label>
+        <label class="block text-sm text-stone-400 mb-1.5">Пароль</label>
         <input
           v-model="password"
           type="password"
@@ -87,8 +87,8 @@ async function handleLogin() {
         class="w-full py-3 rounded-xl bg-amber-600 hover:bg-amber-700 disabled:bg-stone-700 disabled:text-stone-500 text-white font-medium transition-colors"
         @click="handleLogin"
       >
-        <span v-if="auth.isLoading">Connecting...</span>
-        <span v-else>Login</span>
+        <span v-if="auth.isLoading">Подключение...</span>
+        <span v-else>Войти</span>
       </button>
     </div>
   </div>

--- a/mobile/src/views/SettingsView.vue
+++ b/mobile/src/views/SettingsView.vue
@@ -35,14 +35,14 @@ async function handleLogout() {
           <polyline points="15 18 9 12 15 6" />
         </svg>
       </button>
-      <h1 class="text-lg font-semibold text-white">Settings</h1>
+      <h1 class="text-lg font-semibold text-white">Настройки</h1>
     </div>
 
     <div class="flex-1 overflow-y-auto p-4 space-y-6">
       <!-- Account -->
       <div>
         <h2 class="text-sm font-medium text-stone-400 mb-3 uppercase tracking-wider">
-          Account
+          Аккаунт
         </h2>
         <div class="bg-stone-800/50 rounded-xl p-4">
           <div class="flex items-center justify-between">
@@ -58,7 +58,7 @@ async function handleLogout() {
               class="px-4 py-2 rounded-lg bg-red-800/20 text-red-400 text-sm hover:bg-red-800/30 transition-colors"
               @click="handleLogout"
             >
-              Logout
+              Выйти
             </button>
           </div>
         </div>
@@ -67,10 +67,10 @@ async function handleLogout() {
       <!-- App info -->
       <div>
         <h2 class="text-sm font-medium text-stone-400 mb-3 uppercase tracking-wider">
-          About
+          О приложении
         </h2>
         <div class="bg-stone-800/50 rounded-xl p-4">
-          <p class="text-stone-400 text-sm">AI Secretary Mobile v1.0.0</p>
+          <p class="text-stone-400 text-sm">AI Секретарь v1.0.0</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Localize all mobile screens to Russian (Login, ChatList, Settings, ChatInput)
- Non-admin: auto-open most recent chat on login (skip chat list)
- Non-admin: gear logo + "AI Секретарь" title in chat header (no back button)
- Chat settings button available to all users (was admin-only)
- Settings tab for prompt/files in ChatView

## NEWS

📱 **Мобильное приложение теперь на русском языке**

Все экраны мобильного приложения переведены на русский — логин, список чатов, настройки. Обычные пользователи теперь автоматически попадают в чат при входе, без лишних экранов. Кнопка настроек чата доступна всем пользователям.

## Test plan
- [ ] Login screen: Russian labels
- [ ] Non-admin: auto-opens chat, no back button, gear logo
- [ ] Admin: back button, chat title, full toolbar
- [ ] Chat settings button works for all users
- [ ] Settings view: Russian text

🤖 Generated with [Claude Code](https://claude.com/claude-code)