### PR TITLE
feat(mobile): bump to v1.55 + update APK download link

### DIFF
--- a/admin/src/views/LoginView.vue
+++ b/admin/src/views/LoginView.vue
@@ -358,7 +358,7 @@ async function handleSubmit() {
           <!-- Android APK download -->
           <div class="mt-4 flex justify-center">
             <a
-              href="https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.5/ai-secretary-1.5.apk"
+              href="https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.55/ai-secretary-1.55.apk"
               target="_blank"
               rel="noopener noreferrer"
               title="Скачать Android-приложение AI-Секретарь"
@@ -368,7 +368,7 @@ async function handleSubmit() {
                 <path d="M17.523 15.341c-.5866 0-1.0615-.4751-1.0615-1.0613 0-.5862.4749-1.0614 1.0615-1.0614.5864 0 1.0613.4752 1.0613 1.0614 0 .5862-.4749 1.0613-1.0613 1.0613m-11.0456 0c-.5868 0-1.0616-.4751-1.0616-1.0613 0-.5862.4748-1.0614 1.0616-1.0614.5863 0 1.0612.4752 1.0612 1.0614 0 .5862-.4749 1.0613-1.0612 1.0613m11.4264-6.0201 2.1195-3.6713a.4413.4413 0 0 0-.1616-.6025.4415.4415 0 0 0-.6024.1616l-2.1465 3.7185C15.4732 8.1637 13.7923 7.7999 12 7.7999c-1.7922 0-3.4732.3638-4.9924 1.0232L4.8611 5.1046a.441.441 0 0 0-.6023-.1616.4413.4413 0 0 0-.1616.6025l2.1195 3.6713C2.574 10.9842.3949 14.3505 0 18.413h24c-.3949-4.0625-2.5734-7.4288-6.2548-9.4991" />
               </svg>
               <span>Скачать Android-приложение</span>
-              <span class="text-[10px] font-bold uppercase tracking-wide bg-white/20 rounded-full px-1.5 py-0.5">v1.5</span>
+              <span class="text-[10px] font-bold uppercase tracking-wide bg-white/20 rounded-full px-1.5 py-0.5">v1.55</span>
             </a>
           </div>
         </div>

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.shaerware.aisecretary"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 7
-        versionName "1.5"
+        versionCode 8
+        versionName "1.55"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.


### PR DESCRIPTION
## Summary
- Bump Android versionCode 7→8, versionName 1.5→1.55
- Update login page APK download link to `mobile-v1.55` release
- APK already uploaded: https://github.com/ShaerWare/AI_Secretary_System/releases/tag/mobile-v1.55

## NEWS

📱 **Мобильное приложение v1.55**

Обновлённая версия Android-приложения с поиском по веткам диалога и переименованием веток. Скачивайте с кнопки на странице входа.

## Test plan
- [ ] Verify download link on login page points to correct release
- [ ] APK installs and opens on Android device

🤖 Generated with [Claude Code](https://claude.com/claude-code)