### PR TITLE
fix(admin): resizable chat panels stretch fully + auto-collapse at min

### DIFF
--- a/admin/src/composables/useResizablePanel.ts
+++ b/admin/src/composables/useResizablePanel.ts
@@ -1,21 +1,47 @@
 import { ref, onUnmounted } from 'vue'
 
+type MaxWidth = number | (() => number)
+
+interface Options {
+  /** Emitted when user keeps dragging the handle past minWidth — request parent to close the panel. */
+  onCollapse?: () => void
+  /** How many px below minWidth before onCollapse fires (default 40). */
+  collapseThreshold?: number
+}
+
 export function useResizablePanel(
   storageKey: string,
   defaultWidth: number,
   minWidth: number,
-  maxWidth: number,
-  direction: 'right' | 'left' = 'right'
+  maxWidth: MaxWidth,
+  direction: 'right' | 'left' = 'right',
+  options: Options = {}
 ) {
+  const { onCollapse, collapseThreshold = 40 } = options
+
+  function resolveMax(): number {
+    const m = typeof maxWidth === 'function' ? maxWidth() : maxWidth
+    return Math.max(minWidth, m)
+  }
+
   const saved = localStorage.getItem(storageKey)
-  const width = ref(saved ? Math.max(minWidth, Math.min(maxWidth, Number(saved))) : defaultWidth)
+  const width = ref(saved ? Math.max(minWidth, Math.min(resolveMax(), Number(saved))) : defaultWidth)
 
   let startX = 0
   let startW = 0
+  let collapsedMidDrag = false
 
   function applyDelta(clientX: number) {
     const delta = direction === 'right' ? clientX - startX : startX - clientX
-    width.value = Math.max(minWidth, Math.min(maxWidth, startW + delta))
+    const raw = startW + delta
+    const max = resolveMax()
+    // If user drags well below the minimum, request close instead of clamping.
+    if (onCollapse && raw < minWidth - collapseThreshold && !collapsedMidDrag) {
+      collapsedMidDrag = true
+      onCollapse()
+      return
+    }
+    width.value = Math.max(minWidth, Math.min(max, raw))
   }
 
   // Mouse handlers
@@ -35,6 +61,7 @@ export function useResizablePanel(
     e.preventDefault()
     startX = e.clientX
     startW = width.value
+    collapsedMidDrag = false
     document.body.style.cursor = 'col-resize'
     document.body.style.userSelect = 'none'
     document.addEventListener('mousemove', onMouseMove)
@@ -60,10 +87,24 @@ export function useResizablePanel(
     e.preventDefault()
     startX = e.touches[0].clientX
     startW = width.value
+    collapsedMidDrag = false
     document.addEventListener('touchmove', onTouchMove, { passive: false })
     document.addEventListener('touchend', onTouchEnd)
     document.addEventListener('touchcancel', onTouchEnd)
   }
+
+  /** Re-clamp the stored width against the current max (e.g. on window resize). */
+  function clampToBounds() {
+    const max = resolveMax()
+    if (width.value > max) width.value = max
+    if (width.value < minWidth) width.value = minWidth
+  }
+
+  // Listen to window resize so maxWidth functions update live
+  function onWindowResize() {
+    clampToBounds()
+  }
+  window.addEventListener('resize', onWindowResize)
 
   onUnmounted(() => {
     document.removeEventListener('mousemove', onMouseMove)
@@ -71,7 +112,8 @@ export function useResizablePanel(
     document.removeEventListener('touchmove', onTouchMove)
     document.removeEventListener('touchend', onTouchEnd)
     document.removeEventListener('touchcancel', onTouchEnd)
+    window.removeEventListener('resize', onWindowResize)
   })
 
-  return { width, startResize, startTouchResize }
+  return { width, startResize, startTouchResize, clampToBounds }
 }

--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -192,11 +192,38 @@ const inputPosition = ref<'top' | 'bottom'>(
 const { collapsed: sidebarCollapsed, toggle: toggleSidebarCollapse } = useSidebarCollapse('chat-sidebar-collapsed')
 
 // Resizable panels
-const { width: sidebarWidth, startResize: startSidebarResize, startTouchResize: startSidebarTouchResize } = useResizablePanel('chat-sidebar-width', 288, 200, 480, 'right')
-const { width: branchTreeWidth, startResize: startBranchResize, startTouchResize: startBranchTouchResize } = useResizablePanel('chat-branch-width', 208, 160, 400, 'left')
-const { width: settingsWidth, startResize: startSettingsResize, startTouchResize: startSettingsTouchResize } = useResizablePanel('chat-settings-width', 500, 300, 800, 'left')
-const { width: artifactWidth, startResize: startArtifactResize, startTouchResize: startArtifactTouchResize } = useResizablePanel('chat-artifact-width', 500, 300, 800, 'left')
-const { width: ccPanelWidth, startResize: startCcPanelResize, startTouchResize: startCcPanelTouchResize } = useResizablePanel('chat-cc-panel-width', 320, 220, 500, 'left')
+// Right-side panels use a dynamic max = available window width minus the sidebar
+// and a small reserve (~400px) for the messages pane. The onCollapse callback
+// closes the panel when the user keeps dragging past minWidth.
+const MESSAGES_MIN_RESERVE = 380
+
+function rightPanelMax(): number {
+  // Account for the sidebar taking ~sidebarWidth; fall back to 600 if unknown yet.
+  const side = typeof sidebarWidth !== 'undefined' ? sidebarWidth.value : 288
+  return Math.max(320, window.innerWidth - side - MESSAGES_MIN_RESERVE)
+}
+
+const { width: sidebarWidth, startResize: startSidebarResize, startTouchResize: startSidebarTouchResize } = useResizablePanel(
+  'chat-sidebar-width', 288, 200,
+  () => Math.max(240, Math.floor(window.innerWidth * 0.5)),
+  'right',
+)
+const { width: branchTreeWidth, startResize: startBranchResize, startTouchResize: startBranchTouchResize } = useResizablePanel(
+  'chat-branch-width', 208, 160, rightPanelMax, 'left',
+  { onCollapse: () => { showBranchTree.value = false } },
+)
+const { width: settingsWidth, startResize: startSettingsResize, startTouchResize: startSettingsTouchResize } = useResizablePanel(
+  'chat-settings-width', 500, 300, rightPanelMax, 'left',
+  { onCollapse: () => { showSettings.value = false } },
+)
+const { width: artifactWidth, startResize: startArtifactResize, startTouchResize: startArtifactTouchResize } = useResizablePanel(
+  'chat-artifact-width', 500, 300, rightPanelMax, 'left',
+  { onCollapse: () => { closeArtifact() } },
+)
+const { width: ccPanelWidth, startResize: startCcPanelResize, startTouchResize: startCcPanelTouchResize } = useResizablePanel(
+  'chat-cc-panel-width', 320, 220, rightPanelMax, 'left',
+  { onCollapse: () => { showCcPanel.value = false } },
+)
 
 // Pasted content blocks
 const pastedBlocks = ref<PastedBlock[]>([])


### PR DESCRIPTION
## Summary
- Правые панели (BranchTree, Settings, Artifact, CC Orchestra) теперь растягиваются на всю доступную ширину, оставляя ≥380px для области сообщений.
- При сжатии ресайз-хэндла ниже minWidth-40px панель автоматически закрывается.
- \`useResizablePanel\` принимает \`maxWidth\` как число или \`() => number\` и сам слушает \`resize\` окна.

## Test plan
- [ ] Растянуть BranchTree до правого края — он занимает всю ширину минус сайдбар и minReserve
- [ ] Сжать BranchTree резким движением влево — панель закрывается
- [ ] Изменить размер окна браузера — панель не становится шире нового предела