### PR TITLE
fix(chat): hide TTS buttons in cloud mode

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -3206,9 +3206,9 @@ class="w-4 h-4 rounded border flex items-center justify-center shrink-0"
             <ArrowDownToLine v-if="inputPosition === 'top'" class="w-4 h-4" />
             <ArrowUpToLine v-else class="w-4 h-4" />
           </button>
-          <!-- Voice mode toggle -->
+          <!-- Voice mode toggle (TTS only available in non-cloud deployments) -->
           <button
-            v-if="!cc.isActive.value"
+            v-if="!cc.isActive.value && !authStore.isCloudMode"
             :class="[
               'p-2 rounded-lg transition-colors',
               voiceMode ? 'bg-primary text-primary-foreground' : 'hover:bg-secondary'
@@ -3905,9 +3905,9 @@ class="w-4 h-4 rounded border flex items-center justify-center shrink-0"
 
                 <!-- Actions — below content, in normal flow -->
                 <div class="flex flex-wrap gap-1 mt-1 -mb-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                  <!-- TTS button for assistant messages -->
+                  <!-- TTS button for assistant messages (hidden in cloud mode — no TTS service) -->
                   <button
-                    v-if="message.role === 'assistant'"
+                    v-if="message.role === 'assistant' && !authStore.isCloudMode"
                     :disabled="ttsLoading === message.id"
                     class="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground"
                     :title="speakingMessageId === message.id && isSpeaking ? 'Stop' : 'Listen'"


### PR DESCRIPTION
## Problem

On the server (\`DEPLOYMENT_MODE=cloud\`), the **voice mode toggle** in the chat header and the per-message **Listen** button were both visible. But the cloud server doesn't register TTS routers ([orchestrator.py:125](orchestrator.py#L125) gates them on \`DEPLOYMENT_MODE != \"cloud\"\`), so clicking either button would 404 against \`/admin/tts/synthesize\`.

User reported the toggle reappearing in chat focus mode on \`ai-sekretar24.ru\`.

## Fix

Added \`!authStore.isCloudMode\` to both buttons' \`v-if\`:
- [admin/src/views/ChatView.vue:3210](admin/src/views/ChatView.vue#L3210) — voice mode toggle in header
- [admin/src/views/ChatView.vue:3909](admin/src/views/ChatView.vue#L3909) — per-message TTS button

Local/full-mode (\`DEPLOYMENT_MODE != \"cloud\"\`) behaviour unchanged.

## History

\`v-if=\"!cc.isActive.value\"\` was the only guard. It was added in commit \`789ef66\` (Claude Code Web UI). The buttons were briefly hidden for \`isChatOnly\` users in \`9823495\`, then restored in \`c43e69c7\` (\"restore controls for chat-only users in zen mode\"). No commit ever guarded against cloud mode — this PR adds that.

## Test plan

- [ ] Build admin: \`cd admin && npm run build\`
- [ ] Deploy to \`ai-sekretar24.ru\`: \`rsync admin/dist/ /var/www/admin-ai-sekretar24/ && systemctl restart ai-secretary\`
- [ ] In production chat: voice mode toggle and per-message Listen icons not present
- [ ] Locally (\`DEPLOYMENT_MODE=full\`): both buttons still visible and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)