### PR TITLE
Phase 5.2: KnowledgeUpdated event — FAQ cache reload via EventBus

### DIFF
--- a/modules/core/startup.py
+++ b/modules/core/startup.py
@@ -190,7 +190,13 @@ async def setup_event_subscriptions(event_bus) -> None:
 
     event_bus.subscribe(UserRoleChanged, on_user_role_changed)
     event_bus.subscribe(SessionRevoked, on_session_revoked)
-    logger.info("Event subscriptions registered (UserRoleChanged, SessionRevoked)")
+
+    # Domain-specific subscriptions
+    from modules.llm.startup import setup_llm_event_subscriptions
+
+    await setup_llm_event_subscriptions(event_bus)
+
+    logger.info("Event subscriptions registered")
 
 
 async def init_internet_monitor(container, deployment_mode: str) -> None:

--- a/modules/knowledge/events.py
+++ b/modules/knowledge/events.py
@@ -1,0 +1,14 @@
+"""Knowledge domain events."""
+
+from dataclasses import dataclass
+
+from modules.core.events import BaseEvent
+
+
+@dataclass
+class KnowledgeUpdated(BaseEvent):
+    """Emitted when a knowledge resource (FAQ, wiki, collection) changes."""
+
+    kind: str = ""  # "faq", "wiki", "collection"
+    action: str = ""  # "created", "updated", "deleted", "reloaded"
+    item_id: int | None = None

--- a/modules/knowledge/router_faq.py
+++ b/modules/knowledge/router_faq.py
@@ -1,6 +1,8 @@
 # app/routers/faq.py
 """FAQ management router - CRUD operations for FAQ entries."""
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
@@ -9,6 +11,8 @@ from auth_manager import User, require_permission, workspace_context
 from modules.knowledge.service import faq_service
 from modules.monitoring.service import audit_service
 
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin/faq", tags=["faq"])
 
@@ -22,13 +26,16 @@ class AdminFAQTestRequest(BaseModel):
     text: str
 
 
-async def _reload_llm_faq():
-    """Загружает FAQ из БД и обновляет LLM сервис."""
-    container = get_container()
-    llm_service = container.llm_service
-    if llm_service and hasattr(llm_service, "reload_faq"):
-        faq_dict = await faq_service.get_all()
-        llm_service.reload_faq(faq_dict)
+async def _publish_knowledge_updated(action: str, item_id: int | None = None) -> None:
+    """Publish KnowledgeUpdated event for FAQ changes."""
+    from modules.knowledge.events import KnowledgeUpdated
+
+    try:
+        await get_container().event_bus.publish(
+            KnowledgeUpdated(kind="faq", action=action, item_id=item_id)
+        )
+    except Exception as e:
+        logger.warning("Failed to publish KnowledgeUpdated: %s", e)
 
 
 @router.get("")
@@ -56,8 +63,7 @@ async def admin_add_faq(
         details={"response": request.response[:100]},
     )
 
-    # Перезагружаем FAQ в LLM сервисе из БД
-    await _reload_llm_faq()
+    await _publish_knowledge_updated("created")
 
     return {"status": "ok", "trigger": request.trigger}
 
@@ -83,7 +89,7 @@ async def admin_update_faq(
         details={"old_trigger": trigger, "response": request.response[:100]},
     )
 
-    await _reload_llm_faq()
+    await _publish_knowledge_updated("updated")
 
     return {"status": "ok", "trigger": request.trigger}
 
