### PR TITLE
fix(chat): shared workspace-null sessions now visible to recipients

### DIFF
--- a/modules/chat/router.py
+++ b/modules/chat/router.py
@@ -354,7 +354,7 @@ async def admin_list_chat_sessions(
         for s in sessions_list:
             sid = s.get("id", "")
             s_owner = s.get("owner_id")
-            if sid in shared_perms and s_owner != user.id and s_owner is not None:
+            if sid in shared_perms and s_owner != user.id:
                 s["is_shared_with_me"] = True
                 s["share_permission"] = shared_perms[sid]
             else:
@@ -447,11 +447,7 @@ async def admin_get_chat_session(
 
     # Share info
     session_owner_id = session.get("owner_id")
-    is_owner = (
-        user_has_level(user, "chat", "manage")
-        or session_owner_id == user.id
-        or session_owner_id is None
-    )
+    is_owner = user_has_level(user, "chat", "manage") or session_owner_id == user.id
     if is_owner:
         session["is_shared_with_me"] = False
         session["share_permission"] = "owner"


### PR DESCRIPTION
## Summary

Админы с `chat:manage` создают сессии с `owner_id=NULL` через `workspace_context()`. Когда такая сессия явно расшаривалась не-админу через `chat_session_shares`, два места в enrichment неправильно трактовали её как «owned» для получателя — и фронт (`ChatView.vue:566`) фильтровал её из списка для не-админов.

- `modules/chat/router.py:357` (list): условие требовало `s_owner is not None` → workspace-null сессии всегда получали `is_shared_with_me=False`.
- `modules/chat/router.py:453` (get_session): `is_owner` считал `owner_id IS NULL` «владением» для всех, затирая `share_permission` из БД.

Починено: оба места теперь полагаются только на `user_has_level(chat, manage) OR owner_id==user.id`. Явные шары отображаются как `is_shared_with_me=true` независимо от `owner_id`.

## Affected sessions (prod, проверено)

5 workspace-null сессий с активными расшарами, которые получатели не видели до фикса:

| session | shared to |
|---|---|
| DigitaX | digitax |
| БИЗЗИО | mike |
| Proger number nine | anton |
| yasen | yasen |
| Нейрографика | guly |

## NEWS

🔓 **Исправлено: чаты с ассистентами теперь видны тем, кому их расшарили**

Раньше, если админ создавал ассистента в общих чатах и делился им с конкретным человеком или командой — получатель ассистента в списке чатов не видел. Теперь всё работает корректно: расшаренные чаты сразу появляются у получателей с нужными правами. 🎯

## Test plan

- [ ] Админ создаёт чат-ассистента (source=admin, owner_id=NULL), расшаривает пользователю с ролью operator/user через Share dialog
- [ ] Получатель логинится в вебе — сессия появляется в списке с синей пометкой "shared"
- [ ] Получатель открывает сессию — видит `share_permission=write`, может писать сообщения
- [ ] Админ по-прежнему видит свои workspace-null сессии как «owner» (не как shared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)