### PR TITLE
fix(deploy): include devDependencies in npm ci and increase health check timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /build
 
 # Copy package files first for better caching
 COPY admin/package*.json ./
-RUN npm ci --silent
+RUN npm ci --include=dev --silent
 
 # Copy source and build
 COPY admin/ ./

--- a/deploy.sh
+++ b/deploy.sh
@@ -48,7 +48,7 @@ log "Installing bridge dependencies..."
 # Install/update npm deps
 log "Installing npm dependencies..."
 cd "$REPO_DIR/admin"
-npm ci --silent 2>&1 | tee -a "$LOG_FILE"
+npm ci --include=dev --silent 2>&1 | tee -a "$LOG_FILE"
 
 # Ensure .env.production.local exists (base path override)
 if [ ! -f "$REPO_DIR/admin/.env.production.local" ]; then
@@ -76,8 +76,8 @@ rsync -a --delete "$REPO_DIR/admin/dist/" /var/www/admin-ai-sekretar24/
 log "Restarting orchestrator..."
 systemctl restart ai-secretary 2>&1 | tee -a "$LOG_FILE"
 
-# Wait and verify
-sleep 5
+# Wait and verify (orchestrator needs time to initialize services)
+sleep 20
 if curl -sf http://localhost:8002/health > /dev/null 2>&1; then
     log "=== Deploy completed successfully ==="
 else


### PR DESCRIPTION
## Summary
- **`npm ci --include=dev`** in `deploy.sh` and `Dockerfile` — ensures `vue-tsc` and other build tools are installed even when `NODE_ENV=production`
- **Health check wait 5s → 20s** in `deploy.sh` — gives orchestrator sufficient startup time

## Problem
When `NODE_ENV=production` is set, `npm ci` skips devDependencies. Since `vue-tsc` is in devDependencies but required for `npm run build`, deploy fails with `sh: 1: vue-tsc: not found`.

Fixes #458, fixes #359

## Test plan
- [x] 185 unit tests pass
- [ ] Deploy on server and verify `npm run build` succeeds
- [ ] Verify health check passes after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)