### PR TITLE
chore: gitignore scraped irish-tax data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ tax_data/datasets/
 tax_data/sitemap.xml
 tax_data/sitemap_urls.json
 tax_data/.venv/
+
+# Wiki RAG scraped data (large, not code)
+wiki-pages/irish-tax/


### PR DESCRIPTION
## Summary
- Add `wiki-pages/irish-tax/` to `.gitignore` (2417 scraped markdown files, not code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)