### PR TITLE
feat: BotProcessDied event — process watcher + auto-restart (#621)

### DIFF
--- a/modules/channels/events.py
+++ b/modules/channels/events.py
@@ -1,0 +1,19 @@
+"""Channel-level domain events (shared across telegram, whatsapp, etc.)."""
+
+from dataclasses import dataclass
+
+from modules.core.events import BaseEvent
+
+
+@dataclass
+class BotProcessDied(BaseEvent):
+    """Emitted when a bot subprocess is detected as terminated.
+
+    The bot-process-watcher periodic task publishes this event.
+    Subscribers: audit logging, auto-restart with backoff.
+    """
+
+    channel: str = ""  # "telegram" | "whatsapp"
+    instance_id: str = ""
+    exit_code: int | None = None
+    uptime_seconds: float = 0.0

--- a/modules/channels/startup.py
+++ b/modules/channels/startup.py
@@ -1,0 +1,196 @@
+"""Channel-level startup: bot process watcher + event subscriptions."""
+
+import asyncio
+import logging
+from collections import defaultdict
+
+from app.dependencies import get_container
+from modules.channels.events import BotProcessDied
+from modules.monitoring.service import audit_service
+
+
+logger = logging.getLogger(__name__)
+
+# Restart tracking: {(channel, instance_id): consecutive_failure_count}
+_restart_counts: dict[tuple[str, str], int] = defaultdict(int)
+
+_MAX_RESTARTS = 3
+_BACKOFF_BASE = 10  # seconds: 10, 20, 30
+
+
+async def watch_bot_processes() -> None:
+    """Detect dead bot processes and publish BotProcessDied events.
+
+    Called periodically by TaskRegistry (every 30s).
+    Iterates both Telegram and WhatsApp manager process dicts.
+    """
+    bus = get_container().event_bus
+
+    dead: list[tuple[str, str, int | None, float]] = []
+
+    # --- Telegram ---
+    try:
+        from multi_bot_manager import multi_bot_manager
+
+        async with multi_bot_manager._lock:
+            to_remove = []
+            for iid, proc in multi_bot_manager._processes.items():
+                if not proc.is_running:
+                    dead.append(("telegram", iid, proc.process.returncode, proc.uptime_seconds))
+                    to_remove.append(iid)
+            for iid in to_remove:
+                del multi_bot_manager._processes[iid]
+    except Exception:
+        logger.debug("Telegram manager not available", exc_info=True)
+
+    # --- WhatsApp ---
+    try:
+        from whatsapp_manager import whatsapp_manager
+
+        async with whatsapp_manager._lock:
+            to_remove = []
+            for iid, proc in whatsapp_manager._processes.items():
+                if not proc.is_running:
+                    dead.append(("whatsapp", iid, proc.process.returncode, proc.uptime_seconds))
+                    to_remove.append(iid)
+            for iid in to_remove:
+                del whatsapp_manager._processes[iid]
+    except Exception:
+        logger.debug("WhatsApp manager not available", exc_info=True)
+
+    # Publish events
+    for channel, instance_id, exit_code, uptime in dead:
+        await bus.publish(
+            BotProcessDied(
+                channel=channel,
+                instance_id=instance_id,
+                exit_code=exit_code,
+                uptime_seconds=uptime,
+            )
+        )
+
+
+async def setup_channel_event_subscriptions(event_bus) -> None:
+    """Register event handlers for BotProcessDied."""
+
+    async def on_bot_process_died(event: BotProcessDied) -> None:
+        """Audit-log the death and attempt auto-restart with backoff."""
+        await _audit_bot_death(event)
+        await _auto_restart_bot(event)
+
+    event_bus.subscribe(BotProcessDied, on_bot_process_died)
+    logger.info("Channel event subscriptions registered (BotProcessDied)")
+
+
+async def _audit_bot_death(event: BotProcessDied) -> None:
+    """Write bot death to audit log."""
+    try:
+        exit_label = f"exit_code={event.exit_code}" if event.exit_code is not None else "unknown"
+        await audit_service.log(
+            action="process_died",
+            resource=f"{event.channel}_bot",
+            resource_id=str(event.instance_id),
+            details={
+                "channel": event.channel,
+                "exit_code": event.exit_code,
+                "uptime_seconds": event.uptime_seconds,
+            },
+        )
+        logger.warning(
+            "Bot process died: %s instance=%s %s (uptime=%ds)",
+            event.channel,
+            event.instance_id,
+            exit_label,
+            int(event.uptime_seconds),
+        )
+    except Exception:
+        logger.debug("Failed to audit bot death", exc_info=True)
+
+
+async def _auto_restart_bot(event: BotProcessDied) -> None:
+    """Attempt to restart a crashed bot with exponential backoff.
+
+    - exit_code == 0 (graceful stop): no restart
+    - Max 3 consecutive restarts; after that, log as failed
+    - Backoff: 10s, 20s, 30s
+    - Counter resets when uptime exceeds 60s (stable run)
+    """
+    # Graceful shutdown — do not restart
+    if event.exit_code == 0:
+        logger.info(
+            "Bot %s/%s exited gracefully (code=0), not restarting",
+            event.channel,
+            event.instance_id,
+        )
+        return
+
+    key = (event.channel, event.instance_id)
+
+    # Reset counter if the bot had been running stably (>60s)
+    if event.uptime_seconds > 60:
+        _restart_counts[key] = 0
+
+    count = _restart_counts[key]
+    if count >= _MAX_RESTARTS:
+        logger.error(
+            "Bot %s/%s exceeded max restarts (%d), giving up",
+            event.channel,
+            event.instance_id,
+            _MAX_RESTARTS,
+        )
+        try:
+            await audit_service.log(
+                action="restart_failed",
+                resource=f"{event.channel}_bot",
+                resource_id=str(event.instance_id),
+                details={"reason": f"exceeded {_MAX_RESTARTS} consecutive restarts"},
+            )
+        except Exception:
+            pass
+        return
+
+    delay = _BACKOFF_BASE * (count + 1)
+    _restart_counts[key] = count + 1
+
+    logger.info(
+        "Auto-restarting %s/%s in %ds (attempt %d/%d)",
+        event.channel,
+        event.instance_id,
+        delay,
+        count + 1,
+        _MAX_RESTARTS,
+    )
+
+    await asyncio.sleep(delay)
+
+    try:
+        if event.channel == "telegram":
+            from multi_bot_manager import multi_bot_manager
+
+            result = await multi_bot_manager.start_bot(event.instance_id)
+        else:
+            from whatsapp_manager import whatsapp_manager
+
+            result = await whatsapp_manager.start_bot(event.instance_id)
+
+        if result.get("status") == "running":
+            logger.info(
+                "Auto-restart succeeded: %s/%s (attempt %d)",
+                event.channel,
+                event.instance_id,
+                count + 1,
+            )
+        else:
+            logger.warning(
+                "Auto-restart returned non-running status: %s/%s: %s",
+                event.channel,
+                event.instance_id,
+                result,
+            )
+    except Exception:
+        logger.error(
+            "Auto-restart failed: %s/%s",
+            event.channel,
+            event.instance_id,
+            exc_info=True,
+        )

--- a/modules/core/startup.py
+++ b/modules/core/startup.py
@@ -192,10 +192,12 @@ async def setup_event_subscriptions(event_bus) -> None:
     event_bus.subscribe(SessionRevoked, on_session_revoked)
 
     # Domain-specific subscriptions
+    from modules.channels.startup import setup_channel_event_subscriptions
     from modules.crm.startup import setup_crm_event_subscriptions
     from modules.knowledge.startup import setup_knowledge_event_subscriptions
     from modules.llm.startup import setup_llm_event_subscriptions
 
+    await setup_channel_event_subscriptions(event_bus)
     await setup_crm_event_subscriptions(event_bus)
     await setup_knowledge_event_subscriptions(event_bus)
     await setup_llm_event_subscriptions(event_bus)

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -233,6 +233,7 @@ async def startup_event():
         await auto_start_bridge()
 
         # Register background tasks via TaskRegistry
+        from modules.channels.startup import watch_bot_processes
         from modules.core.maintenance import cleanup_expired_sessions, periodic_vacuum
         from modules.ecommerce.tasks import woocommerce_daily_sync
         from modules.kanban.tasks import sync_kanban_issues
@@ -245,6 +246,9 @@ async def startup_event():
             "kanban-sync", sync_kanban_issues, interval=15 * 60, initial_delay=60
         )
         task_registry.register("woocommerce-sync", woocommerce_daily_sync)
