### PR TITLE
fix(login): dynamic mobile APK version from server

### DIFF
--- a/admin/src/views/LoginView.vue
+++ b/admin/src/views/LoginView.vue
@@ -21,6 +21,24 @@ const showPassword = ref(false)
 const showAbout = ref(false)
 const activeTab = ref<'ai' | 'privacy' | 'features' | 'channels' | 'cases'>('cases')
 
+// Mobile app version — fetched from /admin/mobile/version (driven by MOBILE_LATEST_* env on server)
+const mobileVersion = ref('1.61')
+const mobileApkUrl = ref(
+  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-1.61.apk',
+)
+
+async function fetchMobileVersion() {
+  try {
+    const resp = await fetch('/admin/mobile/version')
+    if (!resp.ok) return
+    const data = await resp.json()
+    if (data?.version_name) mobileVersion.value = data.version_name
+    if (data?.apk_url) mobileApkUrl.value = data.apk_url
+  } catch {
+    /* keep defaults */
+  }
+}
+
 // Matrix rain animation
 const matrixCanvas = ref<HTMLCanvasElement | null>(null)
 let matrixRaf = 0
@@ -60,6 +78,7 @@ function unmountChatWidget() {
 }
 
 onMounted(() => {
+  fetchMobileVersion()
   const canvas = matrixCanvas.value
   if (!canvas) return
   const ctx = canvas.getContext('2d')
@@ -358,7 +377,7 @@ async function handleSubmit() {
           <!-- Android APK download -->
           <div class="mt-4 flex justify-center">
             <a
-              href="https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.61/ai-secretary-1.61.apk"
+              :href="mobileApkUrl"
               target="_blank"
               rel="noopener noreferrer"
               title="Скачать Android-приложение AI-Секретарь"
@@ -368,7 +387,7 @@ async function handleSubmit() {
                 <path d="M17.523 15.341c-.5866 0-1.0615-.4751-1.0615-1.0613 0-.5862.4749-1.0614 1.0615-1.0614.5864 0 1.0613.4752 1.0613 1.0614 0 .5862-.4749 1.0613-1.0613 1.0613m-11.0456 0c-.5868 0-1.0616-.4751-1.0616-1.0613 0-.5862.4748-1.0614 1.0616-1.0614.5863 0 1.0612.4752 1.0612 1.0614 0 .5862-.4749 1.0613-1.0612 1.0613m11.4264-6.0201 2.1195-3.6713a.4413.4413 0 0 0-.1616-.6025.4415.4415 0 0 0-.6024.1616l-2.1465 3.7185C15.4732 8.1637 13.7923 7.7999 12 7.7999c-1.7922 0-3.4732.3638-4.9924 1.0232L4.8611 5.1046a.441.441 0 0 0-.6023-.1616.4413.4413 0 0 0-.1616.6025l2.1195 3.6713C2.574 10.9842.3949 14.3505 0 18.413h24c-.3949-4.0625-2.5734-7.4288-6.2548-9.4991" />
               </svg>
               <span>Скачать Android-приложение</span>
-              <span class="text-[10px] font-bold uppercase tracking-wide bg-white/20 rounded-full px-1.5 py-0.5">v1.55</span>
+              <span class="text-[10px] font-bold uppercase tracking-wide bg-white/20 rounded-full px-1.5 py-0.5">v{{ mobileVersion }}</span>
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Login page was still showing hardcoded **v1.55** while backend already exposes the actual latest version via `GET /admin/mobile/version` (driven by `MOBILE_LATEST_*` env vars).

Now `LoginView.vue` fetches the version on mount:
- `mobileVersion` ref — displayed in the badge
- `mobileApkUrl` ref — used as `href`
- Falls back to 1.61 defaults if the endpoint is unreachable

Future version bumps only require updating `MOBILE_LATEST_VERSION_NAME` / `MOBILE_LATEST_APK_URL` in server env + restart.

## Test plan
- [ ] Deploy + reload login page → badge shows v1.61 (current env)
- [ ] Click badge/button → downloads latest APK via APK URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)