### PR TITLE
feat(mobile): POST_NOTIFICATIONS + push test endpoints

### DIFF
--- a/admin/src/views/LoginView.vue
+++ b/admin/src/views/LoginView.vue
@@ -21,6 +21,24 @@ const showPassword = ref(false)
 const showAbout = ref(false)
 const activeTab = ref<'ai' | 'privacy' | 'features' | 'channels' | 'cases'>('cases')
 
+// Mobile app version — fetched from /admin/mobile/version (driven by MOBILE_LATEST_* env on server)
+const mobileVersion = ref('1.61')
+const mobileApkUrl = ref(
+  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-1.61.apk',
+)
+
+async function fetchMobileVersion() {
+  try {
+    const resp = await fetch('/admin/mobile/version')
+    if (!resp.ok) return
+    const data = await resp.json()
+    if (data?.version_name) mobileVersion.value = data.version_name
+    if (data?.apk_url) mobileApkUrl.value = data.apk_url
+  } catch {
+    /* keep defaults */
+  }
+}
+
 // Matrix rain animation
 const matrixCanvas = ref<HTMLCanvasElement | null>(null)
 let matrixRaf = 0
@@ -60,6 +78,7 @@ function unmountChatWidget() {
 }
 
 onMounted(() => {
+  fetchMobileVersion()
   const canvas = matrixCanvas.value
   if (!canvas) return
   const ctx = canvas.getContext('2d')
@@ -358,7 +377,7 @@ async function handleSubmit() {
           <!-- Android APK download -->
           <div class="mt-4 flex justify-center">
             <a
-              href="https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.61/ai-secretary-1.61.apk"
+              :href="mobileApkUrl"
               target="_blank"
               rel="noopener noreferrer"
               title="Скачать Android-приложение AI-Секретарь"
@@ -368,7 +387,7 @@ async function handleSubmit() {
                 <path d="M17.523 15.341c-.5866 0-1.0615-.4751-1.0615-1.0613 0-.5862.4749-1.0614 1.0615-1.0614.5864 0 1.0613.4752 1.0613 1.0614 0 .5862-.4749 1.0613-1.0613 1.0613m-11.0456 0c-.5868 0-1.0616-.4751-1.0616-1.0613 0-.5862.4748-1.0614 1.0616-1.0614.5863 0 1.0612.4752 1.0612 1.0614 0 .5862-.4749 1.0613-1.0612 1.0613m11.4264-6.0201 2.1195-3.6713a.4413.4413 0 0 0-.1616-.6025.4415.4415 0 0 0-.6024.1616l-2.1465 3.7185C15.4732 8.1637 13.7923 7.7999 12 7.7999c-1.7922 0-3.4732.3638-4.9924 1.0232L4.8611 5.1046a.441.441 0 0 0-.6023-.1616.4413.4413 0 0 0-.1616.6025l2.1195 3.6713C2.574 10.9842.3949 14.3505 0 18.413h24c-.3949-4.0625-2.5734-7.4288-6.2548-9.4991" />
               </svg>
               <span>Скачать Android-приложение</span>
-              <span class="text-[10px] font-bold uppercase tracking-wide bg-white/20 rounded-full px-1.5 py-0.5">v1.55</span>
+              <span class="text-[10px] font-bold uppercase tracking-wide bg-white/20 rounded-full px-1.5 py-0.5">v{{ mobileVersion }}</span>
             </a>
           </div>
         </div>

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -38,4 +38,6 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Push notifications (Android 13+) -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 </manifest>

--- a/modules/channels/mobile/router.py
+++ b/modules/channels/mobile/router.py
@@ -303,6 +303,69 @@ async def unregister_push_tokens(
     return {"status": "ok"}
 
 
+class PushTestRequest(BaseModel):
+    title: str = "Test push"
+    body: str = "Hello from AI-Секретарь"
+    to_all: bool = False
+    user_id: Optional[int] = None
+
+
+@router.post("/push/test")
+async def send_test_push(
+    request: PushTestRequest,
+    user: User = Depends(require_permission("channels", "manage")),
+):
+    """Send a test push notification.
+
+    Admin-only. If `to_all=true` — broadcast to every registered device.
+    If `user_id` is given — send only to that user's devices.
+    Otherwise — send to the requesting admin's devices.
+    """
+    if not fcm_push_service.enabled:
+        raise HTTPException(
+            status_code=503,
+            detail="FCM not configured (FCM_PROJECT_ID + FCM_SERVICE_ACCOUNT_FILE env vars)",
+        )
+    target_user_id = request.user_id if request.user_id else user.id
+    if request.to_all:
+        delivered = await fcm_push_service.send_to_all(
+            title=request.title,
+            body=request.body,
+            data={"type": "test"},
+        )
+    else:
+        delivered = await fcm_push_service.send_to_user(
+            user_id=target_user_id,
+            title=request.title,
+            body=request.body,
+            data={"type": "test"},
+        )
+    return {"status": "ok", "delivered": delivered, "fcm_enabled": fcm_push_service.enabled}
+
+
+@router.get("/push/status")
+async def get_push_status(
+    user: User = Depends(require_permission("channels", "manage")),
+):
+    """Check FCM configuration status. Admin-only."""
+    from sqlalchemy import func, select
+
+    from db.database import get_async_session
+    from modules.channels.mobile.models import MobilePushToken
+
+    total = 0
+    async for session in get_async_session():
+        result = await session.execute(select(func.count()).select_from(MobilePushToken))
+        total = result.scalar() or 0
+
+    return {
+        "fcm_enabled": fcm_push_service.enabled,
+        "project_id": fcm_push_service.project_id,
+        "service_account_file": fcm_push_service.service_account_file,
+        "total_tokens": total,
+    }
+
+
 # ============== Resource Sharing (user assignment) ==============
 
 


### PR DESCRIPTION
## Summary

**Android fix:**
- `AndroidManifest.xml`: add `android.permission.POST_NOTIFICATIONS` required on Android 13+. Without it the runtime permission prompt is never shown and notifications are silently dropped at OS level even though FCM delivers them.

**Backend — admin debug endpoints:**
- `POST /admin/mobile/push/test` — send test push (`to_all` / `user_id` / default=self)
- `GET /admin/mobile/push/status` — config check: `fcm_enabled`, `project_id`, `total_tokens`

Used to debug the "push not showing" case — FCM side was fine, the installed APK just lacked the Android 13 permission.

## Test plan
- [x] Server: `curl /admin/mobile/push/status` → `fcm_enabled: true, total_tokens: 1`
- [x] Server: `POST /admin/mobile/push/test` → `delivered: 1` → push showed in tray (with backgrounded app)
- [ ] Rebuild APK with Manifest fix → first-run prompt asks for notification permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)