### PR TITLE
docs: update CLAUDE.md and Architecture wiki for Phase 5.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,15 +135,15 @@ Always run lint locally before pushing. Protected branches require PR workflow �
 
 ### Modular Infrastructure (`modules/`)
 
-Foundation layer for modular decomposition (issue #489). Phase 4 complete: all 28 routers migrated (Phase 3), all inline endpoints extracted (Phase 4.1–4.5), all background tasks via `TaskRegistry` (Phase 4.6), all startup helpers + service init extracted to domain `startup.py` modules, global service variables removed (Phase 4.7a/b). Phase 5 (EventBus events) and Phase 6 (protocol interfaces) pending.
+Foundation layer for modular decomposition (issue #489). Phase 4 complete: all 28 routers migrated (Phase 3), all inline endpoints extracted (Phase 4.1–4.5), all background tasks via `TaskRegistry` (Phase 4.6), all startup helpers + service init extracted to domain `startup.py` modules, global service variables removed (Phase 4.7a/b). Phase 5.1 complete (EventBus infrastructure + first events). Phase 5.2–5.6 and Phase 6 (protocol interfaces) pending.
 
-- **`EventBus`** (`modules/core/events.py`): In-process async pub/sub. Handlers run concurrently via `asyncio.gather`; exceptions are logged, never propagated to publisher. `BaseEvent` dataclass with auto-timestamp.
+- **`EventBus`** (`modules/core/events.py`): In-process async pub/sub. Handlers run concurrently via `asyncio.gather`; exceptions are logged, never propagated to publisher. `BaseEvent` dataclass with auto-timestamp. Singleton in `ServiceContainer.event_bus`. Domain events: `InternetStatusChanged`, `UserRoleChanged`, `SessionRevoked`. Subscriptions registered via `setup_event_subscriptions()` in `modules/core/startup.py`.
 - **`TaskRegistry`** (`modules/core/tasks.py`): Named background tasks — periodic (interval-based) or one-shot. `start_all()` / `cancel_all(timeout)` lifecycle. `TaskInfo` dataclass tracks status, run count, last error. 6 tasks registered in `startup_event()`: `session-cleanup` (1h), `periodic-vacuum` (7d), `kanban-sync` (15min), `woocommerce-sync` (daily 23:00 UTC), `wiki-embeddings` (one-shot), `wiki-collection-indexes` (one-shot). Task functions in `modules/core/maintenance.py`, `modules/knowledge/tasks.py`, `modules/kanban/tasks.py`, `modules/ecommerce/tasks.py`.
 - **`HealthRegistry`** (`modules/core/health.py`): Modular health checks with per-check timeout (`asyncio.wait_for`). Status aggregation: all ok → ok, any degraded → degraded, any error → error.
 
-- **`InternetMonitor`** (`modules/core/internet_monitor.py`): Periodic connectivity checker (ping DNS/Cloudflare). Auto-switches LLM backend: online → cloud provider (claude_bridge priority), offline → local vLLM. Publishes `InternetStatusChanged` events via EventBus. Configurable thresholds, 30s default interval. Status endpoint: `GET /admin/gsm/internet-status`. Health check includes `internet` section.
+- **`InternetMonitor`** (`modules/core/internet_monitor.py`): Periodic connectivity checker (ping DNS/Cloudflare). Auto-switches LLM backend: online → cloud provider (claude_bridge priority), offline → local vLLM. Publishes `InternetStatusChanged` events via EventBus (`container.event_bus`). Configurable thresholds, 30s default interval. Status endpoint: `GET /admin/gsm/internet-status`. Health check includes `internet` section.
 
-Import from `modules.core`: `EventBus`, `BaseEvent`, `TaskRegistry`, `TaskInfo`, `HealthRegistry`, `HealthStatus`.
+Import from `modules.core`: `EventBus`, `BaseEvent`, `TaskRegistry`, `TaskInfo`, `HealthRegistry`, `HealthStatus`, `UserRoleChanged`, `SessionRevoked`.
 
 ### Domain Services (`modules/*/service.py`)
 
@@ -212,7 +212,7 @@ New routers import domain services directly (`from modules.monitoring.service im
 
 **`orchestrator.py`** (~320 lines): FastAPI entry point — **pure wiring**, zero domain logic. No inline endpoints (Phase 4.1–4.5), no raw `asyncio.create_task()` (Phase 4.6), no helper functions (Phase 4.7a), no global service variables (Phase 4.7b). Contains only: imports, CORS/middleware, declarative router registration (~28 routers), `startup_event()` (calls domain init functions + registers tasks), `shutdown_event()` (delegates to `graceful_shutdown()`), static file serving, Vite dev proxy. All service initialization in domain `startup.py` modules: `modules/speech/startup.py` (TTS/STT), `modules/llm/startup.py` (LLM + fallback chain + InternetMonitor callback), `modules/knowledge/startup.py` (Wiki RAG + embeddings), `modules/core/startup.py` (seed, monitor, shutdown), `modules/telephony/startup.py` (GSM), `modules/channels/{telegram,whatsapp}/startup.py` (bot auto-start).
 
-**`ServiceContainer` (`app/dependencies.py`)**: Singleton holding references to all initialized services — the **single source of truth** for service state (no global variables). Routers get services via FastAPI `Depends`. Populated during app startup by domain `init_*()` functions. Runtime mutations (LLM backend switch) write directly to container.
+**`ServiceContainer` (`app/dependencies.py`)**: Singleton holding references to all initialized services — the **single source of truth** for service state (no global variables). Includes `event_bus: EventBus` singleton for inter-module events. Routers get services via FastAPI `Depends`. Populated during app startup by domain `init_*()` functions. Runtime mutations (LLM backend switch) write directly to container.
 
 **Two service layers**: Core AI services at project root (`cloud_llm_service.py`, `vllm_llm_service.py`, `voice_clone_service.py`, `stt_service.py`, etc.). Domain services in `app/services/` (`amocrm_service.py`, `wiki_rag_service.py`, `backup_service.py`, `sales_funnel.py`, etc.).
 

--- a/wiki-pages/Architecture.md
+++ b/wiki-pages/Architecture.md
@@ -61,10 +61,12 @@
 
 ```
 modules/core/
-├── __init__.py      ← реэкспорт EventBus, TaskRegistry, HealthRegistry
-├── events.py        ← EventBus + BaseEvent
+├── __init__.py      ← реэкспорт EventBus, TaskRegistry, HealthRegistry, UserRoleChanged, SessionRevoked
+├── events.py        ← EventBus + BaseEvent + domain events (ConnectivityStatus, InternetStatusChanged, UserRoleChanged, SessionRevoked)
 ├── tasks.py         ← TaskRegistry + TaskInfo
-└── health.py        ← HealthRegistry + HealthStatus
+├── health.py        ← HealthRegistry + HealthStatus
+├── startup.py       ← seed, setup_event_subscriptions(), init_internet_monitor, graceful_shutdown
+└── internet_monitor.py  ← InternetMonitor (imports events from events.py)
 ```
 
 ### Импорт
@@ -112,6 +114,20 @@ async def on_user_created(event: UserCreated):
 bus.subscribe(UserCreated, on_user_created)
 await bus.publish(UserCreated(user_id=42, username="alice"))
 ```
+
+**Инфраструктура (Phase 5.1):**
+
+- **Singleton:** `ServiceContainer.event_bus` (`app/dependencies.py`) — доступен через `get_container().event_bus`
+- **Подписки:** регистрируются в `setup_event_subscriptions()` (`modules/core/startup.py`), вызывается при старте до инициализации сервисов
+- **Каноническое место для событий:** `modules/core/events.py` (core events) и `modules/{domain}/events.py` (domain events)
+
+**Действующие события:**
+
+| Событие | Файл | Издатель | Подписчик |
+|---------|------|----------|-----------|
+| `InternetStatusChanged` | `modules/core/events.py` | `InternetMonitor` | — (GSM, future) |
+| `UserRoleChanged` | `modules/core/events.py` | `WorkspaceService.update_member_role()` | `on_user_role_changed` → cache invalidation + session revocation |
+| `SessionRevoked` | `modules/core/events.py` | `UserService` (password/role/deactivation), `WorkspaceService.remove_member()` | `on_session_revoked` → cache invalidation + session revocation |
 
 ---
 
@@ -614,19 +630,103 @@ from modules.kanban.service import kanban_service as async_kanban_manager
 
 **Результат:** orchestrator.py: 1121 → 1030 строк (−91). Удалены `asyncio`, `datetime`, `timedelta` из импортов.
 
+### Phase 4.7a: Startup helpers → modules/*/startup.py + graceful shutdown
+
+> **Статус:** реализовано (PR [#583](https://github.com/ShaerWare/AI_Secretary_System/pull/583), issue [#580](https://github.com/ShaerWare/AI_Secretary_System/issues/580))
+
+Извлечение 8 helper-функций из `orchestrator.py` в доменные `startup.py` модули + добавление graceful shutdown.
+
+**Новые файлы:**
+
+| Файл | Функции |
+|------|---------|
+| `modules/core/startup.py` | `seed_system_roles()`, `seed_default_workspace()` |
+| `modules/llm/startup.py` | `get_or_create_default_gemini_provider()`, `auto_start_bridge()` |
+| `modules/channels/telegram/startup.py` | `auto_start_bots()` |
+| `modules/channels/whatsapp/startup.py` | `auto_start_bots()` |
+| `modules/knowledge/startup.py` | `reload_llm_faq(container)` |
+| `modules/speech/startup.py` | `reload_voice_presets(container)` |
+
+**Ключевые решения:**
+- `reload_llm_faq` и `reload_voice_presets` принимают `container` как аргумент (вместо глобальных переменных), вызываются после заполнения контейнера
+- Graceful shutdown в `shutdown_event()`: `multi_bot_manager.stop_all()`, `whatsapp_manager.stop_all()`, `bridge_manager.stop()` — каждый в try/except
+- 5 неиспользуемых импортов удалены из `db.integration`
+
+**Результат:** orchestrator.py: 1030 → 805 строк (−225, −22%).
+
+### Phase 4.7b: Модульная инициализация сервисов + удаление глобалов
+
+> **Статус:** реализовано (PR [#585](https://github.com/ShaerWare/AI_Secretary_System/pull/585), issue [#581](https://github.com/ShaerWare/AI_Secretary_System/issues/581))
+
+Вынос всей inline-инициализации сервисов из `startup_event()` в доменные startup-модули. Удаление 8 глобальных переменных — `ServiceContainer` стал единственным источником правды.
+
+**Новые/расширенные файлы:**
+
+| Файл | Функции |
+|------|---------|
+| `modules/speech/startup.py` | `init_tts_services(deployment_mode)`, `init_stt_service()`, `init_streaming_tts_manager()` |
+| `modules/llm/startup.py` | `init_llm_service(llm_backend)` → (service, backend), `create_llm_switch_callback(container)` |
+| `modules/knowledge/startup.py` | `init_wiki_rag(container, deployment_mode, task_registry)` |
+| `modules/core/startup.py` | `init_internet_monitor(container, deployment_mode)`, `check_legacy_files()`, `graceful_shutdown()` |
+| `modules/telephony/startup.py` | `init_gsm_services(container, deployment_mode)` |
+
+**Ключевые решения:**
+- `_switch_llm` callback переделан в фабрику замыканий `create_llm_switch_callback(container)` — записывает только в `container.llm_service` и `os.environ["LLM_BACKEND"]`, глобальные переменные не используются
+- Optional imports (`VLLM_AVAILABLE`, `PIPER_AVAILABLE`, `XTTS_AVAILABLE`, `OPENVOICE_AVAILABLE`) перенесены в соответствующие domain startup модули
+- `init_tts_services()` возвращает dict с ключами, совпадающими с атрибутами `ServiceContainer`
+- `init_llm_service()` возвращает кортеж `(service, updated_backend)` для обновления `os.environ`
+
+**Удалённые глобальные переменные:** `voice_service`, `anna_voice_service`, `piper_service`, `openvoice_service`, `stt_service`, `llm_service`, `streaming_tts_manager`, `current_voice_config`.
+
+**Результат:** orchestrator.py: 805 → 321 строку (−60%). Чистый wiring: импорты, middleware, регистрация роутеров, вызовы доменных init-функций, static files.
+
+---
+
+## Phase 5: EventBus-события
+
+### Phase 5.1: Инфраструктура EventBus + UserRoleChanged / SessionRevoked
+
+> **Статус:** реализовано (PR [#623](https://github.com/ShaerWare/AI_Secretary_System/pull/623), issue [#617](https://github.com/ShaerWare/AI_Secretary_System/issues/617))
+
+Первая реализация EventBus-паттерна в продакшене: инфраструктура (singleton в контейнере, setup_event_subscriptions) + два реальных события.
+
+**Инфраструктура:**
+- `event_bus: EventBus` добавлен в `ServiceContainer` (`app/dependencies.py`)
+- `setup_event_subscriptions(event_bus)` в `modules/core/startup.py` — вызывается в `orchestrator.py` startup, регистрирует обработчики
+- `InternetMonitor` теперь получает `container.event_bus` (раньше `None`)
+- `ConnectivityStatus` и `InternetStatusChanged` перенесены из `internet_monitor.py` в `modules/core/events.py`
+
+**События:**
+
+| Событие | Издатель | Обработчик |
+|---------|----------|------------|
+| `UserRoleChanged` | `WorkspaceService.update_member_role()` | `_member_role_cache.invalidate_user()` + `revoke_all_user_sessions()` |
+| `SessionRevoked` | `UserService.update_password()`, `set_role()`, `set_active()`, `WorkspaceService.remove_member()` | `_member_role_cache.invalidate_user()` + `revoke_all_user_sessions()` |
+
+**Что убрано:**
+- Прямые вызовы `_member_role_cache.invalidate_user()` и `revoke_all_user_sessions()` из `router_workspace.py`
+- Прямой вызов `auth_manager.revoke_all_user_sessions()` из `UserService._revoke_user_sessions()`
+- Метод `UserService._revoke_user_sessions()` заменён на `_publish_session_revoked()`
+
+**Конвенция для следующих Phase 5.x:**
+- События определяются в `modules/{domain}/events.py` (или `modules/core/events.py` для core)
+- Подписки регистрируются в `setup_events()` функции в `startup.py` домена
+- Издатель получает bus через `get_container().event_bus` (lazy import)
+
 ---
 
 ## Тесты
 
-24 unit-теста для core-инфраструктуры:
+30 unit-тестов для core-инфраструктуры:
 
 ```bash
-pytest tests/unit/test_event_bus.py tests/unit/test_task_registry.py tests/unit/test_health_registry.py -v
+pytest tests/unit/test_event_bus.py tests/unit/test_event_subscriptions.py tests/unit/test_task_registry.py tests/unit/test_health_registry.py -v
 ```
 
 | Файл | Тестов | Что покрывает |
 |------|--------|---------------|
-| `test_event_bus.py` | 8 | publish/subscribe, error isolation, type filtering, clear |
+| `test_event_bus.py` | 11 | publish/subscribe, error isolation, type filtering, clear, UserRoleChanged, SessionRevoked |
+| `test_event_subscriptions.py` | 3 | setup_event_subscriptions wiring — cache invalidation + session revocation via events |
 | `test_task_registry.py` | 8 | periodic/one-shot, cancel, errors, initial_delay, list |
 | `test_health_registry.py` | 8 | aggregation (ok/degraded/error), timeout, exceptions |
 
@@ -643,8 +743,8 @@ pytest tests/unit/test_event_bus.py tests/unit/test_task_registry.py tests/unit/
 | **1** | Разделение `db/models.py` → доменные модули | [#491](https://github.com/ShaerWare/AI_Secretary_System/issues/491) | ✅ Завершена |
 | **2** | Разделение `db/integration.py` → доменные сервисы + фасад | [#492](https://github.com/ShaerWare/AI_Secretary_System/issues/492) | ✅ Завершена (#501, #502, #503) |
 | **3** | Перенос роутеров в доменные модули | [#493](https://github.com/ShaerWare/AI_Secretary_System/issues/493) | ✅ Завершена (#508 ✅, #509 ✅, #510 ✅, #511 ✅, #512 ✅, #513 ✅, #514) |
-| **4** | Декомпозиция `orchestrator.py` | [#494](https://github.com/ShaerWare/AI_Secretary_System/issues/494) | 🔄 4.1 ✅ 4.2 ✅ 4.3 ✅ 4.4 ✅ 4.5 ✅ 4.6 ✅ |
-| **5** | Внедрение EventBus-событий | [#495](https://github.com/ShaerWare/AI_Secretary_System/issues/495) | ⏳ |
+| **4** | Декомпозиция `orchestrator.py` | [#494](https://github.com/ShaerWare/AI_Secretary_System/issues/494) | ✅ Завершена (4.1–4.7b) |
+| **5** | Внедрение EventBus-событий | [#495](https://github.com/ShaerWare/AI_Secretary_System/issues/495) | 🔄 5.1 ✅ |
 | **6** | Протокольные интерфейсы | [#496](https://github.com/ShaerWare/AI_Secretary_System/issues/496) | ⏳ |
 
 ### Ключевые ограничения


### PR DESCRIPTION
## Summary

Update documentation to reflect Phase 5.1 (EventBus infrastructure + events).

- **CLAUDE.md**: EventBus now has singleton in ServiceContainer, domain events (UserRoleChanged, SessionRevoked), setup_event_subscriptions() pattern, updated imports
- **wiki-pages/Architecture.md**: Phase 5.1 section added, test counts updated (30 tests), Phase 5 status updated

Wiki already pushed separately to the wiki repo.

## Test plan

- [ ] CI green (docs only, no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)