### PR TITLE
Phase 5.3: DatasetSynced event — CRM/ecommerce/kanban → Knowledge reindex via EventBus

### DIFF
--- a/modules/core/__init__.py
+++ b/modules/core/__init__.py
@@ -1,12 +1,13 @@
 """Core infrastructure modules for the AI Secretary System."""
 
-from modules.core.events import BaseEvent, EventBus, SessionRevoked, UserRoleChanged
+from modules.core.events import BaseEvent, DatasetSynced, EventBus, SessionRevoked, UserRoleChanged
 from modules.core.health import HealthRegistry, HealthStatus
 from modules.core.tasks import TaskInfo, TaskRegistry
 
 
 __all__ = [
     "BaseEvent",
+    "DatasetSynced",
     "EventBus",
     "HealthRegistry",
     "HealthStatus",

--- a/modules/core/events.py
+++ b/modules/core/events.py
@@ -63,6 +63,26 @@ class SessionRevoked(BaseEvent):
     reason: str = ""  # "password_changed", "deactivated", "member_removed"
 
 
+@dataclass
+class DatasetSynced(BaseEvent):
+    """Emitted after CRM/ecommerce/kanban sync writes files to disk.
+
+    Knowledge domain subscribes to create/update DB records and reload RAG index.
+    """
+
+    source: str = ""  # "amocrm" | "woocommerce" | "kanban"
+    collection_slug: str = ""
+    action: str = ""  # "synced" | "cleared"
+    # Collection metadata (used for auto-creation on first sync)
+    collection_name: str = ""
+    collection_description: str = ""
+    base_dir: str = ""
+    # Document list for "synced" action: [{filename, title, source_type, file_size_bytes, section_count}]
+    documents: list = field(default_factory=list)
+    # Whether to delete the collection record on "cleared" (kanban does this)
+    delete_collection: bool = False
+
+
 class EventBus:
     """Simple in-process pub/sub for async event handlers.
 

--- a/modules/core/startup.py
+++ b/modules/core/startup.py
@@ -192,8 +192,10 @@ async def setup_event_subscriptions(event_bus) -> None:
     event_bus.subscribe(SessionRevoked, on_session_revoked)
 
     # Domain-specific subscriptions
+    from modules.knowledge.startup import setup_knowledge_event_subscriptions
     from modules.llm.startup import setup_llm_event_subscriptions
 
+    await setup_knowledge_event_subscriptions(event_bus)
     await setup_llm_event_subscriptions(event_bus)
 
     logger.info("Event subscriptions registered")

--- a/modules/crm/router.py
+++ b/modules/crm/router.py
@@ -47,6 +47,10 @@ from modules.knowledge.service import knowledge_collection_service, knowledge_do
 from modules.monitoring.service import audit_service
 
 
+# knowledge_collection_service and knowledge_doc_service are used only for
+# read-only dataset-status queries; mutations go through DatasetSynced events.
+
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin/crm", tags=["crm"])
@@ -907,44 +911,43 @@ async def crm_dataset_sync(user: User = Depends(require_permission("sales", "edi
     (CRM_DIR / summary_filename).write_text(summary_content, encoding="utf-8")
     written_files.append((summary_filename, summary_content, "amoCRM: Сводка по сделкам"))
 
-    # 5. Ensure "amoCRM" collection exists
-    collection = await knowledge_collection_service.get_by_slug("amocrm")
-    if not collection:
-        collection = await knowledge_collection_service.create(
-            name="amoCRM",
-            slug="amocrm",
-            description="Данные из amoCRM: сделки, контакты, воронки (автосинхронизация)",
-            enabled=True,
-            base_dir="data/crm-dataset",
-        )
-    collection_id = collection["id"]
+    # 5. Publish DatasetSynced event — knowledge domain handles DB + RAG
+    from app.dependencies import get_container
+    from modules.core.events import DatasetSynced
 
-    # 6. Remove old DB records for CRM docs, create new ones
-    existing_docs = await knowledge_doc_service.get_by_collection(collection_id)
-    for doc in existing_docs:
-        await knowledge_doc_service.delete(doc["id"])
-
+    documents = []
     for filename, content, title in written_files:
         sections = len(re.findall(r"^#{2,3}\s+.+$", content, re.MULTILINE))
-        await knowledge_doc_service.create(
-            filename=filename,
-            title=title,
-            source_type="amocrm",
-            file_size_bytes=len(content.encode("utf-8")),
-            section_count=sections,
-            collection_id=collection_id,
+        documents.append(
+            {
+                "filename": filename,
+                "title": title,
+                "source_type": "amocrm",
+                "file_size_bytes": len(content.encode("utf-8")),
+                "section_count": sections,
+            }
         )
 
-    # 7. Re-index the collection in WikiRAG
-    from app.dependencies import get_container
+    try:
+        await get_container().event_bus.publish(
+            DatasetSynced(
+                source="amocrm",
+                collection_slug="amocrm",
+                action="synced",
+                collection_name="amoCRM",
+                collection_description="Данные из amoCRM: сделки, контакты, воронки (автосинхронизация)",
+                base_dir=str(CRM_DIR),
+                documents=documents,
+            )
+        )
+    except Exception as e:
+        logger.warning("Failed to publish DatasetSynced: %s", e)
 
-    container = get_container()
-    wiki_rag = container.wiki_rag_service
-    if wiki_rag:
-        filenames = [f[0] for f in written_files]
-        wiki_rag.reload_collection(collection_id, filenames, CRM_DIR)
+    # Resolve collection_id for response (read-only)
+    collection = await knowledge_collection_service.get_by_slug("amocrm")
+    collection_id = collection["id"] if collection else None
 
-    # 8. Log sync event
+    # 6. Log sync event
     await amocrm_service.log_sync(
         direction="incoming",
         entity_type="dataset",
@@ -1024,18 +1027,20 @@ async def crm_dataset_clear(user: User = Depends(require_permission("sales", "ma
     """Clear CRM dataset — remove files, DB records, and collection index."""
     removed = clean_crm_files()
 
-    collection = await knowledge_collection_service.get_by_slug("amocrm")
-    if collection:
-        docs = await knowledge_doc_service.get_by_collection(collection["id"])
-        for doc in docs:
-            await knowledge_doc_service.delete(doc["id"])
+    from app.dependencies import get_container
+    from modules.core.events import DatasetSynced
 
-        from app.dependencies import get_container
-
-        container = get_container()
-        wiki_rag = container.wiki_rag_service
-        if wiki_rag:
-            wiki_rag.unload_collection(collection["id"])
+    try:
+        await get_container().event_bus.publish(
+            DatasetSynced(
+                source="amocrm",
+                collection_slug="amocrm",
+                action="cleared",
+                base_dir=str(CRM_DIR),
+            )
+        )
+    except Exception as e:
+        logger.warning("Failed to publish DatasetSynced(cleared): %s", e)
 
     return {"status": "ok", "files_removed": len(removed)}
 

--- a/modules/ecommerce/router.py
+++ b/modules/ecommerce/router.py
@@ -13,6 +13,10 @@ from modules.knowledge.service import knowledge_collection_service, knowledge_do
 from modules.monitoring.service import audit_service
 
 
+# knowledge_collection_service and knowledge_doc_service are used only for
+# read-only dataset-status queries; mutations go through DatasetSynced events.
+
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin/woocommerce", tags=["woocommerce"])
@@ -164,23 +168,24 @@ async def wc_dataset_status(user: User = Depends(require_permission("sales", "vi
 @router.delete("/dataset")
 async def wc_dataset_clear(user: User = Depends(require_permission("sales", "manage"))):
     """Clear WooCommerce dataset."""
-    collection = await knowledge_collection_service.get_by_slug(WC_COLLECTION_SLUG)
-    if collection:
-        # Remove DB records
-        docs = await knowledge_doc_service.get_by_collection(collection["id"])
-        for doc in docs:
-            await knowledge_doc_service.delete(doc["id"])
-
-        # Clear RAG index
-        from app.dependencies import get_container
-
-        container = get_container()
-        wiki_rag = container.wiki_rag_service
-        if wiki_rag:
-            wiki_rag.reload_collection(collection["id"], [], WC_DIR)
-
     # Remove files
     removed = clean_wc_files()
+
+    # Publish DatasetSynced(cleared) — knowledge domain handles DB + RAG
+    from app.dependencies import get_container
+    from modules.core.events import DatasetSynced
+
+    try:
+        await get_container().event_bus.publish(
+            DatasetSynced(
+                source="woocommerce",
+                collection_slug=WC_COLLECTION_SLUG,
+                action="cleared",
+                base_dir=str(WC_DIR),
+            )
+        )
+    except Exception as e:
+        logger.warning("Failed to publish DatasetSynced(cleared): %s", e)
 
     # Reset config counts
     await woocommerce_service.save_config(

--- a/modules/ecommerce/sync.py
+++ b/modules/ecommerce/sync.py
@@ -20,7 +20,6 @@ from app.services.woocommerce_service import (
     get_categories,
 )
 from modules.ecommerce.service import woocommerce_service
-from modules.knowledge.service import knowledge_collection_service, knowledge_doc_service
 
 
 logger = logging.getLogger(__name__)
@@ -115,44 +114,47 @@ async def run_woocommerce_sync() -> dict:
     (WC_DIR / summary_filename).write_text(summary_content, encoding="utf-8")
     written_files.append((summary_filename, summary_content, "WooCommerce: Сводка"))
 
-    # 5. Ensure "woocommerce" collection exists
-    collection = await knowledge_collection_service.get_by_slug(WC_COLLECTION_SLUG)
-    if not collection:
-        collection = await knowledge_collection_service.create(
-            name=WC_COLLECTION_NAME,
-            slug=WC_COLLECTION_SLUG,
-            description="Товары, категории и заказы из WooCommerce магазина (автосинхронизация)",
-            enabled=True,
-            base_dir="data/woocommerce-dataset",
-        )
-    collection_id = collection["id"]
+    # 5. Publish DatasetSynced event — knowledge domain handles DB + RAG
+    from app.dependencies import get_container
+    from modules.core.events import DatasetSynced
 
-    # 6. Remove old DB records, create new ones
-    existing_docs = await knowledge_doc_service.get_by_collection(collection_id)
-    for doc in existing_docs:
-        await knowledge_doc_service.delete(doc["id"])
-
+    documents = []
     for filename, content, title in written_files:
         sections = len(re.findall(r"^#{2,3}\s+.+$", content, re.MULTILINE))
-        await knowledge_doc_service.create(
-            filename=filename,
-            title=title,
-            source_type="woocommerce",
-            file_size_bytes=len(content.encode("utf-8")),
-            section_count=sections,
-            collection_id=collection_id,
+        documents.append(
+            {
+                "filename": filename,
+                "title": title,
+                "source_type": "woocommerce",
+                "file_size_bytes": len(content.encode("utf-8")),
+                "section_count": sections,
+            }
         )
 
-    # 7. Re-index the collection in WikiRAG
-    from app.dependencies import get_container
+    try:
+        await get_container().event_bus.publish(
+            DatasetSynced(
+                source="woocommerce",
+                collection_slug=WC_COLLECTION_SLUG,
+                action="synced",
+                collection_name=WC_COLLECTION_NAME,
+                collection_description=(
+                    "Товары, категории и заказы из WooCommerce магазина (автосинхронизация)"
+                ),
+                base_dir=str(WC_DIR),
+                documents=documents,
+            )
+        )
+    except Exception as e:
+        logger.warning("Failed to publish DatasetSynced: %s", e)
 
-    container = get_container()
-    wiki_rag = container.wiki_rag_service
-    if wiki_rag:
-        filenames = [f[0] for f in written_files]
-        wiki_rag.reload_collection(collection_id, filenames, WC_DIR)
+    # Resolve collection_id for response (read-only)
+    from modules.knowledge.service import knowledge_collection_service
 
-    # 8. Update config with counts
+    collection = await knowledge_collection_service.get_by_slug(WC_COLLECTION_SLUG)
+    collection_id = collection["id"] if collection else None
+
+    # 6. Update config with counts
     await woocommerce_service.save_config(
         products_count=len(all_products),
         categories_count=len(all_categories),

--- a/modules/kanban/router.py
+++ b/modules/kanban/router.py
@@ -16,6 +16,10 @@ from modules.knowledge.service import knowledge_collection_service, knowledge_do
 from modules.monitoring.service import audit_service
 
 
+# knowledge_collection_service and knowledge_doc_service are used only for
+# read-only dataset-status queries; mutations go through DatasetSynced events.
+
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin/kanban", tags=["kanban"])
@@ -514,52 +518,43 @@ async def dataset_sync(
     (project_dir / summary_filename).write_text(summary, encoding="utf-8")
     documents.append((summary_filename, f"{project.name}: Сводка", summary))
 
-    # Auto-create or find collection
-    collection = None
-    existing_collections = await knowledge_collection_service.get_all()
-    for col in existing_collections:
-        if col.get("slug") == slug:
-            collection = col
-            break
+    # Publish DatasetSynced event — knowledge domain handles DB + RAG
+    from app.dependencies import get_container
+    from modules.core.events import DatasetSynced
 
-    if not collection:
-        collection = await knowledge_collection_service.create(
-            name=f"Kanban: {project.name}",
-            slug=slug,
-            description=f"Задачи: {project.github_owner}/{project.github_repo}",
-            enabled=True,
-            base_dir=str(project_dir),
-        )
-
-    collection_id = collection["id"]
-
-    # Clear existing documents for this collection
-    existing_docs = await knowledge_doc_service.get_by_collection(collection_id)
-    for doc in existing_docs:
-        await knowledge_doc_service.delete(doc["id"])
-
-    # Create new knowledge document records
+    doc_infos = []
     total_sections = 0
     for filename, title, content in documents:
         sections = len(re.findall(r"^#{2,3}\s+.+$", content, re.MULTILINE))
         total_sections += sections
-        await knowledge_doc_service.create(
-            filename=filename,
-            title=title,
-            source_type="kanban",
-            file_size_bytes=len(content.encode("utf-8")),
-            section_count=sections,
-            collection_id=collection_id,
+        doc_infos.append(
+            {
+                "filename": filename,
+                "title": title,
+                "source_type": "kanban",
+                "file_size_bytes": len(content.encode("utf-8")),
+                "section_count": sections,
+            }
         )
 
-    # Reload RAG index
-    from app.dependencies import get_container
+    try:
+        await get_container().event_bus.publish(
+            DatasetSynced(
+                source="kanban",
+                collection_slug=slug,
+                action="synced",
+                collection_name=f"Kanban: {project.name}",
+                collection_description=f"Задачи: {project.github_owner}/{project.github_repo}",
+                base_dir=str(project_dir),
+                documents=doc_infos,
+            )
+        )
+    except Exception as e:
+        logger.warning("Failed to publish DatasetSynced: %s", e)
 
-    container = get_container()
-    wiki_rag = container.wiki_rag_service
-    if wiki_rag:
-        filenames = [d[0] for d in documents]
-        wiki_rag.reload_collection(collection_id, filenames, project_dir)
+    # Resolve collection_id for response (read-only)
+    collection = await knowledge_collection_service.get_by_slug(slug)
+    collection_id = collection["id"] if collection else None
 
     await audit_service.log(
         action="dataset_sync",
@@ -634,36 +629,27 @@ async def dataset_clear(
         raise HTTPException(status_code=404, detail="Project not found")
 
     slug = f"kanban-{project.github_owner}-{project.github_repo}".lower()
-
-    # Find and delete collection
-    existing_collections = await knowledge_collection_service.get_all()
-    collection = None
-    for col in existing_collections:
-        if col.get("slug") == slug:
-            collection = col
-            break
-
-    if collection:
-        collection_id = collection["id"]
-
-        # Delete knowledge documents
-        docs = await knowledge_doc_service.get_by_collection(collection_id)
-        for doc in docs:
-            await knowledge_doc_service.delete(doc["id"])
-
-        # Clear RAG index
-        from app.dependencies import get_container
-
-        container = get_container()
-        wiki_rag = container.wiki_rag_service
-        if wiki_rag:
-            project_dir = get_project_dir(slug)
-            wiki_rag.reload_collection(collection_id, [], project_dir)
-
-        await knowledge_collection_service.delete(collection_id)
+    project_dir = get_project_dir(slug)
 
     # Remove files
     clean_kanban_files(slug)
+
+    # Publish DatasetSynced(cleared) — knowledge domain handles DB + RAG + collection deletion
+    from app.dependencies import get_container
+    from modules.core.events import DatasetSynced
+
+    try:
+        await get_container().event_bus.publish(
+            DatasetSynced(
+                source="kanban",
+                collection_slug=slug,
+                action="cleared",
+                base_dir=str(project_dir),
+                delete_collection=True,
+            )
+        )
+    except Exception as e:
+        logger.warning("Failed to publish DatasetSynced(cleared): %s", e)
 
     await audit_service.log(
         action="dataset_clear",

--- a/modules/knowledge/startup.py
+++ b/modules/knowledge/startup.py
@@ -1,10 +1,112 @@
-"""Knowledge domain startup: FAQ reload + Wiki RAG init."""
+"""Knowledge domain startup: FAQ reload, Wiki RAG init, event subscriptions."""
 
 import logging
 from functools import partial
+from pathlib import Path
 
 
 logger = logging.getLogger(__name__)
+
+
+async def setup_knowledge_event_subscriptions(event_bus) -> None:
+    """Register knowledge-domain event handlers."""
+    from modules.core.events import DatasetSynced
+
+    async def on_dataset_synced(event: DatasetSynced) -> None:
+        """Sync knowledge DB records and RAG index after dataset files are written."""
+        from modules.knowledge.service import knowledge_collection_service, knowledge_doc_service
+
+        if event.action == "synced":
+            await _handle_dataset_sync(event, knowledge_collection_service, knowledge_doc_service)
+        elif event.action == "cleared":
+            await _handle_dataset_clear(event, knowledge_collection_service, knowledge_doc_service)
+        else:
+            logger.warning("DatasetSynced: unknown action=%s", event.action)
+
+    event_bus.subscribe(DatasetSynced, on_dataset_synced)
+    logger.info("Knowledge event subscriptions registered (DatasetSynced)")
+
+
+async def _handle_dataset_sync(event, collection_svc, doc_svc) -> None:
+    """Create/update knowledge collection and document records, reload RAG."""
+    collection = await collection_svc.get_by_slug(event.collection_slug)
+    if not collection:
+        collection = await collection_svc.create(
+            name=event.collection_name,
+            slug=event.collection_slug,
+            description=event.collection_description,
+            enabled=True,
+            base_dir=event.base_dir,
+        )
+    collection_id = collection["id"]
+
+    # Remove old document records
+    existing_docs = await doc_svc.get_by_collection(collection_id)
+    for doc in existing_docs:
+        await doc_svc.delete(doc["id"])
+
+    # Create new document records
+    for doc_info in event.documents:
+        await doc_svc.create(
+            filename=doc_info["filename"],
+            title=doc_info["title"],
+            source_type=doc_info["source_type"],
+            file_size_bytes=doc_info.get("file_size_bytes", 0),
+            section_count=doc_info.get("section_count", 0),
+            collection_id=collection_id,
+        )
+
+    # Reload RAG index
+    from app.dependencies import get_container
+
+    container = get_container()
+    wiki_rag = container.wiki_rag_service
+    if wiki_rag:
+        filenames = [d["filename"] for d in event.documents]
+        wiki_rag.reload_collection(collection_id, filenames, Path(event.base_dir))
+
+    logger.info(
+        "DatasetSynced handled: source=%s slug=%s docs=%d",
+        event.source,
+        event.collection_slug,
+        len(event.documents),
+    )
+
+
+async def _handle_dataset_clear(event, collection_svc, doc_svc) -> None:
+    """Remove knowledge document records and unload RAG index."""
+    collection = await collection_svc.get_by_slug(event.collection_slug)
+    if not collection:
+        return
+
+    collection_id = collection["id"]
+
+    # Delete document records
+    docs = await doc_svc.get_by_collection(collection_id)
+    for doc in docs:
+        await doc_svc.delete(doc["id"])
+
+    # Unload/clear RAG index
+    from app.dependencies import get_container
+
+    container = get_container()
+    wiki_rag = container.wiki_rag_service
+    if wiki_rag:
+        if event.delete_collection:
+            wiki_rag.unload_collection(collection_id)
+        else:
+            wiki_rag.reload_collection(collection_id, [], Path(event.base_dir))
+
+    # Delete collection record if requested
+    if event.delete_collection:
+        await collection_svc.delete(collection_id)
+
+    logger.info(
+        "DatasetSynced(cleared) handled: source=%s slug=%s delete_collection=%s",
+        event.source,
+        event.collection_slug,
+        event.delete_collection,
+    )
 
 
 async def reload_llm_faq(container) -> None:

--- a/tests/unit/test_dataset_synced.py
+++ b/tests/unit/test_dataset_synced.py
@@ -1,0 +1,238 @@
+"""Tests for DatasetSynced event and knowledge reindex handler."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from modules.core.events import DatasetSynced, EventBus
+from modules.knowledge.startup import setup_knowledge_event_subscriptions
+
+
+async def test_dataset_synced_creates_collection_and_docs():
+    """Handler creates collection + documents + reloads RAG on sync event."""
+    bus = EventBus()
+    await setup_knowledge_event_subscriptions(bus)
+
+    mock_collection_svc = AsyncMock()
+    mock_collection_svc.get_by_slug = AsyncMock(return_value=None)
+    mock_collection_svc.create = AsyncMock(return_value={"id": 42})
+
+    mock_doc_svc = AsyncMock()
+    mock_doc_svc.get_by_collection = AsyncMock(return_value=[])
+    mock_doc_svc.create = AsyncMock()
+
+    mock_wiki_rag = MagicMock()
+    mock_container = MagicMock()
+    mock_container.wiki_rag_service = mock_wiki_rag
+
+    documents = [
+        {
+            "filename": "crm-pipeline-1.md",
+            "title": "Pipeline 1",
+            "source_type": "amocrm",
+            "file_size_bytes": 100,
+            "section_count": 3,
+        },
+        {
+            "filename": "crm-summary.md",
+            "title": "Summary",
+            "source_type": "amocrm",
+            "file_size_bytes": 200,
+            "section_count": 5,
+        },
+    ]
+
+    with (
+        patch(
+            "modules.knowledge.service.knowledge_collection_service",
+            mock_collection_svc,
+        ),
+        patch("modules.knowledge.service.knowledge_doc_service", mock_doc_svc),
+        patch("app.dependencies.get_container", return_value=mock_container),
+    ):
+        await bus.publish(
+            DatasetSynced(
+                source="amocrm",
+                collection_slug="amocrm",
+                action="synced",
+                collection_name="amoCRM",
+                collection_description="CRM data",
+                base_dir="data/crm-dataset",
+                documents=documents,
+            )
+        )
+
+    mock_collection_svc.get_by_slug.assert_awaited_once_with("amocrm")
+    mock_collection_svc.create.assert_awaited_once()
+    assert mock_doc_svc.create.await_count == 2
+    mock_wiki_rag.reload_collection.assert_called_once_with(
+        42, ["crm-pipeline-1.md", "crm-summary.md"], Path("data/crm-dataset")
+    )
+
+
+async def test_dataset_synced_reuses_existing_collection():
+    """Handler reuses existing collection and deletes old docs before creating new ones."""
+    bus = EventBus()
+    await setup_knowledge_event_subscriptions(bus)
+
+    mock_collection_svc = AsyncMock()
+    mock_collection_svc.get_by_slug = AsyncMock(return_value={"id": 7})
+
+    mock_doc_svc = AsyncMock()
+    mock_doc_svc.get_by_collection = AsyncMock(return_value=[{"id": 10}, {"id": 11}])
+    mock_doc_svc.delete = AsyncMock()
+    mock_doc_svc.create = AsyncMock()
+
+    mock_container = MagicMock()
+    mock_container.wiki_rag_service = None
+
+    with (
+        patch(
+            "modules.knowledge.service.knowledge_collection_service",
+            mock_collection_svc,
+        ),
+        patch("modules.knowledge.service.knowledge_doc_service", mock_doc_svc),
+        patch("app.dependencies.get_container", return_value=mock_container),
+    ):
+        await bus.publish(
+            DatasetSynced(
+                source="woocommerce",
+                collection_slug="woocommerce",
+                action="synced",
+                base_dir="data/wc-dataset",
+                documents=[
+                    {
+                        "filename": "wc-summary.md",
+                        "title": "WC Summary",
+                        "source_type": "woocommerce",
+                    }
+                ],
+            )
+        )
+
+    mock_collection_svc.create.assert_not_awaited()
+    assert mock_doc_svc.delete.await_count == 2
+    mock_doc_svc.create.assert_awaited_once()
+
+
+async def test_dataset_cleared_deletes_docs_and_reloads_rag():
+    """Handler deletes docs and reloads RAG with empty list on clear event."""
+    bus = EventBus()
+    await setup_knowledge_event_subscriptions(bus)
+
+    mock_collection_svc = AsyncMock()
+    mock_collection_svc.get_by_slug = AsyncMock(return_value={"id": 5})
+
+    mock_doc_svc = AsyncMock()
+    mock_doc_svc.get_by_collection = AsyncMock(return_value=[{"id": 1}])
+    mock_doc_svc.delete = AsyncMock()
+
+    mock_wiki_rag = MagicMock()
+    mock_container = MagicMock()
+    mock_container.wiki_rag_service = mock_wiki_rag
+
+    with (
+        patch(
+            "modules.knowledge.service.knowledge_collection_service",
+            mock_collection_svc,
+        ),
+        patch("modules.knowledge.service.knowledge_doc_service", mock_doc_svc),
+        patch("app.dependencies.get_container", return_value=mock_container),
+    ):
+        await bus.publish(
+            DatasetSynced(
+                source="amocrm",
+                collection_slug="amocrm",
+                action="cleared",
+                base_dir="data/crm-dataset",
+            )
+        )
+
+    mock_doc_svc.delete.assert_awaited_once_with(1)
+    mock_wiki_rag.reload_collection.assert_called_once_with(5, [], Path("data/crm-dataset"))
+    mock_collection_svc.delete.assert_not_awaited()
+
+
+async def test_dataset_cleared_with_delete_collection():
+    """Handler deletes collection record when delete_collection=True."""
+    bus = EventBus()
+    await setup_knowledge_event_subscriptions(bus)
+
+    mock_collection_svc = AsyncMock()
+    mock_collection_svc.get_by_slug = AsyncMock(return_value={"id": 9})
+    mock_collection_svc.delete = AsyncMock()
+
+    mock_doc_svc = AsyncMock()
+    mock_doc_svc.get_by_collection = AsyncMock(return_value=[])
+
+    mock_wiki_rag = MagicMock()
+    mock_container = MagicMock()
+    mock_container.wiki_rag_service = mock_wiki_rag
+
+    with (
+        patch(
+            "modules.knowledge.service.knowledge_collection_service",
+            mock_collection_svc,
+        ),
+        patch("modules.knowledge.service.knowledge_doc_service", mock_doc_svc),
+        patch("app.dependencies.get_container", return_value=mock_container),
+    ):
+        await bus.publish(
+            DatasetSynced(
+                source="kanban",
+                collection_slug="kanban-owner-repo",
+                action="cleared",
+                base_dir="data/kanban-dataset",
+                delete_collection=True,
+            )
+        )
+
+    mock_wiki_rag.unload_collection.assert_called_once_with(9)
+    mock_collection_svc.delete.assert_awaited_once_with(9)
+
+
+async def test_dataset_cleared_noop_when_collection_missing():
+    """Handler does nothing if collection doesn't exist on clear."""
+    bus = EventBus()
+    await setup_knowledge_event_subscriptions(bus)
+
+    mock_collection_svc = AsyncMock()
+    mock_collection_svc.get_by_slug = AsyncMock(return_value=None)
+
+    mock_doc_svc = AsyncMock()
+
+    with (
+        patch(
+            "modules.knowledge.service.knowledge_collection_service",
+            mock_collection_svc,
+        ),
+        patch("modules.knowledge.service.knowledge_doc_service", mock_doc_svc),
+    ):
+        await bus.publish(
+            DatasetSynced(
+                source="amocrm",
+                collection_slug="amocrm",
+                action="cleared",
+            )
+        )
+
+    mock_doc_svc.get_by_collection.assert_not_awaited()
+
+
+async def test_dataset_synced_event_fields():
+    """DatasetSynced event has all expected fields."""
+    event = DatasetSynced(
+        source="woocommerce",
+        collection_slug="woocommerce",
+        action="synced",
+        collection_name="WooCommerce",
+        collection_description="WC data",
+        base_dir="/data/wc",
+        documents=[{"filename": "test.md"}],
+        delete_collection=False,
+    )
+    assert event.source == "woocommerce"
+    assert event.collection_slug == "woocommerce"
+    assert event.action == "synced"
+    assert event.collection_name == "WooCommerce"
+    assert len(event.documents) == 1
+    assert event.timestamp > 0


### PR DESCRIPTION
## Summary

Closes #619.

- **DatasetSynced event** (`modules/core/events.py`) — cross-domain event carrying collection metadata + document list
- **Knowledge handler** (`modules/knowledge/startup.py`) — subscribes to `DatasetSynced`, handles collection create/reuse, document CRUD, RAG reload/unload
- **CRM router** — `dataset-sync` and `dataset-clear` publish events instead of direct `knowledge_collection_service`/`knowledge_doc_service` calls
- **WooCommerce sync + router** — same refactoring for `run_woocommerce_sync()` and `dataset-clear`
- **Kanban router** — same refactoring for `dataset-sync` and `dataset-clear` (with `delete_collection=True`)
- **Read-only** `dataset-status` endpoints kept with direct knowledge imports (no mutation = no coupling concern)
- 6 tests covering: collection creation, collection reuse, doc deletion, clear with/without collection deletion, noop on missing collection

### Dependency graph change

Before: `crm → knowledge`, `ecommerce → knowledge`, `kanban → knowledge`
After: `crm → events ← knowledge`, `ecommerce → events ← knowledge`, `kanban → events ← knowledge`

## Test plan

- [x] `pytest tests/unit/test_dataset_synced.py` — 6 tests pass
- [x] `pytest tests/unit/test_event_subscriptions.py tests/unit/test_knowledge_events.py` — existing event tests pass
- [x] `ruff check` + `ruff format --check` clean
- [x] `tsc --noEmit` clean
- [ ] CI checks (lint-backend, lint-frontend, security)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)