### PR TITLE
fix: refresh default mobile counter on session switch

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -950,6 +950,12 @@ function selectSession(sessionId: string) {
   showSidebar.value = false
 }
 
+watch(currentSessionId, () => {
+  defaultMobileUsers.value = []
+  showDefaultMobileMenu.value = false
+  if (currentSessionId.value) loadDefaultMobileUsers()
+})
+
 function createNewChat() {
   createSessionMutation.mutate()
 }


### PR DESCRIPTION
## Summary
- Watch `currentSessionId` to reset and reload `defaultMobileUsers`
- Counter now shows correct number per chat session

## Test plan
- [ ] Switch between chats — counter updates to correct number
- [ ] Open chat with no assigned users — no badge shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)