### PR TITLE
fix: handle empty HTML in tax parser

### DIFF
--- a/tax_data/02_parse_to_markdown.py
+++ b/tax_data/02_parse_to_markdown.py
@@ -58,7 +58,14 @@ def parse_html_to_markdown(filepath: Path) -> dict | None:
         log.warning("Cannot read %s: %s", filepath.name, e)
         return None
 
-    tree = lxml_html.fromstring(raw)
+    if not raw.strip():
+        return None
+
+    try:
+        tree = lxml_html.fromstring(raw)
+    except Exception as e:
+        log.warning("Cannot parse HTML %s: %s", filepath.name, e)
+        return None
 
     # Extract title
     title_el = tree.xpath("//title/text()")


### PR DESCRIPTION
## Summary
- Skip empty HTML files instead of crashing on `lxml.ParserError: Document is empty`

## Test plan
- [x] Local parser runs without crash on 1204 HTML + 1220 PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)