### PR TITLE
feat(mobile): bump to v1.61 — FCM push enabled build

### DIFF
--- a/admin/src/views/LoginView.vue
+++ b/admin/src/views/LoginView.vue
@@ -358,7 +358,7 @@ async function handleSubmit() {
           <!-- Android APK download -->
           <div class="mt-4 flex justify-center">
             <a
-              href="https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.6/ai-secretary-1.6.apk"
+              href="https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.61/ai-secretary-1.61.apk"
               target="_blank"
               rel="noopener noreferrer"
               title="Скачать Android-приложение AI-Секретарь"

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.shaerware.aisecretary"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 9
-        versionName "1.6"
+        versionCode 10
+        versionName "1.61"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.


### PR DESCRIPTION
## Summary
- versionCode 10, versionName 1.61
- Admin login APK link → mobile-v1.61

This is the first APK with push notifications wired. After install + login,
device registers FCM token and will receive:
- News pushes on every merged PR with `## NEWS`
- Update pushes on every `mobile-v*` release tag

## NEWS

🆕 **Вышла v1.61 мобильного приложения с пушами**

Первая версия мобилки с поддержкой push-уведомлений. После установки и входа в аккаунт приложение получит токен и будет получать новости и уведомления об обновлениях прямо в шторку Android.

## Test plan
- [ ] После мерджа GitHub webhook `/webhooks/github/release` должен выстрелить и запушить на v1.6 установки
- [ ] На v1.6 появится пуш про v1.61 (т.к. v1.6 уже имеет FCM клиент? нет — у v1.6 FCM нет, поэтому пушей там не будет)
- [ ] Установить 1.61, залогиниться, убедиться что `/admin/mobile/push/register` улетел
- [ ] Следующий merge с `## NEWS` → проверить push на 1.61

🤖 Generated with [Claude Code](https://claude.com/claude-code)