### PR TITLE
fix(digitax-scraper): repair cpa-ireland, accountant-forums, icaew-ireland parsers

### DIFF
--- a/scripts/scrape_digitax/config.py
+++ b/scripts/scrape_digitax/config.py
@@ -106,8 +106,31 @@ SITES = {
     "icaew-ireland": {
         "name": "ICAEW Ireland Standards",
         "base_url": "https://www.icaew.com",
-        "seed_paths": ["/technical/by-country/europe/ireland"],
-        "stay_under": "/technical/by-country/europe/ireland",
+        "seed_paths": [
+            "/technical/by-country/europe/ireland",
+            "/technical/by-country/europe/ireland/accounting-in-ireland",
+            "/technical/by-country/europe/ireland/doing-business-in-ireland",
+            "/technical/by-country/europe/ireland/tax-in-ireland",
+            "/library/subject-gateways/tax-and-duty/country-tax-guides/ireland",
+            "/library/doing-business-in/ireland",
+            "/insights/tax-news/ireland",
+            "/regulation-and-working-in-the-profession/regulations/tax",
+        ],
+        # Previous `stay_under=/technical/by-country/europe/ireland` produced
+        # only 3 pages because that subsection is tiny. Broaden to allow the
+        # crawler to follow outgoing ICAEW links from the Ireland seeds,
+        # relying on Ireland-keyword filtering (below) + the generic filter
+        # to avoid drifting onto unrelated countries.
+        "stay_under": "/",
+        "ireland_filter": True,
+        "ireland_keywords": [
+            "ireland",
+            "irish",
+            "dublin",
+            "revenue.ie",
+            "cai",
+            "cro",
+        ],
         "max_pages": 200,
         "type": "standards",
         "description": (

--- a/scripts/scrape_digitax/parse.py
+++ b/scripts/scrape_digitax/parse.py
@@ -125,10 +125,25 @@ def strip_boilerplate(tree, slug: str = ""):
             if parent is not None:
                 parent.remove(bad)
 
-    # CPA-specific: remove login forms
+    # CPA-specific: remove login forms + Kentico chrome (header, search
+    # modal, cookie bar, breadcrumbs, banners, hidden aspnet fields, scripts).
+    # The page is one big <form id="form">, so without this strip the parser
+    # was picking up navigation menus as "content".
     if slug == "cpa-ireland":
         for bad in tree.xpath(
-            './/form[contains(@action, "login")]| .//*[contains(@class, "login")]'
+            './/form[contains(@action, "login")]'
+            '| .//*[contains(@class, "login")]'
+            '| .//*[contains(@class, "header__wrapper")]'
+            '| .//*[contains(@class, "search_modal")]'
+            '| .//*[contains(@class, "aspNetHidden")]'
+            '| .//*[contains(@class, "cookie_bar")]'
+            '| .//*[contains(@class, "m16_breadcrumbs")]'
+            '| .//*[contains(@class, "m01_banner")]'
+            "| .//header"
+            "| .//footer"
+            "| .//input"
+            "| .//script"
+            "| .//noscript"
         ):
             parent = bad.getparent()
             if parent is not None:
@@ -267,8 +282,14 @@ CONTENT_SELECTORS = {
         "//body",
     ],
     "cpa-ireland": [
+        # The site is ASP.NET Web Forms / Kentico; there is no <main> or
+        # <article>, everything lives inside <form id="form">. Old selectors
+        # (content-wysiwyg, m07_three_col) no longer match — the site was
+        # redesigned and the content is now in Kentico-generated divs with
+        # dynamic IDs like p_lt_WebPartZone*_pageplaceholder_*_m02div.
+        # Using the form as root + strip_boilerplate gives us the real page.
+        '//form[@id="form"]',
         '//div[contains(@class, "content-wysiwyg")]',
-        '//div[contains(@class, "grid-container mb")]',
         '//div[contains(@class, "m07_three_col")]',
         "//main",
         "//article",
@@ -340,12 +361,23 @@ def extract_title(tree, slug: str) -> str:
 
 def _clean_forum_post(text: str) -> str:
     """Remove common forum noise from post body text."""
+    # Tabs → single space (XenForo leaves huge tab runs from column layout)
+    text = text.replace("\t", " ")
     # Remove multi-line whitespace runs (broken HTML extraction)
     text = re.sub(r"(\s*\n){3,}", "\n\n", text)
     # Remove "Registered Users, Registered Users 2 Posts: N,NNN ✭✭✭" etc.
     text = re.sub(r"Registered Users.*?Posts:\s*[\d,]+\s*✭*", "", text)
     # Remove "Join Date: ..." lines
     text = re.sub(r"Join\s*\n?\s*Date:.*", "", text)
+    # XenForo profile boilerplate: "Joined\nJun 8, 2017", "Messages\n42",
+    # "Reaction score\n10", "Location\nDublin" — strip the label + its value.
+    text = re.sub(
+        r"^\s*(Joined|Messages|Reaction score|Location|Likes Received|Trophy Points)\s*\n"
+        r"[^\n]{0,80}\n",
+        "",
+        text,
+        flags=re.MULTILINE,
+    )
     # Remove post numbers "#1", "#23"
     text = re.sub(r"^\s*#\d+\s*$", "", text, flags=re.MULTILINE)
     # Remove "Help Keep Boards Alive" promos
@@ -356,7 +388,21 @@ def _clean_forum_post(text: str) -> str:
     text = re.sub(r"Private Group for paid up members.*", "", text)
     # Remove "please see this major site announcement" blurbs
     text = re.sub(r"please see this major site announcement.*", "", text, flags=re.IGNORECASE)
-    # Collapse whitespace
+    # Accountantforums.com footer/sidebar promos (appear under every post)
+    text = re.sub(
+        r"(What Are the Key Benefits of Payroll Outsourcing\?.*?Started by Mika[^\n]*)",
+        "",
+        text,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    text = re.sub(r"Similar threads.*", "", text, flags=re.IGNORECASE | re.DOTALL)
+    text = re.sub(r"(You must log in|Register a new account).*", "", text, flags=re.IGNORECASE)
+    # Drop isolated single-letter avatar initials on their own line
+    text = re.sub(r"^\s*[A-Z]\s*$", "", text, flags=re.MULTILINE)
+    # Collapse leading whitespace on every line
+    text = re.sub(r"[ \t]+$", "", text, flags=re.MULTILINE)
+    text = re.sub(r"^[ \t]+", "", text, flags=re.MULTILINE)
+    # Collapse blank lines
     text = re.sub(r"\n{3,}", "\n\n", text)
     return text.strip()
 
@@ -478,13 +524,23 @@ def parse_forum_accountant_forums(
     # Check Ireland relevance in title
     combined_text = title.lower()
 
-    # Extract posts
+    # Extract posts. XPath may return nested matches (a message inside a
+    # message container also has class "message"), so dedupe by element id.
     posts = []
+    seen_elements = set()
     for post_el in tree.xpath(
         '//article[contains(@class, "message")]'
         '| //div[contains(@class, "message")]'
         '| //li[contains(@class, "block-row")]'
     ):
+        el_id = id(post_el)
+        if el_id in seen_elements:
+            continue
+        seen_elements.add(el_id)
+        # Also skip if this element contains a nested article.message child
+        # (i.e. this is the outer wrapper, not the leaf post).
+        if post_el.xpath('.//article[contains(@class, "message")]'):
+            continue
         author_els = post_el.xpath(
             './/*[contains(@class, "username")]//text()| .//a[@class="username"]//text()'
         )
@@ -493,16 +549,21 @@ def parse_forum_accountant_forums(
         date_els = post_el.xpath('.//time/@datetime| .//*[contains(@class, "u-dt")]//text()')
         post_date = date_els[0].strip() if date_els else ""
 
+        # Prefer bbWrapper (innermost XenForo message container — just the
+        # user text, no avatar/profile chrome). Fall back to message-body.
         body_els = post_el.xpath(
-            './/*[contains(@class, "message-body")]| .//*[contains(@class, "bbWrapper")]'
+            './/*[contains(@class, "bbWrapper")]| .//*[contains(@class, "message-body")]'
         )
         if body_els:
             strip_boilerplate(body_els[0])
-            lines: list[str] = []
-            extract_text_recursive(body_els[0], lines)
-            body = "\n".join(lines).strip()
+            # XenForo bbWrapper holds free-flowing text separated by <br>,
+            # which extract_text_recursive (paragraph-based) silently drops.
+            # text_content() + _clean_forum_post is the right tool here.
+            body = (body_els[0].text_content() or "").strip()
         else:
             body = (post_el.text_content() or "").strip()
+
+        body = _clean_forum_post(body)
 
         if body and len(body) > 20:
             posts.append({"author": author, "date": post_date, "body": body})

--- a/scripts/scrape_digitax/scrape.py
+++ b/scripts/scrape_digitax/scrape.py
@@ -228,16 +228,32 @@ def filter_accountant_forums(url: str, cfg: dict) -> bool:
 
 
 def extract_links_icaew(url: str, html_text: str, base_url: str) -> list[str]:
-    """Extract links from ICAEW, staying under /technical/by-country/europe/ireland."""
-    links = extract_links_generic(url, html_text, base_url)
-    stay_under = "/technical/by-country/europe/ireland"
-    return [link for link in links if stay_under in urlparse(link).path]
+    """Extract links from ICAEW. Scope is enforced by filter_icaew, which reads
+    `stay_under` and `ireland_keywords` from site config — we pass everything
+    through here and let the filter reject unrelated pages."""
+    return extract_links_generic(url, html_text, base_url)
 
 
 def filter_icaew(url: str, cfg: dict) -> bool:
-    """Stay within Ireland section."""
+    """Stay within Ireland-related content on icaew.com.
+
+    Prefer `ireland_keywords` (matched against URL path) when configured —
+    lets the crawler follow Ireland-relevant pages that live outside the
+    small /technical/by-country/europe/ireland subsection. Fall back to
+    `stay_under` (legacy behaviour) otherwise.
+    """
+    path = urlparse(url).path.lower()
+    # Global skip — avoid obvious junk
+    skip_patterns = ["/login", "/register", "/search", "/media/", "/assets/", "/my-account"]
+    if any(p in path for p in skip_patterns):
+        return False
+
+    ireland_keywords = cfg.get("ireland_keywords")
+    if ireland_keywords:
+        return any(kw in path for kw in ireland_keywords)
+
     stay_under = cfg.get("stay_under", "/technical/by-country/europe/ireland")
-    return stay_under in urlparse(url).path
+    return stay_under in path
 
 
 def filter_professional_site(url: str, cfg: dict) -> bool:


### PR DESCRIPTION
## Summary

Three of the seven Irish accountancy collections from #698 produced almost no usable RAG signal. After thematic vector-search tests on the freshly synced embeddings, they all came back with low similarity and duplicated boilerplate:

- **cpa-ireland** (237 docs, 103 sections) → similarity 0.4–0.5 on every query, all hits pointing at the same navigation titles (About-CPA, Business-Reports). Parser had picked up sidebar menus instead of page body.
- **accountant-forums-ireland** (25 docs, 524 sections) → every document was an identical footer \`"What Are the Key Benefits of Payroll Outsourcing? Started by Mika…"\`. Post bodies came back empty because the text extractor dropped \`<br>\`-separated text.
- **icaew-ireland** (3 docs, 19 sections) → just boilerplate about Terms of use and Deloitte links. Crawler's \`stay_under="/technical/by-country/europe/ireland"\` is a genuinely tiny subsection.

## Fixes

- **parse.py — CPA selectors + boilerplate strip.** CPA Ireland is ASP.NET Web Forms / Kentico: no \`<main>\`, no \`<article>\`, everything lives inside \`<form id="form">\`. Old selectors (\`content-wysiwyg\`, \`m07_three_col\`) stopped matching after a site redesign, so the generic fallback \`//main\`/\`//body\` captured nav chrome. New selector: \`//form[@id="form"]\` first, plus hard-strip of Kentico chrome (\`header__wrapper\`, \`search_modal\`, \`aspNetHidden\`, \`cookie_bar\`, \`m16_breadcrumbs\`, \`m01_banner\`, inputs, scripts). Verified on \`www.cpaireland.ie/Members\` — recovered 93 words of real content where the old parser produced 0.
- **parse.py — accountant-forums post body.** XenForo \`bbWrapper\` holds free-flowing text separated by \`<br>\`. \`extract_text_recursive\` is paragraph-based and silently dropped it, so every post's body came out empty. Switched to \`text_content()\` for forum posts and added cleanup rules for XenForo profile boilerplate (\`Joined / Messages / Reaction score / Location\` label+value pairs) and common footer promos. Also added dedup to avoid counting nested \`<article class="message">\` elements twice. Verified on a sample thread — 10 posts, 2KB of real discussion text about Irish PAYE.
- **config.py + scrape.py — ICAEW scope.** The hard-coded \`/technical/by-country/europe/ireland\` limit yields only 3 pages. Broadened: 8 seed paths covering ICAEW's Ireland-related tax guides / doing-business / library gateway / insights sections. Replaced \`filter_icaew\`'s hard-coded path check with a keyword filter (\`ireland_keywords\`: ireland, irish, dublin, revenue.ie, cai, cro) so the crawler can follow outgoing Ireland-relevant links without drifting to other countries. \`extract_links_icaew\` delegates scoping to the filter.

## Out of scope (next step)

Re-scrape these 3 sites with the fixed pipeline, re-upload to the \`knowledge_documents\` table, and let vector-search-sync (fixed in #708) push fresh embeddings. The 3 collections are already removed from the DigiTax chat session until the rescrape lands. Scrape takes ~1h for CPA + AF, ~15 min for ICAEW.

## Test plan

- [x] Lint clean (ruff format + check)
- [x] CPA parser on \`/Members\` page → 93 words of real content, no nav menus
- [x] AF parser on sample thread → 10 posts, 2016 chars, real PAYE discussion
- [ ] After re-scrape: thematic vector-search queries hit similarity >0.55 in all 3 groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)