### PR TITLE
fix(wiki-rag): survive snowballstemmer IndexError on malformed tokens

### DIFF
--- a/app/services/wiki_rag_service.py
+++ b/app/services/wiki_rag_service.py
@@ -132,10 +132,20 @@ def _is_cyrillic(word: str) -> bool:
 
 
 def _stem(word: str) -> str:
-    """Stem a single word using the appropriate language stemmer."""
-    if _is_cyrillic(word):
-        return _ru_stemmer.stemWord(word)
-    return _en_stemmer.stemWord(word)
+    """Stem a single word using the appropriate language stemmer.
+
+    snowballstemmer has a long-standing bug where certain token shapes trigger
+    `IndexError: string index out of range` inside `find_among_b`. We've hit
+    this on real-world forum/CMS content (mixed case/digit tokens). Falling
+    back to the raw word keeps indexing deterministic instead of crashing the
+    whole collection load.
+    """
+    try:
+        if _is_cyrillic(word):
+            return _ru_stemmer.stemWord(word)
+        return _en_stemmer.stemWord(word)
+    except IndexError:
+        return word
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- `snowballstemmer` throws `IndexError: string index out of range` inside `find_among_b` on specific token shapes that show up in the new forum/CMS corpora (accountant-forums, ICAEW, boards.ie).
- Propagating exception killed the `wiki-collection-indexes` startup task and the manual `/admin/wiki-rag/vector-search/sync` endpoint — last 3 collections never loaded, full sync never ran.
- Wrap `_stem()` in try/except: return the raw word on `IndexError`. Slightly weaker BM25 matching for ~a few tokens ≫ refusing to index whole collections.

## Test plan

- [ ] Deploy → check logs show `📚 Wiki RAG collection 6/5/… секций из … файлов` for all 13 collections (no IndexError traceback)
- [ ] Trigger full vector-search sync, confirm it doesn't 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)