### PR TITLE
feat(chat): recursive expand of branch subtree on toggle

### DIFF
--- a/admin/src/components/BranchTree.vue
+++ b/admin/src/components/BranchTree.vue
@@ -23,6 +23,48 @@ const { t } = useI18n()
 
 const deleteMode = ref(false)
 const selectedForDelete = ref(new Set<string>())
+const collapsedNodes = ref(new Set<string>())
+
+function collectDescendantIds(node: BranchNode, out: string[]) {
+  out.push(node.id)
+  if (node.children?.length) {
+    for (const c of node.children) collectDescendantIds(c, out)
+  }
+}
+
+function collectAllIds(nodes: BranchNode[], out: Set<string>) {
+  for (const n of nodes) {
+    out.add(n.id)
+    if (n.children?.length) collectAllIds(n.children, out)
+  }
+}
+
+// Whenever branches change, collapse any new nodes by default
+watch(
+  () => props.branches,
+  (roots) => {
+    const next = new Set(collapsedNodes.value)
+    collectAllIds(roots, next)
+    collapsedNodes.value = next
+  },
+  { immediate: true, deep: true },
+)
+
+function toggleCollapse(messageId: string) {
+  const entry = nodeMap.value[messageId]
+  if (!entry) return
+  const next = new Set(collapsedNodes.value)
+  const ids: string[] = []
+  collectDescendantIds(entry.node, ids)
+  if (next.has(messageId)) {
+    // Expand subtree: remove self + all descendants
+    for (const d of ids) next.delete(d)
+  } else {
+    // Collapse subtree: add self + all descendants
+    for (const d of ids) next.add(d)
+  }
+  collapsedNodes.value = next
+}
 
 // ── nodeMap: quick lookup by id → { node, parentId } ──
 interface NodeEntry {
@@ -254,10 +296,12 @@ onUnmounted(() => {
           :depth="0"
           :delete-mode="deleteMode"
           :selected-for-delete="selectedForDelete"
+          :collapsed-nodes="collapsedNodes"
           @click-node="handleClick"
           @scroll-to="handleScrollTo"
           @delete-node="handleDeleteNode"
           @toggle-select="toggleSelect"
+          @toggle-collapse="toggleCollapse"
         />
       </div>
     </div>

--- a/admin/src/components/BranchTreeNode.vue
+++ b/admin/src/components/BranchTreeNode.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed } from 'vue'
 import { ChevronRight, ChevronDown, User, Bot, Settings, Trash2 } from 'lucide-vue-next'
 import type { BranchNode } from '@/api/chat'
 
@@ -8,6 +8,7 @@ const props = defineProps<{
   depth: number
   deleteMode: boolean
   selectedForDelete: Set<string>
+  collapsedNodes: Set<string>
 }>()
 
 const emit = defineEmits<{
@@ -15,9 +16,10 @@ const emit = defineEmits<{
   'scroll-to': [messageId: string]
   'delete-node': [messageId: string]
   'toggle-select': [messageId: string]
+  'toggle-collapse': [messageId: string]
 }>()
 
-const collapsed = ref(true)
+const collapsed = computed(() => props.collapsedNodes.has(props.node.id))
 
 const maxVisualDepth = 8
 const visualDepth = Math.min(props.depth, maxVisualDepth)
@@ -41,7 +43,7 @@ function onClick() {
 
 function toggleCollapse(e: Event) {
   e.stopPropagation()
-  collapsed.value = !collapsed.value
+  emit('toggle-collapse', props.node.id)
 }
 
 function onDeleteNode(e: Event) {
@@ -63,6 +65,10 @@ function onChildDeleteNode(messageId: string) {
 
 function onChildToggleSelect(messageId: string) {
   emit('toggle-select', messageId)
+}
+
+function onChildToggleCollapse(messageId: string) {
+  emit('toggle-collapse', messageId)
 }
 </script>
 
@@ -177,10 +183,12 @@ function onChildToggleSelect(messageId: string) {
           :depth="hasBranches ? depth + 1 : depth"
           :delete-mode="deleteMode"
           :selected-for-delete="selectedForDelete"
+          :collapsed-nodes="collapsedNodes"
           @click-node="onChildClick"
           @scroll-to="onChildScrollTo"
           @delete-node="onChildDeleteNode"
           @toggle-select="onChildToggleSelect"
+          @toggle-collapse="onChildToggleCollapse"
         />
       </div>
     </div>

--- a/mobile/src/views/ChatView.vue
+++ b/mobile/src/views/ChatView.vue
@@ -289,10 +289,37 @@ async function deleteBranch() {
 
 const expandedBranchNodes = ref<Set<string>>(new Set());
 
+function findBranchNode(nodes: BranchNode[], id: string): BranchNode | null {
+  for (const n of nodes) {
+    if (n.id === id) return n;
+    if (n.children?.length) {
+      const found = findBranchNode(n.children, id);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function collectDescendantIds(node: BranchNode, out: string[]) {
+  out.push(node.id);
+  if (node.children?.length) {
+    for (const c of node.children) collectDescendantIds(c, out);
+  }
+}
+
 function toggleBranchNode(id: string) {
   const next = new Set(expandedBranchNodes.value);
-  if (next.has(id)) next.delete(id);
-  else next.add(id);
+  const node = findBranchNode(branches.value, id);
+  if (!node) return;
+  const ids: string[] = [];
+  collectDescendantIds(node, ids);
+  if (next.has(id)) {
+    // Collapse: remove self + all descendants
+    for (const d of ids) next.delete(d);
+  } else {
+    // Expand: add self + all descendants so the whole subtree is visible
+    for (const d of ids) next.add(d);
+  }
   expandedBranchNodes.value = next;
 }
 


### PR DESCRIPTION
## Summary

- **Admin**: lifted `collapsed` state from `BranchTreeNode` into `BranchTree` as a shared `Set<string>`. Toggle walks descendants via `collectDescendantIds` and adds/removes the whole subtree at once. New branches default to collapsed.
- **Mobile**: `toggleBranchNode` uses `findBranchNode` + `collectDescendantIds` to fold/unfold the full subtree in one tap.

## NEWS

🌲 **Ветка в чате раскрывается целиком одним кликом**

Раньше пришлось щёлкать по каждому уровню отдельно, чтобы добраться до нужного сообщения. Теперь один тап на свёрнутую ветку показывает весь её диалог — все вопросы и ответы разом. Повторный тап сворачивает всё обратно.

## Test plan

- [ ] Web: open a chat with nested branches, tap chevron on a collapsed root — whole subtree becomes visible, not just the next level
- [ ] Tap again — entire subtree folds back
- [ ] Clicking the label (not the chevron) still switches the active branch
- [ ] Mobile: same behaviour in Android app

🤖 Generated with [Claude Code](https://claude.com/claude-code)