### PR TITLE
fix: switch web search to ddgs for reliable results

### DIFF
--- a/modules/search/service.py
+++ b/modules/search/service.py
@@ -1,17 +1,22 @@
-"""Web search service using DuckDuckGo."""
+"""Web search service using DuckDuckGo (ddgs package)."""
 
 import logging
 
 
 logger = logging.getLogger(__name__)
 
+DDGS_AVAILABLE = False
 try:
-    from duckduckgo_search import DDGS
+    from ddgs import DDGS
 
     DDGS_AVAILABLE = True
 except ImportError:
-    DDGS_AVAILABLE = False
-    logger.warning("duckduckgo-search not installed, web search unavailable")
+    try:
+        from duckduckgo_search import DDGS
+
+        DDGS_AVAILABLE = True
+    except ImportError:
+        logger.warning("ddgs/duckduckgo-search not installed, web search unavailable")
 
 
 class WebSearchService:
@@ -26,12 +31,9 @@ class WebSearchService:
         max_results: int = 5,
         region: str = "ru-ru",
     ) -> str:
-        """Search the web and return formatted results.
-
-        Returns a text block suitable for injection into LLM context.
-        """
+        """Search the web and return formatted results."""
         if not self.available:
-            return "Web search is not available (duckduckgo-search not installed)."
+            return "Web search is not available (ddgs not installed)."
 
         try:
             with DDGS() as ddgs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,4 +65,4 @@ pytesseract>=0.3.10
 
 # Docker management (for starting vLLM from container)
 docker>=7.0.0
-duckduckgo-search>=8.0
+ddgs>=6.0


### PR DESCRIPTION
## Summary
- Replaced `duckduckgo-search` with `ddgs` package (maintained fork, same API)
- `duckduckgo-search` was returning spam/irrelevant results
- Fallback import: tries `ddgs` first, then `duckduckgo-search`

## Test plan
- [ ] Search "пивные лавки Екатеринбург" — returns real addresses from 2GIS/Zoon

🤖 Generated with [Claude Code](https://claude.com/claude-code)