### PR TITLE
fix: telegram register_user fails for users with no chat session

### DIFF
--- a/modules/channels/telegram/service.py
+++ b/modules/channels/telegram/service.py
@@ -182,25 +182,23 @@ class TelegramSessionService:
         last_name: Optional[str] = None,
     ) -> None:
         """Register a Telegram user for a bot (without chat session)."""
-        async with AsyncSessionLocal() as session:
-            repo = TelegramRepository(session, bot_id=bot_id)
-            existing = await repo.get_session(user_id, bot_id=bot_id)
-            if existing:
-                # Update user info
-                from sqlalchemy import select
+        from sqlalchemy import select
 
-                result = await session.execute(
-                    select(TelegramSession).where(
-                        TelegramSession.bot_id == bot_id,
-                        TelegramSession.user_id == user_id,
-                    )
+        async with AsyncSessionLocal() as session:
+            # Look up the ORM object directly (not chat_session_id which can be None)
+            result = await session.execute(
+                select(TelegramSession).where(
+                    TelegramSession.bot_id == bot_id,
+                    TelegramSession.user_id == user_id,
                 )
-                ts = result.scalar_one_or_none()
-                if ts:
-                    ts.username = username
-                    ts.first_name = first_name
-                    ts.last_name = last_name
-                    ts.updated = datetime.utcnow()
+            )
+            ts = result.scalar_one_or_none()
+
+            if ts:
+                ts.username = username
+                ts.first_name = first_name
+                ts.last_name = last_name
+                ts.updated = datetime.utcnow()
             else:
                 ts = TelegramSession(
                     bot_id=bot_id,


### PR DESCRIPTION
## Summary

- **Telegram bot "empty response" bug**: `register_user` used `repo.get_session()` which returns `chat_session_id` — `None` for users without a linked chat session. This caused the code to attempt INSERT on an existing user → UNIQUE constraint → PendingRollbackError → 500
- **Fix**: Query `TelegramSession` ORM object directly to correctly distinguish "user not found" from "user exists with no chat session"
- **Widget CORS fix** (DB-only, not in code): added `bizzio.ru` to widget instance `allowed_domains` — preflight was returning 400

## NEWS

🔧 **Исправлена ошибка Telegram-бота "empty response"**

Бот переставал отвечать пользователям, которые уже были зарегистрированы, но не имели привязанной чат-сессии. Теперь регистрация корректно обновляет данные существующих пользователей вместо попытки создать дубликат.

## Test plan

- [x] `register_user` for existing user with `chat_session_id=None` → 200 (was 500)
- [x] Widget CORS preflight from `https://bizzio.ru` → 200 (was 400)
- [x] Server health check passing
- [x] Both Telegram bots auto-started successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)