### PR TITLE
feat: default mobile chat for pinning sessions to users

### DIFF
--- a/admin/src/api/chat.ts
+++ b/admin/src/api/chat.ts
@@ -82,6 +82,7 @@ export interface ChatSessionSummary {
   is_shared_with_me?: boolean
   share_permission?: string
   share_count?: number
+  is_default_mobile?: boolean
 }
 
 export interface ChatShare {
@@ -298,6 +299,21 @@ export const chatApi = {
 
   getShareableUsers: () =>
     api.get<{ users: ShareableUser[] }>('/admin/chat/shareable-users'),
+
+  // Default mobile chat
+  getDefaultMobileUsers: (sessionId: string) =>
+    api.get<{ users: { user_id: number; username: string; display_name: string }[] }>(
+      `/admin/chat/sessions/${sessionId}/default-mobile-users`,
+    ),
+
+  setDefaultMobile: (sessionId: string, userIds: number[]) =>
+    api.put(`/admin/chat/sessions/${sessionId}/default-mobile`, { user_ids: userIds }),
+
+  unsetDefaultMobile: (sessionId: string, userId: number) =>
+    api.delete(`/admin/chat/sessions/${sessionId}/default-mobile/${userId}`),
+
+  getMyDefaultMobileSession: () =>
+    api.get<{ session_id: string | null }>('/admin/chat/my-default-mobile-session'),
 
   // Image upload
   uploadImage: (sessionId: string, file: File) =>

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -24,7 +24,7 @@ import 'prismjs/components/prism-diff'
 import 'prismjs/components/prism-markdown'
 import 'prismjs/components/prism-jsx'
 import 'prismjs/components/prism-tsx'
-import { chatApi, ttsApi, llmApi, sttApi, wikiRagApi, type ChatSession, type ChatMessage, type ChatImage, type ChatSessionSummary, type CloudProvider, type BranchNode, type SiblingInfo, type TokenUsage } from '@/api'
+import { chatApi, ttsApi, llmApi, sttApi, wikiRagApi, type ChatSession, type ChatMessage, type ChatImage, type ChatSessionSummary, type CloudProvider, type BranchNode, type SiblingInfo, type TokenUsage, type ShareableUser } from '@/api'
 import BranchTree from '@/components/BranchTree.vue'
 import ChatShareDialog from '@/components/ChatShareDialog.vue'
 import ArtifactPanel, { type Artifact } from '@/components/ArtifactPanel.vue'
@@ -70,6 +70,7 @@ import {
   GitFork,
   Users,
   Terminal,
+  Smartphone,
   StopCircle,
   ChevronDown,
   FolderOpen,
@@ -174,6 +175,8 @@ const showCcFilesMenu = ref(false)
 const showCcKanbanMenu = ref(false)
 const ccKanbanTasks = ref<KanbanTask[]>([])
 const showShareDialog = ref(false)
+const showDefaultMobileMenu = ref(false)
+const defaultMobileUsers = ref<{ user_id: number; username: string; display_name: string }[]>([])
 const showZenSettings = ref(false)
 const showZenLlmMenu = ref(false)
 const inputPosition = ref<'top' | 'bottom'>(
@@ -575,6 +578,33 @@ function toggleCcMode() {
   } else {
     cc.toggle()
   }
+}
+
+const shareableUsersData = ref<{ users: ShareableUser[] } | null>(null)
+
+async function loadDefaultMobileUsers() {
+  if (!currentSessionId.value) return
+  try {
+    const [mobileResp, usersResp] = await Promise.all([
+      chatApi.getDefaultMobileUsers(currentSessionId.value),
+      shareableUsersData.value ? Promise.resolve(shareableUsersData.value) : chatApi.getShareableUsers(),
+    ])
+    defaultMobileUsers.value = mobileResp.users || []
+    shareableUsersData.value = usersResp
+  } catch {
+    defaultMobileUsers.value = []
+  }
+}
+
+async function toggleDefaultMobile(userId: number) {
+  if (!currentSessionId.value) return
+  const existing = defaultMobileUsers.value.find(u => u.user_id === userId)
+  if (existing) {
+    await chatApi.unsetDefaultMobile(currentSessionId.value, userId)
+  } else {
+    await chatApi.setDefaultMobile(currentSessionId.value, [userId])
+  }
+  await loadDefaultMobileUsers()
 }
 
 async function openCcKanbanMenu() {
@@ -1736,6 +1766,9 @@ function handleGlobalClick(e: MouseEvent) {
   if (showZenLlmMenu.value && !target.closest('.zen-llm-anchor')) {
     showZenLlmMenu.value = false
   }
+  if (showDefaultMobileMenu.value) {
+    showDefaultMobileMenu.value = false
+  }
 }
 
 // Zen mode: restore from localStorage (only for admin users, not locked mode)
@@ -2093,6 +2126,54 @@ watch(() => cc.isProcessing.value, (processing, wasProcesing) => {
 
         <div class="w-6 h-px bg-border/50 my-1 shrink-0"></div>
         </template>
+
+        <!-- Default Mobile Chat (admin only) -->
+        <div v-if="!isChatOnly && !cc.isActive.value && currentSessionId" class="relative shrink-0">
+          <button
+            :class="[
+              'w-8 h-8 rounded-lg flex items-center justify-center transition-colors',
+              showDefaultMobileMenu ? 'bg-primary/20 text-primary' : (defaultMobileUsers.length ? 'text-green-400' : 'text-muted-foreground hover:bg-secondary/50')
+            ]"
+            :title="'Основной чат для мобильного приложения'"
+            @click.stop="showDefaultMobileMenu = !showDefaultMobileMenu; if (showDefaultMobileMenu) { loadDefaultMobileUsers(); }"
+          >
+            <Smartphone class="w-4 h-4" />
+            <span
+              v-if="defaultMobileUsers.length"
+              class="absolute -top-0.5 -right-0.5 bg-green-500 text-white text-[9px] font-bold rounded-full w-3.5 h-3.5 flex items-center justify-center"
+            >{{ defaultMobileUsers.length }}</span>
+          </button>
+          <div
+            v-if="showDefaultMobileMenu"
+            class="absolute left-full ml-2 top-0 zen-glass rounded-xl shadow-2xl py-2 z-50 min-w-[220px] animate-scale-in"
+            @click.stop
+          >
+            <div class="px-3 pb-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Основной чат для мобильного
+            </div>
+            <div v-if="!shareableUsersData?.users?.length" class="px-3 py-2 text-sm text-muted-foreground">
+              {{ t('chatView.noUsersToShare') }}
+            </div>
+            <template v-else>
+              <button
+                v-for="u in shareableUsersData?.users"
+                :key="u.id"
+                class="flex items-center gap-2 w-full px-3 py-1.5 text-sm transition-colors text-left hover:bg-secondary/50"
+                :class="defaultMobileUsers.some(d => d.user_id === u.id) ? 'text-green-400' : 'text-foreground'"
+                @click="toggleDefaultMobile(u.id)"
+              >
+                <span
+class="w-4 h-4 rounded border flex items-center justify-center shrink-0"
+                  :class="defaultMobileUsers.some(d => d.user_id === u.id) ? 'border-green-400 bg-green-400/20' : 'border-muted-foreground/30'"
+                >
+                  <Check v-if="defaultMobileUsers.some(d => d.user_id === u.id)" class="w-3 h-3" />
+                </span>
+                <span class="flex-1 truncate">{{ u.display_name || u.username }}</span>
+                <span class="text-[10px] text-muted-foreground">{{ u.role }}</span>
+              </button>
+            </template>
+          </div>
+        </div>
 
         <!-- Claude Code toggle (restricted users, admin only) -->
         <button

--- a/alembic/versions/20260319_0001_add_is_default_mobile.py
+++ b/alembic/versions/20260319_0001_add_is_default_mobile.py
@@ -1,0 +1,30 @@
+"""Add is_default_mobile to chat_session_shares.
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2026-03-19
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+revision: str = "0016"
+down_revision: Union[str, None] = "0015"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("chat_session_shares") as batch_op:
+        batch_op.add_column(
+            sa.Column("is_default_mobile", sa.Boolean(), server_default="0", nullable=False)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("chat_session_shares") as batch_op:
+        batch_op.drop_column("is_default_mobile")

--- a/mobile/src/api/chat.ts
+++ b/mobile/src/api/chat.ts
@@ -232,4 +232,9 @@ export const chatApi = {
 
     return { abort: () => controller.abort() };
   },
+
+  getMyDefaultMobileSession: () =>
+    api.get<{ session_id: string | null }>(
+      "/admin/chat/my-default-mobile-session",
+    ),
 };

--- a/mobile/src/views/ChatListView.vue
+++ b/mobile/src/views/ChatListView.vue
@@ -42,12 +42,22 @@ async function loadSessions() {
 }
 
 async function autoOpenChat() {
-  // If there are visible sessions, open the most recent one
+  // Priority 1: default mobile session
+  try {
+    const resp = await chatApi.getMyDefaultMobileSession();
+    if (resp.session_id) {
+      router.replace(`/chat/${resp.session_id}`);
+      return;
+    }
+  } catch {
+    // fallback to other logic
+  }
+  // Priority 2: first visible (shared) session
   if (visibleSessions.value.length > 0) {
     router.replace(`/chat/${visibleSessions.value[0]!.id}`);
     return;
   }
-  // Otherwise create a new session and open it
+  // Priority 3: create a new session
   try {
     const data = await chatApi.createSession();
     router.replace(`/chat/${data.session.id}`);

--- a/modules/chat/models.py
+++ b/modules/chat/models.py
@@ -205,6 +205,7 @@ class ChatSessionShare(Base):
     )
     shared_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     branch_message_id: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    is_default_mobile: Mapped[bool] = mapped_column(Boolean, default=False, server_default="0")
 
     __table_args__ = (
         Index("ix_chat_session_shares_session_user", "session_id", "user_id", unique=True),
@@ -219,6 +220,7 @@ class ChatSessionShare(Base):
             "shared_by": self.shared_by,
             "shared_at": self.shared_at.isoformat() if self.shared_at else None,
             "branch_message_id": self.branch_message_id,
+            "is_default_mobile": self.is_default_mobile,
         }
 
 

--- a/modules/chat/router.py
+++ b/modules/chat/router.py
@@ -452,6 +452,9 @@ async def admin_list_chat_sessions(
     if owner_id is not None:
         shared_perms = await chat_share_service.get_shared_sessions_with_permissions(user.id)
 
+    # Check default mobile session for current user
+    default_mobile_sid = await chat_share_service.get_user_default_mobile_session(user.id)
+
     def _enrich(sessions_list: list[dict], share_counts: dict[str, int]) -> list[dict]:
         for s in sessions_list:
             sid = s.get("id", "")
@@ -463,6 +466,7 @@ async def admin_list_chat_sessions(
                 s["is_shared_with_me"] = False
                 s["share_permission"] = "owner"
             s["share_count"] = share_counts.get(sid, 0)
+            s["is_default_mobile"] = sid == default_mobile_sid
         return sessions_list
 
     if group_by == "source":
@@ -1526,6 +1530,63 @@ async def admin_get_shareable_users(user: User = Depends(require_permission("cha
     """Список пользователей для шаринга"""
     users = await chat_share_service.list_shareable_users(exclude_user_id=user.id)
     return {"users": users}
+
+
+# ============== Default Mobile Chat Endpoints ==============
+
+
+class SetDefaultMobileRequest(BaseModel):
+    user_ids: list[int]
+
+
+@router.get("/sessions/{session_id}/default-mobile-users")
+async def get_default_mobile_users(
+    session_id: str,
+    user: User = Depends(require_permission("chat", "edit")),
+):
+    """Get users who have this session as their default mobile chat."""
+    users = await chat_share_service.get_default_mobile_users(session_id)
+    return {"users": users}
+
+
+@router.put("/sessions/{session_id}/default-mobile")
+async def set_default_mobile_chat(
+    session_id: str,
+    req: SetDefaultMobileRequest,
+    user: User = Depends(require_permission("chat", "edit")),
+):
+    """Set this session as default mobile chat for selected users.
+
+    Clears previous defaults for each user before setting new ones.
+    Auto-creates share if not exists.
+    """
+    results = []
+    for uid in req.user_ids:
+        share = await chat_share_service.set_default_mobile(session_id, uid, shared_by=user.id)
+        results.append(share)
+    return {"shares": results}
+
+
+@router.delete("/sessions/{session_id}/default-mobile/{target_user_id}")
+async def unset_default_mobile_chat(
+    session_id: str,
+    target_user_id: int,
+    user: User = Depends(require_permission("chat", "edit")),
+):
+    """Remove default mobile flag for a user on this session."""
+    ok = await chat_share_service.unset_default_mobile(session_id, target_user_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Share not found")
+    return {"status": "ok"}
+
+
+@router.get("/my-default-mobile-session")
+async def get_my_default_mobile_session(
+    user: User = Depends(require_permission("chat", "view")),
+):
+    """Get the default mobile session for the current user."""
+    session_id = await chat_share_service.get_user_default_mobile_session(user.id)
+    return {"session_id": session_id}
 
 
 # ============== Image Endpoints ==============

--- a/modules/chat/service.py
+++ b/modules/chat/service.py
@@ -6,6 +6,9 @@ import time
 from datetime import datetime
 from typing import Dict, List, Optional
 
+from sqlalchemy import select as sa_select
+from sqlalchemy import update as sa_update
+
 from db.database import AsyncSessionLocal
 from db.repositories import ChatRepository, ChatShareRepository, UserRepository
 from db.retry import retry_on_busy
@@ -396,6 +399,109 @@ class ChatShareService:
                 and u.get("role") != "guest"
                 and u["id"] != exclude_user_id
             ]
+
+    async def set_default_mobile(
+        self,
+        session_id: str,
+        user_id: int,
+        shared_by: Optional[int] = None,
+    ) -> dict:
+        """Set session as default mobile chat for user.
+
+        Clears any previous default for this user, ensures share exists,
+        and marks the new share as default.
+        """
+        async with AsyncSessionLocal() as session:
+            from modules.chat.models import ChatSessionShare
+
+            # Clear previous defaults for this user
+            stmt = (
+                sa_update(ChatSessionShare)
+                .where(
+                    ChatSessionShare.user_id == user_id,
+                    ChatSessionShare.is_default_mobile.is_(True),
+                )
+                .values(is_default_mobile=False)
+            )
+            await session.execute(stmt)
+
+            # Ensure share exists
+            repo = ChatShareRepository(session)
+            existing = await repo.get_share(session_id, user_id)
+            if existing:
+                existing.is_default_mobile = True
+                await session.flush()
+                result = existing.to_dict()
+            else:
+                share_dict = await repo.add_share(session_id, user_id, "write", shared_by)
+                # Set default on the newly created share
+                new_share = await repo.get_share(session_id, user_id)
+                if new_share:
+                    new_share.is_default_mobile = True
+                    await session.flush()
+                    result = new_share.to_dict()
+                else:
+                    result = share_dict
+            await session.commit()
+            return result
+
+    async def unset_default_mobile(self, session_id: str, user_id: int) -> bool:
+        """Remove default mobile flag from a share."""
+        async with AsyncSessionLocal() as session:
+            from modules.chat.models import ChatSessionShare
+
+            stmt = (
+                sa_update(ChatSessionShare)
+                .where(
+                    ChatSessionShare.session_id == session_id,
+                    ChatSessionShare.user_id == user_id,
+                )
+                .values(is_default_mobile=False)
+            )
+            result = await session.execute(stmt)
+            await session.commit()
+            return result.rowcount > 0  # type: ignore[union-attr]
+
+    async def get_default_mobile_users(self, session_id: str) -> List[dict]:
+        """Get users who have this session as their default mobile chat."""
+        async with AsyncSessionLocal() as session:
+            from db.models import User
+            from modules.chat.models import ChatSessionShare
+
+            stmt = (
+                sa_select(ChatSessionShare, User)
+                .join(User, ChatSessionShare.user_id == User.id)
+                .where(
+                    ChatSessionShare.session_id == session_id,
+                    ChatSessionShare.is_default_mobile.is_(True),
+                )
+            )
+            result = await session.execute(stmt)
+            return [
+                {
+                    "user_id": share.user_id,
+                    "username": user.username,
+                    "display_name": user.display_name,
+                }
+                for share, user in result.all()
+            ]
+
+    async def get_user_default_mobile_session(self, user_id: int) -> Optional[str]:
+        """Get the default mobile session_id for a user."""
+        async with AsyncSessionLocal() as session:
+            from modules.chat.models import ChatSessionShare
+
+            stmt = (
+                sa_select(ChatSessionShare.session_id)
+                .where(
+                    ChatSessionShare.user_id == user_id,
+                    ChatSessionShare.is_default_mobile.is_(True),
+                )
+                .limit(1)
+            )
+            result = await session.execute(stmt)
+            row = result.scalar_one_or_none()
+            return row
 
 
 # Singletons


### PR DESCRIPTION
## Summary

- New `is_default_mobile` column on `chat_session_shares` (migration 0016)
- Admin zen toolbar: Smartphone icon button (first position, before CC) to assign default chat per user
- Dropdown shows all shareable users with checkboxes; green = assigned
- Setting a new default auto-clears any previous default for that user
- Auto-creates share if not exists (permission: write)
- Mobile app: `autoOpenChat()` first checks `GET /admin/chat/my-default-mobile-session`
- API endpoints: `GET/PUT/DELETE /admin/chat/sessions/{id}/default-mobile`, `GET /my-default-mobile-session`

## NEWS

📱 **Закрепление чата для мобильного приложения**

Администратор теперь может назначить любой чат основным для пользователей
мобильного приложения. Нажмите иконку телефона в панели чата и выберите
пользователей — при входе в приложение они сразу попадут в нужный чат.
Если пользователь был закреплён за другим чатом, он автоматически открепится.

## Test plan

- [ ] Open admin zen mode — Smartphone icon visible before CC toggle
- [ ] Click Smartphone icon — dropdown shows users with checkboxes
- [ ] Select user — badge shows count, user gets default
- [ ] Deselect user — default cleared
- [ ] Mobile app login as assigned user — auto-navigates to pinned chat
- [ ] `alembic upgrade head` — migration applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)