### PR TITLE
feat(rag): 3 RU sources for USN-юрлиц assistant (MVP from #731)

### DIFF
--- a/app/services/wiki_rag_service.py
+++ b/app/services/wiki_rag_service.py
@@ -210,7 +210,14 @@ class WikiRAGService:
         return [_stem(t) for t in tokens if len(t) >= MIN_TOKEN_LEN and t not in STOP_WORDS]
 
     def _split_md_by_headers(self, content: str) -> list[tuple[str, str]]:
-        """Split markdown by ## and ### headers. Returns (header, body) pairs."""
+        """Split markdown by ## and ### headers. Returns (header, body) pairs.
+
+        Fallback when the file has no ##/### subheaders: treat the whole body
+        as a single section titled by the top-level H1 (`# Title`). Legal
+        texts scraped from consultant.ru (НК РФ, etc.) come as one flat H1 +
+        paragraphs — without this fallback they'd contribute zero BM25
+        sections to the index.
+        """
         sections = []
         pattern = r"^(#{2,3})\s+(.+?)$"
         current_header = ""
@@ -229,7 +236,16 @@ class WikiRAGService:
         if current_header and current_body:
             sections.append((current_header, "\n".join(current_body)))
 
-        return sections
+        if sections:
+            return sections
+
+        # No ##/### seen — emit one section from H1 + body.
+        h1_match = re.search(r"^#\s+(.+?)$", content, re.MULTILINE)
+        title = h1_match.group(1).strip() if h1_match else "(untitled)"
+        body = content.strip()
+        if body:
+            return [(title, body)]
+        return []
 
     def _load_and_index(self, wiki_dir: Path) -> None:
         """Parse all .md files in wiki_dir, build BM25 index."""

--- a/scripts/scrape_digitax/config.py
+++ b/scripts/scrape_digitax/config.py
@@ -103,6 +103,60 @@ SITES = {
         ],
         "description": ("International accountancy forum — Ireland-related threads only."),
     },
