### PR TITLE
fix(mobile): fully reload session on branch switch/new

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.shaerware.aisecretary"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 3
+        versionName "1.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/mobile/src/views/ChatView.vue
+++ b/mobile/src/views/ChatView.vue
@@ -245,13 +245,8 @@ function toggleBranches() {
 
 async function switchBranch(messageId: string) {
   try {
-    const data = await chatApi.switchBranch(sessionId.value, messageId);
-    if (data.session) {
-      messages.value = data.session.messages.filter(
-        (m) => m.is_active !== false,
-      );
-      title.value = data.session.title || "Chat";
-    }
+    await chatApi.switchBranch(sessionId.value, messageId);
+    await loadSession();
     await loadBranches();
     await scrollToBottom();
   } catch (e) {
@@ -261,12 +256,8 @@ async function switchBranch(messageId: string) {
 
 async function createNewBranch() {
   try {
-    const data = await chatApi.newBranch(sessionId.value);
-    if (data.session) {
-      messages.value = data.session.messages.filter(
-        (m) => m.is_active !== false,
-      );
-    }
+    await chatApi.newBranch(sessionId.value);
+    await loadSession();
     if (showBranches.value) await loadBranches();
     await scrollToBottom();
   } catch (e) {


### PR DESCRIPTION
## Summary

- `switchBranch()` and `createNewBranch()` in [mobile/src/views/ChatView.vue](mobile/src/views/ChatView.vue) now call `loadSession()` instead of swapping `messages.value` directly from the endpoint response
- Fixes cases where tapping a branch in the tree didn't visibly switch: context files / system prompt / web_search_enabled weren't refreshed, and Vue reactivity occasionally reused DOM for overlapping message ids
- Bumps Android `versionName` to `1.3` / `versionCode 3`

## NEWS

🌿 **Переключение веток в мобильном приложении починено**

Раньше тап по ветке в дереве диалогов иногда ничего не менял — приложение подгружало только часть данных, и старая переписка оставалась на экране. Теперь при переключении ветки подтягивается вся сессия целиком, как в веб-версии: история, файлы контекста и системный промпт обновляются за один шаг.

## Test plan

- [ ] `cd mobile && npm run build && npx cap sync android && (cd android && ./gradlew assembleDebug)` succeeds
- [ ] On device: open a chat with ≥2 branches, tap a non-active branch in the tree — messages, context files and system prompt update
- [ ] Tap `+` (new branch) in toolbar — empty branch loads, previous branch still reachable via tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)