### PR TITLE
fix: bridge RAG tools + panel height for non-admins

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -2759,7 +2759,7 @@ class="w-4 h-4 rounded border flex items-center justify-center shrink-0"
       </div>
 
       <!-- Compact input when panels open and no session selected -->
-      <div v-else-if="isChatOnly && !currentSessionId && (showBranchTree || showSettings)" class="flex-1 flex items-center justify-center px-4">
+      <div v-else-if="isChatOnly && !currentSessionId && (showBranchTree || showSettings)" class="shrink-0 flex items-center justify-center px-4 py-3">
         <div class="w-full max-w-md">
           <div class="flex items-end gap-2">
             <textarea

--- a/cloud_llm_service.py
+++ b/cloud_llm_service.py
@@ -190,6 +190,12 @@ class OpenAICompatibleProvider(BaseLLMProvider):
     def __init__(self, config: dict):
         super().__init__(config)
 
+        # Bridge CLI runs with --tools "" (no tool access), so tool calls
+        # are silently ignored. Disable supports_tools to fall back to
+        # one-shot RAG injection instead of agentic loop.
+        if self.provider_type == "claude_bridge":
+            self.supports_tools = False
+
         # Bridge runs on localhost — must bypass global VLESS/HTTP proxy.
         # GeminiProvider sets HTTP_PROXY globally for xray; httpx picks it up
         # and routes localhost requests through the proxy, which fails.


### PR DESCRIPTION
## Summary
- **claude_bridge**: `supports_tools=False` — bridge CLI runs with `--tools ""` so tool calls are ignored. Now falls back to one-shot RAG injection (context in system prompt) instead of agentic loop
- **ChatView**: compact input for chat-only users uses `shrink-0` instead of `flex-1`, so sliding panels (branch tree, settings) take full vertical height

## NEWS

📚 **Исправлена база знаний для Claude Bridge**

Ассистент через Claude Bridge теперь корректно использует базу знаний —
контекст подставляется напрямую в промпт вместо попытки вызова
инструментов. Также исправлена высота боковых панелей у обычных
пользователей — теперь занимают весь экран как у админа.

## Test plan
- [ ] Chat with claude_bridge + RAG collection — should inject context, no "инструмент недоступен" error
- [ ] Non-admin user: open branch tree/settings panel — should be full height, not 50%
- [ ] Admin user: panels unchanged (still full height)

🤖 Generated with [Claude Code](https://claude.com/claude-code)