### PR TITLE
fix: agentic RAG truncation after 2-3 iterations

### DIFF
--- a/cloud_llm_service.py
+++ b/cloud_llm_service.py
@@ -326,7 +326,14 @@ class OpenAICompatibleProvider(BaseLLMProvider):
                 )
                 response.raise_for_status()
                 result = response.json()
-                message = result["choices"][0]["message"]
+                choice = result["choices"][0]
+                finish_reason = choice.get("finish_reason")
+                if finish_reason == "length":
+                    logger.warning(
+                        f"[{self.provider_id}] Response truncated (finish_reason=length) "
+                        f"with model '{model}'. Consider increasing max_tokens."
+                    )
+                message = choice["message"]
                 tool_calls = message.get("tool_calls")
                 if tool_calls:
                     return message  # dict with role, content, tool_calls
@@ -367,6 +374,7 @@ class OpenAICompatibleProvider(BaseLLMProvider):
                     # Accumulate tool_calls from delta chunks
                     tool_calls_acc: Dict[int, dict] = {}
                     has_tool_calls = False
+                    finish_reason = None
 
                     for line in response.iter_lines():
                         if line.startswith("data: "):
@@ -375,7 +383,13 @@ class OpenAICompatibleProvider(BaseLLMProvider):
                                 break
                             try:
                                 chunk = json.loads(data)
-                                delta = chunk["choices"][0].get("delta", {})
+                                choice = chunk["choices"][0]
+                                delta = choice.get("delta", {})
+
+                                # Track finish_reason for truncation detection
+                                fr = choice.get("finish_reason")
+                                if fr:
+                                    finish_reason = fr
 
                                 # Content chunk
                                 content = delta.get("content")
@@ -405,12 +419,33 @@ class OpenAICompatibleProvider(BaseLLMProvider):
                             except json.JSONDecodeError:
                                 continue
 
+                    # Detect truncated response (max_tokens hit)
+                    if finish_reason == "length":
+                        logger.warning(
+                            f"[{self.provider_id}] Response truncated (finish_reason=length) "
+                            f"with model '{model}'. Consider increasing max_tokens."
+                        )
+
                     # Emit accumulated tool_calls at the end
                     if has_tool_calls and tool_calls_acc:
-                        yield {
-                            "type": "tool_calls",
-                            "tool_calls": [tool_calls_acc[i] for i in sorted(tool_calls_acc)],
-                        }
+                        # Validate tool call arguments are parseable JSON
+                        valid_tool_calls = []
+                        for i in sorted(tool_calls_acc):
+                            tc = tool_calls_acc[i]
+                            args_str = tc["function"]["arguments"]
+                            try:
+                                json.loads(args_str)
+                                valid_tool_calls.append(tc)
+                            except json.JSONDecodeError:
+                                logger.warning(
+                                    f"[{self.provider_id}] Truncated tool call arguments "
+                                    f"(index={i}, fn={tc['function']['name']}): {args_str[:100]}"
+                                )
+                        if valid_tool_calls:
+                            yield {
+                                "type": "tool_calls",
+                                "tool_calls": valid_tool_calls,
+                            }
                     return  # Stream completed successfully
             except httpx.HTTPStatusError as e:
                 status = e.response.status_code
@@ -435,11 +470,16 @@ class OpenAICompatibleProvider(BaseLLMProvider):
     def _build_request_json(
         self, model: str, messages: List[Dict], stream: bool, tools: Optional[List[Dict]] = None
     ) -> dict:
+        default_max_tokens = 512
+        # Tool-calling (agentic RAG) needs much more tokens: text + JSON tool calls
+        # + accumulated context from prior search results
+        if tools:
+            default_max_tokens = 4096
         payload = {
             "model": model,
             "messages": messages,
             "temperature": self.runtime_params.get("temperature", 0.7),
-            "max_tokens": self.runtime_params.get("max_tokens", 512),
+            "max_tokens": self.runtime_params.get("max_tokens", default_max_tokens),
             "top_p": self.runtime_params.get("top_p", 0.9),
             "stream": stream,
         }

--- a/modules/chat/router.py
+++ b/modules/chat/router.py
@@ -60,7 +60,7 @@ KNOWLEDGE_SEARCH_TOOL = {
         },
     },
 }
