### PR TITLE
feat(admin): VITE_PRODUCT_VARIANT=lite — trimmed UI for new server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,8 @@ New routers import domain services directly (`from modules.monitoring.service im
 
 **Demo mode**: `VITE_DEMO_MODE=true` monkey-patches `window.fetch` to intercept API calls with mock data from 23 domain files in `admin/src/api/demo/`.
 
+**Product variant** (`VITE_PRODUCT_VARIANT` env var, defaults to `full`): Set to `lite` to ship a stripped admin panel. Lite variant whitelists `/chat`, `/llm`, `/wiki`, `/finetune` (collections CRUD), `/widget`, `/telegram`, `/whatsapp`, `/mobile-app`, `/settings`, `/users`, `/about`, `/login`, `/invite/*` — everything else is blocked by the router guard and hidden from nav. Scripts: `npm run dev:lite` and `npm run build:lite`. Central helper: `admin/src/config/productVariant.ts` (`IS_LITE`, `isPathAllowed()`).
+
 **Vite base path**: Production `/admin/` (served by FastAPI). Demo/standalone: `/` (via `VITE_BASE_PATH` or `.env.production.local`).
 
 ### Mobile App (`mobile/`)

--- a/admin/package.json
+++ b/admin/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:lite": "VITE_PRODUCT_VARIANT=lite vite",
     "build": "vue-tsc -b && vite build",
+    "build:lite": "VITE_PRODUCT_VARIANT=lite vue-tsc -b && VITE_PRODUCT_VARIANT=lite vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
     "lint:check": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore",

--- a/admin/src/App.vue
+++ b/admin/src/App.vue
@@ -17,6 +17,7 @@ import {
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from './stores/auth'
+import { isPathAllowed } from './config/productVariant'
 import { useSearchStore } from './stores/search'
 import { useThemeStore } from './stores/theme'
 import { useChatFullscreenStore } from './stores/chatFullscreen'
@@ -198,7 +199,7 @@ const localeTitle: Record<string, string> = { ru: 'Переключить язы
               <span class="flex-1 text-left">{{ t('nav.chat') }}</span>
             </router-link>
             <router-link
-              v-if="authStore.canView('kanban')"
+              v-if="authStore.canView('kanban') && isPathAllowed('/kanban')"
               to="/kanban"
               class="flex items-center gap-2 w-full px-3 py-2 text-sm rounded-lg transition-colors"
               :class="route.path === '/kanban' ? 'bg-primary/10 text-primary' : 'text-muted-foreground bg-secondary/50 hover:bg-secondary'"
@@ -217,7 +218,7 @@ const localeTitle: Record<string, string> = { ru: 'Переключить язы
               <MessageCircle class="w-5 h-5" />
             </router-link>
             <router-link
-              v-if="authStore.canView('kanban')"
+              v-if="authStore.canView('kanban') && isPathAllowed('/kanban')"
               to="/kanban"
               class="flex items-center justify-center w-full p-2 rounded-lg transition-colors"
               :class="route.path === '/kanban' ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:bg-secondary/50'"

--- a/admin/src/components/AccordionNav.vue
+++ b/admin/src/components/AccordionNav.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch, onMounted } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '../stores/auth'
+import { isPathAllowed } from '../config/productVariant'
 import { ChevronDown } from 'lucide-vue-next'
 import {
   LayoutDashboard,
@@ -40,7 +41,8 @@ const authStore = useAuthStore()
 
 const LVL: Record<string, number> = { view: 1, edit: 2, manage: 3 }
 
-function isVisible(item: { module?: string; minLevel?: string; localOnly?: boolean }): boolean {
+function isVisible(item: { path: string; module?: string; minLevel?: string; localOnly?: boolean }): boolean {
+  if (!isPathAllowed(item.path)) return false
   if (item.localOnly && authStore.isCloudMode) return false
   if (!item.module) return true
   const min = item.minLevel || 'view'

--- a/admin/src/config/productVariant.ts
+++ b/admin/src/config/productVariant.ts
@@ -1,0 +1,51 @@
+// Product variant flag — configures which admin features/routes are
+// exposed at build time. Set via `VITE_PRODUCT_VARIANT` env var.
+//
+// - `full` (default) — all modules visible. Matches the historical
+//   admin panel used on ai-sekretar24.ru.
+// - `lite` — strictly a subset: chat, LLM providers, RAG (wiki +
+//   collection CRUD in finetune), website widget, Telegram, WhatsApp,
+//   mobile app, account settings, users (for inviting teammates),
+//   plus auxiliary routes (login, invite, about, root). Every other
+//   route is removed from navigation and blocked by the router guard.
+//
+// Used from `router.ts` (navigation guard), `AccordionNav.vue` (menu
+// filter), and `App.vue` (top shortcut for /kanban).
+
+export type ProductVariant = 'full' | 'lite'
+
+export const PRODUCT_VARIANT: ProductVariant =
+  (import.meta.env.VITE_PRODUCT_VARIANT as ProductVariant) || 'full'
+
+export const IS_LITE = PRODUCT_VARIANT === 'lite'
+
+// Whitelist of paths the lite variant is allowed to render. Exact
+// matches + prefix matches against this set (for /chat/:id, /users/:id,
+// /invite/:code etc.).
+const LITE_ALLOWED_PATHS: readonly string[] = [
+  '/',
+  '/login',
+  '/chat',
+  '/llm',
+  '/wiki',
+  '/finetune',
+  '/widget',
+  '/telegram',
+  '/whatsapp',
+  '/mobile-app',
+  '/settings',
+  '/users',
+  '/about',
+  '/invite',
+] as const
+
+export function isPathAllowed(path: string): boolean {
+  if (!IS_LITE) return true
+  if (path === '/') return true
+  for (const allowed of LITE_ALLOWED_PATHS) {
+    if (allowed === '/') continue
+    if (path === allowed) return true
+    if (path.startsWith(allowed + '/')) return true
+  }
+  return false
+}

--- a/admin/src/router.ts
+++ b/admin/src/router.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHashHistory } from "vue-router";
 import { useAuthStore } from "./stores/auth";
+import { isPathAllowed } from "./config/productVariant";
 import DashboardView from "./views/DashboardView.vue";
 import ChatView from "./views/ChatView.vue";
 import ServicesView from "./views/ServicesView.vue";
@@ -234,6 +235,12 @@ router.beforeEach((to, from, next) => {
 
   // Check deployment mode (localOnly routes hidden in cloud mode)
   if (to.meta.localOnly && authStore.isCloudMode) {
+    next({ name: "chat" });
+    return;
+  }
+
+  // Product variant gate — `lite` build exposes only whitelisted paths.
+  if (!isPublicRoute && !isPathAllowed(to.path)) {
     next({ name: "chat" });
     return;
   }


### PR DESCRIPTION
## Summary
Первая часть плана из #734: один флаг сборки `VITE_PRODUCT_VARIANT` переключает админку между `full` (сейчас) и `lite` (для нового сервера).

**Что остаётся в lite**: `/chat`, `/llm`, `/wiki`, `/finetune` (там сейчас CRUD коллекций), `/widget`, `/telegram`, `/whatsapp`, `/mobile-app`, `/settings`, `/users`, `/about`, `/login`, `/invite/*`.

**Что выпиливается (hidden + router guard redirect на /chat)**: Dashboard, Services, TTS, Monitoring, Models, GSM, Audit, Usage, CRM, Kanban, Sales, WooCommerce.

## Архитектурное решение
Пошёл по **варианту A** из #734 — single-source-of-truth helper `admin/src/config/productVariant.ts` с `IS_LITE` (boolean) и `isPathAllowed(path)` (whitelist check). Тот же хелпер используется в трёх местах:

- `admin/src/router.ts` — navigation guard редиректит на `/chat` если путь не в whitelist'е
- `admin/src/components/AccordionNav.vue` — фильтрует пункты меню (в дополнение к существующим `localOnly` / RBAC-гейтам)
- `admin/src/App.vue` — прячет shortcut `/kanban` в сайдбаре

Views по-прежнему импортируются статически в router — фильтрация runtime, не build-time. Bundle размер lite ≈ full (1442 kB). Если в будущем захочется реальный tree-shake — заменим импорты на `() => import(...)`, это отдельный PR.

## Скрипты
```
npm run dev:lite     # dev server в lite-режиме
npm run build:lite   # production build в lite-режиме
```

Обычные `npm run dev` и `npm run build` собирают `full` — существующий prod (`ai-sekretar24.ru`) ничего не теряет.

## State of issue #734
- [x] Шаг 1 — архитектура и флаги
- [ ] Шаг 2 — backend trim (`DEPLOYMENT_VARIANT=lite` → пропускать регистрацию роутеров kanban/crm/sales/monitoring/etc) — отдельный PR
- [ ] Шаг 3 — инфра нового сервера (VPS, systemd, nginx, webhook с `flock`) — после ответа владельца на 5 вопросов в issue
- [ ] Шаг 4 — seed-скрипт
- [ ] Шаг 5 — приёмка

## Test plan
- [x] `npx vue-tsc --noEmit` — clean
- [x] `npm run build` (full) — 1442.17 kB
- [x] `npm run build:lite` — 1442.40 kB, билд зелёный
- [ ] Прод на `ai-sekretar24.ru` после деплоя — всё видно как раньше (регресс-чек для full)
- [ ] Dev-сессия `npm run dev:lite` → в сайдбаре нет CRM/Kanban/Sales/Dashboard/Monitoring/Models/TTS/GSM/Audit/Usage/Services; клик по deep-link `/crm` → redirect на `/chat`

## NEWS

🪄 **Секретарь24-lite — облегчённая версия админки**

Теперь тот же кодбейз собирается в два варианта: полный (как на ai-sekretar24.ru) и lite — только то, что нужно ассистенту: чат, LLM-провайдеры, базы знаний и RAG-коллекции, виджет на сайт, Telegram/WhatsApp/мобилка, настройки аккаунта. Ни CRM, ни Kanban, ни Sales — чистое пространство для клиентов, которым нужна только AI-помощь. Деплоится на отдельный сервер одним флагом сборки.

Relates to #734 (шаг 1 из 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)