### PR TITLE
fix(mobile): show only default-mobile chat for non-admin users

### DIFF
--- a/mobile/src/api/chat.ts
+++ b/mobile/src/api/chat.ts
@@ -85,6 +85,7 @@ export interface ChatSessionSummary {
   is_shared_with_me?: boolean;
   share_permission?: string;
   share_count?: number;
+  is_default_mobile?: boolean;
 }
 
 export interface StreamChunk {

--- a/mobile/src/views/ChatListView.vue
+++ b/mobile/src/views/ChatListView.vue
@@ -49,10 +49,13 @@ const sessionRagIds = ref<number[]>([]);
 // Mobile instance attached to session
 const sessionMobileInstanceId = ref<string | null>(null);
 
-// For non-admins: only shared chats
+// For non-admins: only the chat that admin explicitly assigned as
+// "default mobile" for this user. Regular shares (via the Share menu)
+// are not surfaced on mobile — the mobile app is a single-assistant
+// surface, not a general chat browser.
 const visibleSessions = computed(() => {
   if (isAdmin.value) return sessions.value;
-  return sessions.value.filter((s) => s.is_shared_with_me);
+  return sessions.value.filter((s) => s.is_default_mobile);
 });
 
 async function loadSessions() {


### PR DESCRIPTION
## Summary
Non-admin мобильный юзер видел все чаты, которые админ ему когда-либо шарил через обычное «Поделиться», а не только тот, который был явно прикреплён к его мобилке через «В мобильное приложение». Ожидание — именно этот чат и никакой другой.

Меняю фильтр `visibleSessions` в `mobile/src/views/ChatListView.vue:54` с `is_shared_with_me` на `is_default_mobile`.

Backend уже проставляет `is_default_mobile=true` для единственной сессии, которая назначена юзеру как default mobile (`modules/chat/router.py:364`), и `get_user_default_mobile_session` гарантирует, что эта сессия уникальна per user (сервис очищает прошлые флаги при назначении новой). То есть никаких новых API не нужно — просто фильтруем по правильному полю. Заодно добавляю `is_default_mobile?: boolean` в тип `ChatSessionSummary` (был в admin/, в mobile/ забыли).

## Что поменялось с точки зрения юзера
- Приложение по-прежнему автологинится в прикреплённый чат (`autoOpenChat` → `GET /my-default-mobile-session`)
- При возврате свайпом/кнопкой «назад» на welcome-экран в блоке «Ваши чаты» теперь только прикреплённый чат, без старых пришаренных
- Если ни одного прикрепления нет — блок «Ваши чаты» пустой (как и раньше для юзера без шаринга)

## Обратной совместимости не ломается
- Админам видимость не меняется (они используют отдельную ветку `isAdmin ? sessions : ...`)
- Non-admin'ы без привязки default-mobile теперь не видят случайные пришаренные чаты — это и была просьба пользователя

## NEWS

📱 **В мобильном ассистенте — только ваш чат**

Если админ в настройках чата выбрал «прикрепить в мобильное приложение» для конкретного пользователя — этот пользователь теперь видит в мобилке именно этот чат и ничего больше. Никаких случайно пришаренных из админки чатов в списке — чисто, без отвлечений.

## Test plan
- [x] vue-tsc --noEmit — clean
- [x] Просмотрел подтверждение в БД: у тестового юзера \`ivan\` (uid=3) есть 2 шары, одна из них \`is_default_mobile=1\` — после фикса в мобилке он увидит только эту одну
- [ ] На проде: логин под \`ivan\` в мобилке → авто-открытие закреплённого чата, список «Ваши чаты» содержит 1 запись

🤖 Generated with [Claude Code](https://claude.com/claude-code)