### PR TITLE
fix(knowledge): unique doc_id per section in vector-search sync

### DIFF
--- a/modules/knowledge/tasks.py
+++ b/modules/knowledge/tasks.py
@@ -86,7 +86,7 @@ async def sync_vector_search(wiki_rag: WikiRAGService, vs_client: VectorSearchCl
         text = f"{section.title}\n{section.body}"
         await vs_client.upsert(
             text=text,
-            doc_id=section.source_file,
+            doc_id=wiki_rag._section_id(section),
             group="default",
             metadata={"title": section.title, "source_file": section.source_file},
         )
@@ -110,9 +110,14 @@ async def sync_collection_to_vector_search(
     count = 0
     for section in idx.sections:
         text = f"{section.title}\n{section.body}"
+        # `doc_id` must be unique per section. `source_file` collapsed many
+        # sections (e.g. all products in one WooCommerce md file) onto the
+        # same doc_id, and vector-search upsert REPLACES chunks under the
+        # same doc_id — so only the last section per file survived. Reuse
+        # the same hash WikiRAGService uses for its embedding cache.
         await vs_client.upsert(
             text=text,
-            doc_id=section.source_file,
+            doc_id=wiki_rag._section_id(section),
             group=group,
             metadata={"title": section.title, "source_file": section.source_file},
         )


### PR DESCRIPTION
## Summary

- `sync_vector_search` / `sync_collection_to_vector_search` used `doc_id=section.source_file`. Many sections share one source_file (94k WooCommerce products → 659 md files, 2081 Chartered sections → 476 files, etc.), and Vector Search `/upsert` REPLACES chunks under the same `doc_id` — so only the last section per file survived.
- Real numbers after the most recent full sync:
  - WooCommerce: **818 / 94,350** records (≈99% data loss)
  - Accountant Forums: **79 / 923** (≈91%)
  - Boards.ie: **365 / 1979** (≈82%)
  - Accounting Technicians: 19 / 76, ICAEW: 50 / 128, Chartered: 1439 / 2081
- Fix: switch to `wiki_rag._section_id(section)` (md5 of `source_file::title`) — same hash the wiki service uses for its embedding cache, so IDs stay stable across re-syncs.

## Test plan

- [ ] Merge → deploy → trigger full vector-search sync
- [ ] Verify per-group `/count` roughly matches the `synced N sections for collection X` log lines (chunking may multiply by 1–3x)
- [ ] Spot-check thematic queries on woocommerce, accountant-forums, boards-ie — should return many more unique hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)