### PR TITLE
fix: allow admin to assign self as default mobile user

### DIFF
--- a/admin/src/api/chat.ts
+++ b/admin/src/api/chat.ts
@@ -297,8 +297,10 @@ export const chatApi = {
   forkSession: (sessionId: string, title?: string) =>
     api.post<{ session: ChatSession }>(`/admin/chat/sessions/${sessionId}/fork`, { title }),
 
-  getShareableUsers: () =>
-    api.get<{ users: ShareableUser[] }>('/admin/chat/shareable-users'),
+  getShareableUsers: (includeSelf = false) =>
+    api.get<{ users: ShareableUser[] }>(
+      `/admin/chat/shareable-users${includeSelf ? '?include_self=true' : ''}`,
+    ),
 
   // Default mobile chat
   getDefaultMobileUsers: (sessionId: string) =>

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -587,7 +587,7 @@ async function loadDefaultMobileUsers() {
   try {
     const [mobileResp, usersResp] = await Promise.all([
       chatApi.getDefaultMobileUsers(currentSessionId.value),
-      shareableUsersData.value ? Promise.resolve(shareableUsersData.value) : chatApi.getShareableUsers(),
+      shareableUsersData.value ? Promise.resolve(shareableUsersData.value) : chatApi.getShareableUsers(true),
     ])
     defaultMobileUsers.value = mobileResp.users || []
     shareableUsersData.value = usersResp

--- a/modules/chat/router.py
+++ b/modules/chat/router.py
@@ -1526,9 +1526,13 @@ async def admin_fork_session(
 
 
 @router.get("/shareable-users")
-async def admin_get_shareable_users(user: User = Depends(require_permission("chat", "view"))):
+async def admin_get_shareable_users(
+    include_self: bool = False,
+    user: User = Depends(require_permission("chat", "view")),
+):
     """Список пользователей для шаринга"""
-    users = await chat_share_service.list_shareable_users(exclude_user_id=user.id)
+    exclude_id = None if include_self else user.id
+    users = await chat_share_service.list_shareable_users(exclude_user_id=exclude_id)
     return {"users": users}
 
 


### PR DESCRIPTION
## Summary
- Added `include_self` query param to `/admin/chat/shareable-users`
- Default mobile dropdown passes `include_self=true` to include current admin
- Share dialog unchanged (still excludes self)

## Test plan
- [ ] Open default mobile dropdown — current admin visible in list
- [ ] Share dialog — current admin still excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)