### PR TITLE
fix(knowledge): vector search sync covers all enabled collections

### DIFF
--- a/modules/knowledge/tasks.py
+++ b/modules/knowledge/tasks.py
@@ -54,16 +54,34 @@ async def sync_vector_search(wiki_rag: WikiRAGService, vs_client: VectorSearchCl
         logger.warning("Vector Search: service unavailable, skipping sync")
         return
 
+    collections = await async_knowledge_collection_manager.get_all(enabled_only=True)
+
+    # Ensure per-collection BM25 indexes are loaded. The background task
+    # registry starts this sync in parallel with `wiki-collection-indexes`,
+    # so when sync runs first (or the manual endpoint is called before
+    # collections were hot) `_collection_indexes` is empty and each
+    # sync_collection_to_vector_search would return 0 — only the global
+    # default collection would reach Vector Search. Load whatever is missing.
+    missing = [col for col in collections if col["id"] not in wiki_rag._collection_indexes]
+    if missing:
+        logger.info("Vector Search sync: loading %d missing collection indexes first", len(missing))
+        for col in missing:
+            filenames = await async_knowledge_collection_manager.get_document_filenames(col["id"])
+            if not filenames:
+                continue
+            base_dir = Path(col.get("base_dir", "wiki-pages"))
+            await asyncio.to_thread(wiki_rag.load_collection, col["id"], filenames, base_dir)
+
     total_upserted = 0
 
     # Sync per-collection indexes
-    collections = await async_knowledge_collection_manager.get_all(enabled_only=True)
     for col in collections:
         slug = col.get("slug", str(col["id"]))
         count = await sync_collection_to_vector_search(wiki_rag, vs_client, col["id"], slug)
         total_upserted += count
 
-    # Sync global index
+    # Sync global index (legacy "default" group — kept for back-compat with
+    # widgets/bots querying without a collection filter).
     for section in wiki_rag.sections:
         text = f"{section.title}\n{section.body}"
         await vs_client.upsert(


### PR DESCRIPTION
## Summary

Background task registry starts \`vector-search-sync\` in parallel with \`wiki-collection-indexes\` (both via \`asyncio.create_task\` in \`TaskRegistry.start_all\`). When sync wins the race, \`wiki_rag._collection_indexes\` is empty — \`sync_collection_to_vector_search\` returns 0 for every collection, and only the global \`wiki_rag.sections\` loop reaches ChromaDB (the default collection, 902 sections).

Observed on prod:
- 12 enabled collections, ~109k sections total (WooCommerce alone = 94350).
- 4 manual \`/vector-search/sync\` runs today, log line every time: \`✅ Vector Search sync: 902 sections upserted\`. No per-collection \`Vector Search: synced N sections for collection X\` lines — confirming every collection returned 0.

## Fix

In \`sync_vector_search\`, before iterating, preload any collections missing from \`wiki_rag._collection_indexes\` via the existing \`wiki_rag.load_collection\` (same work as the parallel \`wiki-collection-indexes\` task). Idempotent and cheap on re-runs.

## Impact

- No schema change, no reindex required.
- First run after deploy upserts ~108k additional sections (amoCRM, WooCommerce, BIZZIO, Irish tax + accountancy bundle, Boards.ie, CashSnapp). Takes ~90 minutes at the current ~30 upsert/min rate — will run in background.
- Existing 902 default-collection vectors stay (upsert is idempotent by doc_id).

## Test plan

- [ ] After deploy, \`journalctl -u ai-secretary | grep "synced.*sections for collection"\` shows one line per collection with counts matching BM25 totals.
- [ ] Final \`✅ Vector Search sync:\` log reports total > 100k (not 902).
- [ ] Chat with \`rag_mode=collection\` + \`knowledge_collection_ids=[6]\` (WooCommerce) hits vector search and returns product hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)