### PR TITLE
feat(login): pill Android APK download button

### DIFF
--- a/admin/src/views/LoginView.vue
+++ b/admin/src/views/LoginView.vue
@@ -315,6 +315,23 @@ async function handleSubmit() {
               </svg>
             </a>
           </div>
+
+          <!-- Android APK download -->
+          <div class="mt-4 flex justify-center">
+            <a
+              href="https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.3/ai-secretary-1.3.apk"
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Скачать Android-приложение AI-Секретарь"
+              class="group inline-flex items-center gap-2.5 rounded-full px-5 py-2.5 bg-gradient-to-r from-orange-600 via-amber-500 to-orange-600 bg-[length:200%_100%] bg-left hover:bg-right text-white text-sm font-semibold shadow-lg shadow-orange-900/30 ring-1 ring-orange-400/30 hover:ring-orange-300/60 hover:shadow-orange-700/50 hover:-translate-y-0.5 active:translate-y-0 transition-all duration-500"
+            >
+              <svg class="w-4 h-4 transition-transform group-hover:-translate-y-0.5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M17.523 15.341c-.5866 0-1.0615-.4751-1.0615-1.0613 0-.5862.4749-1.0614 1.0615-1.0614.5864 0 1.0613.4752 1.0613 1.0614 0 .5862-.4749 1.0613-1.0613 1.0613m-11.0456 0c-.5868 0-1.0616-.4751-1.0616-1.0613 0-.5862.4748-1.0614 1.0616-1.0614.5863 0 1.0612.4752 1.0612 1.0614 0 .5862-.4749 1.0613-1.0612 1.0613m11.4264-6.0201 2.1195-3.6713a.4413.4413 0 0 0-.1616-.6025.4415.4415 0 0 0-.6024.1616l-2.1465 3.7185C15.4732 8.1637 13.7923 7.7999 12 7.7999c-1.7922 0-3.4732.3638-4.9924 1.0232L4.8611 5.1046a.441.441 0 0 0-.6023-.1616.4413.4413 0 0 0-.1616.6025l2.1195 3.6713C2.574 10.9842.3949 14.3505 0 18.413h24c-.3949-4.0625-2.5734-7.4288-6.2548-9.4991" />
+              </svg>
+              <span>Скачать Android-приложение</span>
+              <span class="text-[10px] font-bold uppercase tracking-wide bg-white/20 rounded-full px-1.5 py-0.5">v1.3</span>
+            </a>
+          </div>
         </div>
 
         <!-- About toggle -->


### PR DESCRIPTION
## Summary

Adds a gradient-orange pill button under the GitHub / Website / Telegram icon row on the login page linking to the `ai-secretary-1.3.apk` asset of the [mobile-v1.3](https://github.com/ShaerWare/AI_Secretary_System/releases/tag/mobile-v1.3) release. Background-position shimmer on hover, lift transform, and a version badge.

## NEWS

📲 **Android-приложение можно скачать прямо с экрана входа**

На странице входа админки появилась красивая оранжевая кнопка «Скачать Android-приложение» — клик ведёт на GitHub-релиз с последним APK. Больше не нужно искать ссылку в README или Telegram — всё под рукой там же, где логинитесь.

## Test plan

- [ ] Open `/admin/login`, verify pill button renders under the icon row
- [ ] Hover shows shimmer gradient + lift
- [ ] Click downloads the APK asset from GitHub releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)