+        task_registry.register(
+            "bot-process-watcher", watch_bot_processes, interval=30, initial_delay=15
+        )
 
         await task_registry.start_all()
         logger.info("✅ Основные сервисы загружены успешно")

--- a/tests/unit/test_bot_process_watcher.py
+++ b/tests/unit/test_bot_process_watcher.py
@@ -1,0 +1,256 @@
+"""Tests for BotProcessDied event: watcher, audit, auto-restart."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from modules.channels.events import BotProcessDied
+from modules.channels.startup import (
+    _MAX_RESTARTS,
+    _audit_bot_death,
+    _auto_restart_bot,
+    _restart_counts,
+    setup_channel_event_subscriptions,
+    watch_bot_processes,
+)
+from modules.core.events import EventBus
+
+
+def _make_proc(instance_id, *, running, returncode=1, uptime=120):
+    """Create a mock bot process object."""
+    proc = MagicMock()
+    proc.instance_id = instance_id
+    proc.is_running = running
+    proc.uptime_seconds = uptime
+    proc.process = MagicMock()
+    proc.process.returncode = returncode
+    return proc
+
+
+def _mock_manager(processes=None):
+    """Create a mock bot manager with lock and processes dict."""
+    mgr = MagicMock()
+    mgr._lock = asyncio.Lock()
+    mgr._processes = dict(processes or {})
+    return mgr
+
+
+async def test_watcher_detects_dead_telegram_bot():
+    """Watcher publishes BotProcessDied for a dead Telegram process."""
+    dead_proc = _make_proc("42", running=False, returncode=1, uptime=300)
+    tg_mgr = _mock_manager({"42": dead_proc})
+    wa_mgr = _mock_manager()
+
+    events = []
+    bus = EventBus()
+
+    async def capture(e):
+        events.append(e)
+
+    bus.subscribe(BotProcessDied, capture)
+
+    with (
+        patch(
+            "modules.channels.startup.get_container",
+            return_value=MagicMock(event_bus=bus),
+        ),
+        patch.dict(
+            "sys.modules",
+            {
+                "multi_bot_manager": MagicMock(multi_bot_manager=tg_mgr),
+                "whatsapp_manager": MagicMock(whatsapp_manager=wa_mgr),
+            },
+        ),
+    ):
+        await watch_bot_processes()
+
+    assert len(events) == 1
+    assert events[0].channel == "telegram"
+    assert events[0].instance_id == "42"
+    assert events[0].exit_code == 1
+    assert events[0].uptime_seconds == 300
+    assert "42" not in tg_mgr._processes
+
+
+async def test_watcher_detects_dead_whatsapp_bot():
+    """Watcher publishes BotProcessDied for a dead WhatsApp process."""
+    dead_proc = _make_proc("7", running=False, returncode=137, uptime=60)
+    tg_mgr = _mock_manager()
+    wa_mgr = _mock_manager({"7": dead_proc})
+
+    events = []
+    bus = EventBus()
+
+    async def capture(e):
+        events.append(e)
+
+    bus.subscribe(BotProcessDied, capture)
+
+    with (
+        patch(
+            "modules.channels.startup.get_container",
+            return_value=MagicMock(event_bus=bus),
+        ),
+        patch.dict(
+            "sys.modules",
+            {
+                "multi_bot_manager": MagicMock(multi_bot_manager=tg_mgr),
+                "whatsapp_manager": MagicMock(whatsapp_manager=wa_mgr),
+            },
+        ),
+    ):
+        await watch_bot_processes()
+
+    assert len(events) == 1
+    assert events[0].channel == "whatsapp"
+    assert events[0].exit_code == 137
+
+
+async def test_watcher_ignores_running_processes():
+    """Watcher does not publish events for running processes."""
+    running_proc = _make_proc("1", running=True)
+    tg_mgr = _mock_manager({"1": running_proc})
+    wa_mgr = _mock_manager()
+
+    events = []
+    bus = EventBus()
+
+    async def capture(e):
+        events.append(e)
+
+    bus.subscribe(BotProcessDied, capture)
+
+    with (
+        patch(
+            "modules.channels.startup.get_container",
+            return_value=MagicMock(event_bus=bus),
+        ),
+        patch.dict(
+            "sys.modules",
+            {
+                "multi_bot_manager": MagicMock(multi_bot_manager=tg_mgr),
+                "whatsapp_manager": MagicMock(whatsapp_manager=wa_mgr),
+            },
+        ),
+    ):
+        await watch_bot_processes()
+
+    assert len(events) == 0
+    assert "1" in tg_mgr._processes
+
+
+async def test_audit_bot_death():
+    """Audit handler logs bot death."""
+    event = BotProcessDied(channel="telegram", instance_id="42", exit_code=1, uptime_seconds=300)
+
+    mock_audit = AsyncMock()
+    with patch("modules.channels.startup.audit_service", mock_audit):
+        await _audit_bot_death(event)
+
+    mock_audit.log.assert_awaited_once()
+    kw = mock_audit.log.call_args[1]
+    assert kw["action"] == "process_died"
+    assert kw["resource"] == "telegram_bot"
+    assert kw["resource_id"] == "42"
+
+
+async def test_auto_restart_skips_graceful_exit():
+    """Auto-restart does nothing when exit_code is 0."""
+    event = BotProcessDied(channel="telegram", instance_id="99", exit_code=0, uptime_seconds=600)
+
+    mock_mgr = MagicMock()
+    mock_mgr.start_bot = AsyncMock()
+    _restart_counts.clear()
+
+    with patch.dict(
+        "sys.modules",
+        {"multi_bot_manager": MagicMock(multi_bot_manager=mock_mgr)},
+    ):
+        await _auto_restart_bot(event)
+
+    mock_mgr.start_bot.assert_not_awaited()
+
+
+async def test_auto_restart_with_backoff():
+    """Auto-restart calls start_bot after backoff delay."""
+    event = BotProcessDied(channel="telegram", instance_id="10", exit_code=1, uptime_seconds=5)
+
+    mock_mgr = MagicMock()
+    mock_mgr.start_bot = AsyncMock(return_value={"status": "running"})
+    _restart_counts.clear()
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {"multi_bot_manager": MagicMock(multi_bot_manager=mock_mgr)},
+        ),
+        patch("modules.channels.startup.asyncio") as mock_asyncio,
+    ):
+        mock_asyncio.sleep = AsyncMock()
+        await _auto_restart_bot(event)
+
+    mock_asyncio.sleep.assert_awaited_once_with(10)  # first attempt: 10s
+    mock_mgr.start_bot.assert_awaited_once_with("10")
+
+
+async def test_auto_restart_gives_up_after_max():
+    """Auto-restart stops after MAX_RESTARTS consecutive failures."""
+    event = BotProcessDied(channel="whatsapp", instance_id="5", exit_code=1, uptime_seconds=3)
+
+    mock_mgr = MagicMock()
+    mock_mgr.start_bot = AsyncMock()
+    _restart_counts.clear()
+    _restart_counts[("whatsapp", "5")] = _MAX_RESTARTS
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {"whatsapp_manager": MagicMock(whatsapp_manager=mock_mgr)},
+        ),
+        patch("modules.channels.startup.audit_service", AsyncMock()),
+    ):
+        await _auto_restart_bot(event)
+
+    mock_mgr.start_bot.assert_not_awaited()
+
+
+async def test_restart_counter_resets_on_stable_run():
+    """Restart counter resets when uptime > 60s (stable run)."""
+    event = BotProcessDied(channel="telegram", instance_id="10", exit_code=1, uptime_seconds=120)
+
+    mock_mgr = MagicMock()
+    mock_mgr.start_bot = AsyncMock(return_value={"status": "running"})
+    _restart_counts.clear()
+    _restart_counts[("telegram", "10")] = 2
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {"multi_bot_manager": MagicMock(multi_bot_manager=mock_mgr)},
+        ),
+        patch("modules.channels.startup.asyncio") as mock_asyncio,
+    ):
+        mock_asyncio.sleep = AsyncMock()
+        await _auto_restart_bot(event)
+
+    # Counter reset to 0 because uptime > 60, so delay = 10 * (0 + 1) = 10
+    mock_asyncio.sleep.assert_awaited_once_with(10)
+    mock_mgr.start_bot.assert_awaited_once_with("10")
+
+
+async def test_event_subscription_wiring():
+    """setup_channel_event_subscriptions registers BotProcessDied handler."""
+    bus = EventBus()
+    await setup_channel_event_subscriptions(bus)
+
+    assert BotProcessDied in bus._handlers
+    assert len(bus._handlers[BotProcessDied]) == 1
+
+
+async def test_bot_process_died_event_fields():
+    """BotProcessDied has expected fields."""
+    event = BotProcessDied(channel="telegram", instance_id="42", exit_code=1, uptime_seconds=300.5)
+    assert event.channel == "telegram"
+    assert event.instance_id == "42"
+    assert event.exit_code == 1
+    assert event.uptime_seconds == 300.5
+    assert event.timestamp > 0


### PR DESCRIPTION
## Summary
- Add `BotProcessDied` event in `modules/channels/events.py` — shared across Telegram/WhatsApp
- Add periodic `bot-process-watcher` task (30s interval via TaskRegistry) that detects dead bot subprocesses and publishes events
- Two EventBus subscribers: audit logging (via `AuditService`) and auto-restart with backoff (max 3 retries, 10/20/30s delays)
- Graceful exits (code=0) are logged but not restarted; restart counter resets after stable run (>60s uptime)
- 10 unit tests covering: dead process detection (telegram + whatsapp), running process ignored, audit logging, graceful exit skip, backoff delay, max restart limit, counter reset, subscription wiring, event fields

## Test plan
- [x] All 10 new tests pass (`pytest tests/unit/test_bot_process_watcher.py`)
- [x] All 97 unit tests pass (no regressions)
- [ ] CI checks (lint-backend, lint-frontend, security)

Closes #621

🤖 Generated with [Claude Code](https://claude.ai/claude-code)