@@ -100,7 +106,7 @@ async def admin_delete_faq(trigger: str, user: User = Depends(require_permission
         action="delete", resource="faq", resource_id=trigger, user_id=user.username
     )
 
-    await _reload_llm_faq()
+    await _publish_knowledge_updated("deleted")
 
     return {"status": "ok", "deleted": trigger}
 
@@ -108,7 +114,7 @@ async def admin_delete_faq(trigger: str, user: User = Depends(require_permission
 @router.post("/reload")
 async def admin_reload_faq(user: User = Depends(require_permission("faq", "edit"))):
     """Перезагрузить FAQ из БД"""
-    await _reload_llm_faq()
+    await _publish_knowledge_updated("reloaded")
     container = get_container()
     llm_service = container.llm_service
     faq_count = len(llm_service.faq) if llm_service and hasattr(llm_service, "faq") else 0

--- a/modules/llm/startup.py
+++ b/modules/llm/startup.py
@@ -208,6 +208,29 @@ def create_llm_switch_callback(container):
     return switch_llm
 
 
+async def setup_llm_event_subscriptions(event_bus) -> None:
+    """Register LLM-domain event handlers."""
+    from modules.knowledge.events import KnowledgeUpdated
+
+    async def on_knowledge_updated(event: KnowledgeUpdated) -> None:
+        """Reload FAQ cache when FAQ entries change."""
+        if event.kind != "faq":
+            return
+
+        from app.dependencies import get_container
+        from modules.knowledge.service import faq_service
+
+        container = get_container()
+        llm_service = container.llm_service
+        if llm_service and hasattr(llm_service, "reload_faq"):
+            faq_dict = await faq_service.get_all()
+            llm_service.reload_faq(faq_dict)
+            logger.info("KnowledgeUpdated handled: FAQ cache reloaded (action=%s)", event.action)
+
+    event_bus.subscribe(KnowledgeUpdated, on_knowledge_updated)
+    logger.info("LLM event subscriptions registered (KnowledgeUpdated)")
+
+
 async def auto_start_bridge() -> None:
     """Auto-start CLI-OpenAI Bridge if any enabled claude_bridge provider exists."""
     from bridge_manager import bridge_manager

--- a/tests/unit/test_knowledge_events.py
+++ b/tests/unit/test_knowledge_events.py
@@ -1,0 +1,53 @@
+"""Tests for KnowledgeUpdated event and FAQ reload handler."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from modules.core.events import EventBus
+from modules.knowledge.events import KnowledgeUpdated
+from modules.llm.startup import setup_llm_event_subscriptions
+
+
+async def test_faq_reload_on_knowledge_updated():
+    """FAQ cache reloaded when KnowledgeUpdated(kind='faq') is published."""
+    bus = EventBus()
+    await setup_llm_event_subscriptions(bus)
+
+    mock_llm = MagicMock()
+    mock_llm.reload_faq = MagicMock()
+    mock_container = MagicMock()
+    mock_container.llm_service = mock_llm
+
+    mock_faq_service = AsyncMock()
+    mock_faq_service.get_all = AsyncMock(return_value={"hello": "world"})
+
+    with (
+        patch("app.dependencies.get_container", return_value=mock_container),
+        patch("modules.knowledge.service.faq_service", mock_faq_service),
+    ):
+        await bus.publish(KnowledgeUpdated(kind="faq", action="created"))
+
+    mock_faq_service.get_all.assert_awaited_once()
+    mock_llm.reload_faq.assert_called_once_with({"hello": "world"})
+
+
+async def test_non_faq_knowledge_updated_ignored():
+    """KnowledgeUpdated with kind != 'faq' does not trigger FAQ reload."""
+    bus = EventBus()
+    await setup_llm_event_subscriptions(bus)
+
+    mock_llm = MagicMock()
+    mock_container = MagicMock()
+    mock_container.llm_service = mock_llm
+
+    with patch("app.dependencies.get_container", return_value=mock_container):
+        await bus.publish(KnowledgeUpdated(kind="wiki", action="updated"))
+
+    mock_llm.reload_faq.assert_not_called()
+
+
+async def test_knowledge_updated_event_has_fields():
+    event = KnowledgeUpdated(kind="faq", action="deleted", item_id=42)
+    assert event.kind == "faq"
+    assert event.action == "deleted"
+    assert event.item_id == 42
+    assert event.timestamp > 0


### PR DESCRIPTION
## Summary

Closes #618 (sub-issue of #495 Phase 5: EventBus)

- New `KnowledgeUpdated` event in `modules/knowledge/events.py` (kind: faq/wiki/collection, action, item_id)
- FAQ router publishes `KnowledgeUpdated(kind="faq")` instead of calling `_reload_llm_faq()` directly
- LLM domain subscribes via `setup_llm_event_subscriptions()` in `modules/llm/startup.py` — reloads FAQ cache when `kind == "faq"`
- `setup_event_subscriptions()` in `modules/core/startup.py` now calls LLM subscription setup
- Startup FAQ reload remains a direct call in `orchestrator.py` (reliability guarantee)
- `_reload_llm_faq()` removed from FAQ router; `get_container` import preserved for `/reload` count and `/test` endpoint

**5 files changed**, +115 / -13. No new dependencies.

## Test plan

- [x] 3 new tests (FAQ reload via event, non-faq ignored, event fields)
- [x] All 74 tests pass
- [x] Ruff lint + format clean
- [ ] CI green
- [ ] Manual: add/update/delete FAQ in admin → verify LLM cache updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)