-MAX_TOOL_ITERATIONS = 5
+MAX_TOOL_ITERATIONS = 10
 
 # Temporary cache for OCR text from uploaded images (upload → send are two separate requests)
 _pending_image_ocr: dict[str, str] = {}
@@ -715,8 +715,15 @@ async def admin_send_chat_message(
                     try:
                         args = json.loads(tc["function"]["arguments"])
                     except json.JSONDecodeError:
+                        logger.warning(
+                            f"Agentic RAG: malformed tool args "
+                            f"(likely truncated): {tc['function']['arguments'][:100]}"
+                        )
                         args = {}
                     query = args.get("query", "")
+                    if not query:
+                        logger.warning("Agentic RAG: empty search query, skipping iteration")
+                        continue
                     search_result = _execute_knowledge_search(wiki_rag, query, collection_ids)
                     loop_messages.append(
                         {
@@ -988,8 +995,15 @@ async def admin_stream_chat_message(
                         try:
                             args = json.loads(tc["function"]["arguments"])
                         except json.JSONDecodeError:
+                            logger.warning(
+                                f"Agentic RAG: malformed tool args "
+                                f"(likely truncated): {tc['function']['arguments'][:100]}"
+                            )
                             args = {}
                         query = args.get("query", "")
+                        if not query:
+                            logger.warning("Agentic RAG: empty search query, skipping iteration")
+                            continue
                         yield f"data: {json.dumps({'type': 'tool_start', 'name': fn_name, 'query': query}, ensure_ascii=False)}\n\n"
 
                         result = _execute_knowledge_search(wiki_rag, query, collection_ids)
@@ -1117,8 +1131,15 @@ async def admin_edit_chat_message(
                     try:
                         args = json.loads(tc["function"]["arguments"])
                     except json.JSONDecodeError:
+                        logger.warning(
+                            f"Agentic RAG: malformed tool args "
+                            f"(likely truncated): {tc['function']['arguments'][:100]}"
+                        )
                         args = {}
                     query = args.get("query", "")
+                    if not query:
+                        logger.warning("Agentic RAG: empty search query, skipping iteration")
+                        continue
                     search_result = _execute_knowledge_search(wiki_rag, query, collection_ids)
                     loop_messages.append(
                         {
@@ -1247,8 +1268,15 @@ async def admin_regenerate_chat_response(
                     try:
                         args = json.loads(tc["function"]["arguments"])
                     except json.JSONDecodeError:
+                        logger.warning(
+                            f"Agentic RAG: malformed tool args "
+                            f"(likely truncated): {tc['function']['arguments'][:100]}"
+                        )
                         args = {}
                     query = args.get("query", "")
+                    if not query:
+                        logger.warning("Agentic RAG: empty search query, skipping iteration")
+                        continue
                     search_result = _execute_knowledge_search(wiki_rag, query, collection_ids)
                     loop_messages.append(
                         {


### PR DESCRIPTION
## Summary

- Increase default `max_tokens` from 512 to 4096 when tools are passed (agentic RAG)
- Track `finish_reason` in streaming; log warning on truncation (`finish_reason=length`)
- Validate tool call arguments JSON before emitting; skip malformed entries
- Log warnings on malformed/empty tool call arguments in all 4 agentic RAG loops
- Skip iterations with empty search queries instead of wasting them
- Increase `MAX_TOOL_ITERATIONS` from 5 to 10 for complex multi-search queries

**Root cause**: default `max_tokens=512` was too low for tool-calling. After 2-3 search iterations, accumulated context exceeded 512 tokens → LLM response truncated → tool call JSON incomplete → silently swallowed as empty dict → wasted iterations → user sees cut-off response.

## NEWS

🔍 **Исправлен обрыв ответов при поиске по базе знаний**

Ассистент больше не обрывается на полпути при поиске информации в базе знаний.
Раньше после 2-3 итераций поиска ответ обрезался из-за слишком низкого лимита токенов.
Теперь лимит автоматически увеличивается при использовании поиска, а количество
допустимых итераций поиска поднято с 5 до 10 для сложных запросов.

## Test plan

- [ ] Send a chat message that triggers agentic RAG with multiple search iterations
- [ ] Verify response is not truncated after 2-3 iterations
- [ ] Check logs for absence of `finish_reason=length` warnings
- [ ] Verify malformed tool call args are logged, not silently ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)