+    # ------------------------------------------------------------------
+    # Russian accountant assistant — USN (6% / 15%) for legal entities
+    # ------------------------------------------------------------------
+    "ru-fns-usn": {
+        "name": "ФНС России — УСН",
+        "base_url": "https://www.nalog.gov.ru",
+        "seed_paths": [
+            "/rn77/taxation/taxes/usn/",
+            "/rn77/taxation/taxes/nds_usn/",
+            "/rn77/taxation/taxes/usn/all_about/",
+        ],
+        "stay_under": "/rn77/taxation/",
+        "max_pages": 300,
+        "type": "official",
+        "description": (
+            "Федеральная налоговая служба — официальный раздел УСН. "
+            "Ставки, льготы, переход/отказ, декларация, КУДиР, разъяснения. "
+            "Включает НДС при УСН (актуально с 2025)."
+        ),
+    },
+    "ru-nk-rf-glava-26-2": {
+        "name": "НК РФ — Глава 26.2 (УСН)",
+        "base_url": "https://www.consultant.ru",
+        "seed_paths": [
+            "/document/cons_doc_LAW_28165/d29da7b903e5cc351ee08a2f10414ccee3c12bad/",
+        ],
+        # Whole Part 2 of Taxcode lives under this document id. Stay inside it
+        # to avoid drifting onto unrelated КонсультантПлюс content.
+        "stay_under": "/document/cons_doc_LAW_28165/",
+        "max_pages": 60,
+        "type": "legal",
+        "description": (
+            "Налоговый кодекс РФ — Глава 26.2 «Упрощенная система "
+            "налогообложения». Первоисточник: ст. 346.11 — 346.25.1."
+        ),
+    },
+    "ru-moedelo-usn": {
+        "name": "МоеДело — клуб",
+        "base_url": "https://www.moedelo.org",
+        "seed_paths": [
+            "/club/nalogovyj-uchet",
+            "/club/buhgalterskij-uchet",
+            "/club/registratsiya-biznesa",
+            "/club/likvidaciya-biznesa",
+        ],
+        "stay_under": "/club/",
+        "max_pages": 400,
+        "type": "practical",
+        "description": (
+            "МоеДело (Моё Дело) — клуб, практические статьи по бухгалтерскому "
+            "и налоговому учёту. Не весь контент про УСН — на пост-парсинге "
+            "отфильтруем не-USN статьи по ключевым словам."
+        ),
+    },
     "icaew-ireland": {
         "name": "ICAEW Ireland Standards",
         "base_url": "https://www.icaew.com",

--- a/scripts/scrape_digitax/scrape.py
+++ b/scripts/scrape_digitax/scrape.py
@@ -122,9 +122,25 @@ def crawl_site(
 
 
 def _normalize_url(url: str) -> str:
-    """Strip fragment, trailing slash for consistency."""
+    """Drop the fragment, preserve a trailing slash on directory-looking paths.
+
+    Some servers (e.g. nalog.gov.ru) return 404 without the trailing slash on
+    directory URLs. Others (e.g. GitHub) return a redirect. Stripping the
+    slash blindly (as the older implementation did) broke the former. The
+    heuristic used here: keep the trailing slash if the last path segment
+    does not look like a file (no dot) and the URL originally had one;
+    strip it otherwise so `/foo.html/` and `/foo.html` don't diverge.
+    """
     parsed = urlparse(url)
-    path = parsed.path.rstrip("/") or "/"
+    path = parsed.path or "/"
+    had_trailing = path.endswith("/") and path != "/"
+    stripped = path.rstrip("/") or "/"
+    last_seg = stripped.rsplit("/", 1)[-1]
+    looks_like_file = "." in last_seg
+    if had_trailing and not looks_like_file:
+        path = stripped + "/"
+    else:
+        path = stripped
     query = parsed.query
     normalized = f"{parsed.scheme}://{parsed.netloc}{path}"
     if query:
@@ -298,6 +314,13 @@ LINK_FILTERS: dict[str, callable] = {
     "cpa-ireland": filter_professional_site,
     "accounting-technicians-ie": filter_professional_site,
     "iafa": filter_professional_site,
+    # Russian accountant assistant sites — all three rely on the `stay_under`
+    # path prefix to keep the crawler inside the relevant section.
+    # filter_icaew reads `stay_under` from cfg, so it works as a generic
+    # stay-under filter when `ireland_keywords` is absent.
+    "ru-fns-usn": filter_icaew,
+    "ru-nk-rf-glava-26-2": filter_icaew,
+    "ru-moedelo-usn": filter_icaew,
 }
 
 

--- a/scripts/scrape_digitax/scrape.py
+++ b/scripts/scrape_digitax/scrape.py
@@ -266,9 +266,11 @@ def filter_icaew(url: str, cfg: dict) -> bool:
 
     ireland_keywords = cfg.get("ireland_keywords")
     if ireland_keywords:
-        return any(kw in path for kw in ireland_keywords)
+        return any(kw.lower() in path for kw in ireland_keywords)
 
-    stay_under = cfg.get("stay_under", "/technical/by-country/europe/ireland")
+    # `path` is already lower-cased; lower the prefix too so mixed-case
+    # document IDs (e.g. consultant.ru `/document/cons_doc_LAW_28165/`) match.
+    stay_under = cfg.get("stay_under", "/technical/by-country/europe/ireland").lower()
     return stay_under in path
 
 


### PR DESCRIPTION
## Summary
MVP слот из #731 — RAG-источники для русского ассистента-бухгалтера (ЮЛ на УСН 6% / 15%):

- `ru-fns-usn` — ФНС, раздел УСН (первичный официал)
- `ru-nk-rf-glava-26-2` — НК РФ Глава 26.2 (consultant.ru, первоисточник)
- `ru-moedelo-usn` — МоеДело клуб (практика)

Контур.Эльба/Контур возвращали 403 (IP/country-блок), поэтому solid-слот — МоеДело (robots.txt открыт, равноценный тир).

Попутно два фикса, без которых MVP не работал:

1. `_normalize_url` теперь сохраняет trailing slash на directory-URL — nalog.gov.ru отдаёт 404 без слэша.
2. `filter_icaew` сравнивал lower-cased path с mixed-case `stay_under`; consultant.ru использует `cons_doc_LAW_28165` и из-за регистра фильтр резал всё, кроме seed. `.lower()` применён к префиксу (и для ireland_keywords — для симметрии).
3. `_split_md_by_headers` получил fallback на случай flat markdown (H1 + абзацы без `##`/`###`). Без него НК РФ (61 файл с consultant.ru) давал **0 секций** в BM25 индексе.

## State after this PR (перед деплоем)
В БД создано 3 коллекции, файлы спарсены и rsync'нуты в `wiki-pages/`:
- 18 `ru-fns-usn`: 271 md / 1135 секций
- 19 `ru-nk-rf-glava-26-2`: 61 md / 0 секций (fallback подхватит после рестарта)
- 20 `ru-moedelo-usn`: 334 md / 3002 секции

Relates to #731 (MVP — первая часть, expansion отдельным PR).

## NEWS

🇷🇺 **Ассистент-бухгалтер заговорил по-русски**

Для юрлиц на УСН 6% / 15% добавлены три источника знаний: ФНС России, Налоговый кодекс (Глава 26.2) и практические статьи МоеДело — всего 666 страниц материалов. Теперь ассистент отвечает не только по ирландскому праву, но и по российской упрощёнке: ставки, декларации, страховые взносы, расчёт налога. Это MVP-подборка — дальше будем добавлять Минфин, Главную книгу и Клерк.

## Test plan
- [x] ruff check — clean
- [x] `_split_md_by_headers` — normal / flat / empty / h1-only / no-title
- [x] `filter_icaew` — mixed-case консульт URL проходит; ICAEW Ireland по-прежнему проходит
- [x] `_normalize_url` — trailing slash сохраняется для dir-URL, снимается для `.html`/`.pdf`
- [x] Реальный прогон: scrape + parse, 666 файлов всего, dedup отработал
- [ ] После merge + deploy: collection 19 должна показать ненулевое число секций в логе `📚 Wiki RAG collection 19: N секций из 61 файлов`
- [ ] Baseline отчёт — отдельный docs-PR (как #728 после #727)

🤖 Generated with [Claude Code](https://claude.com/claude-code)