### PR TITLE
feat(rag): decouple embedding provider from active LLM

### DIFF
--- a/modules/knowledge/startup.py
+++ b/modules/knowledge/startup.py
@@ -202,17 +202,62 @@ async def init_wiki_rag(container, deployment_mode: str, task_registry) -> None:
                     from app.services.embedding_provider import GeminiEmbeddingProvider
 
                     embedding_provider = GeminiEmbeddingProvider(api_key=api_key)
-                    logger.info("✅ Wiki RAG: cloud embeddings (Gemini)")
-                elif api_key and cloud_config.get("base_url"):
+                    logger.info("✅ Wiki RAG: cloud embeddings (Gemini, active LLM)")
+                elif provider_type in ("openai", "deepseek", "openrouter") and api_key:
                     from app.services.embedding_provider import OpenAIEmbeddingProvider
 
                     embedding_provider = OpenAIEmbeddingProvider(
                         api_key=api_key,
-                        base_url=cloud_config["base_url"],
+                        base_url=cloud_config.get("base_url") or "https://api.openai.com",
                     )
-                    logger.info("✅ Wiki RAG: cloud embeddings (OpenAI-compatible)")
+                    logger.info("✅ Wiki RAG: cloud embeddings (OpenAI-compatible, active LLM)")
             except Exception as cloud_err:
                 logger.debug(f"Wiki RAG: cloud embeddings not available: {cloud_err}")
+
+        # Embeddings-capable provider from DB (decoupled from active LLM).
+        # Lets chat use providers without /v1/embeddings (e.g. claude_bridge) while
+        # still getting semantic search via any enabled gemini/openai provider.
+        if not vector_search_configured and not embedding_provider:
+            try:
+                from modules.llm.service import cloud_provider_service
+
+                gemini_providers = await cloud_provider_service.get_by_type("gemini")
+                if gemini_providers:
+                    full = await cloud_provider_service.get_provider_with_key(
+                        gemini_providers[0]["id"]
+                    )
+                    if full and full.get("api_key"):
+                        from app.services.embedding_provider import GeminiEmbeddingProvider
+
+                        embedding_provider = GeminiEmbeddingProvider(api_key=full["api_key"])
+                        logger.info(
+                            "✅ Wiki RAG: cloud embeddings (Gemini from DB: %s)",
+                            gemini_providers[0]["id"],
+                        )
+
+                if not embedding_provider:
+                    for ptype in ("openai", "deepseek", "openrouter"):
+                        candidates = await cloud_provider_service.get_by_type(ptype)
+                        if not candidates:
+                            continue
+                        full = await cloud_provider_service.get_provider_with_key(
+                            candidates[0]["id"]
+                        )
+                        if full and full.get("api_key"):
+                            from app.services.embedding_provider import OpenAIEmbeddingProvider
+
+                            embedding_provider = OpenAIEmbeddingProvider(
+                                api_key=full["api_key"],
+                                base_url=full.get("base_url") or "https://api.openai.com",
+                            )
+                            logger.info(
+                                "✅ Wiki RAG: cloud embeddings (%s from DB: %s)",
+                                ptype,
+                                candidates[0]["id"],
+                            )
+                            break
+            except Exception as db_err:
+                logger.debug(f"Wiki RAG: DB-provider embeddings lookup failed: {db_err}")
 
         if embedding_provider:
             wiki_rag.set_embedding_provider(embedding_provider)


### PR DESCRIPTION
## Summary
- Add a third tier in `init_wiki_rag()` that picks any enabled `gemini` / `openai` / `deepseek` / `openrouter` provider from the `cloud_llm_providers` table and uses its key for embeddings — *only when the active LLM didn't already produce one*.
- Tighten the OpenAI-compatible branch in the active-LLM tier: only fire for `provider_type ∈ {openai, deepseek, openrouter}` instead of "any provider with a `base_url`" (previously this would have happily handed a `claude_bridge` base_url to the OpenAI embeddings client).
- Order stays: local sentence-transformers → active-LLM cloud → DB-provider cloud → BM25-only.

## Why
Server runs `LLM_BACKEND=cloud:claude-bridge-…` for chat. `claude_bridge` has no `/v1/embeddings` endpoint, so before this patch Wiki RAG fell through to BM25-only (or to Vector Search, which was OOM-crashing on a 6 GB VPS with the 768-dim mpnet model). Result: zero semantic search for every assistant on the server.

With this patch, chat keeps `claude_bridge` (Sonnet quality) while embeddings go through the existing enabled `gemini-default` provider via REST. No local model in memory, free tier covers our volume.

## Test plan
- [x] `ruff check` + `ruff format` clean
- [x] Verified locally: `cloud_provider_service.get_by_type("gemini")` + `get_provider_with_key()` returns the api_key from DB
- [ ] Server pull → restart `ai-secretary` → grep startup log for `Wiki RAG: cloud embeddings (Gemini from DB: gemini-default)` (only appears if `VECTOR_SEARCH_URL` is unset or empty)
- [ ] Smoke-test a chat query against a collection — should return ranked semantic matches, not just BM25 hits

## Notes
- This patch is the safety net. On the server we *also* re-enabled Vector Search with a lighter model (`paraphrase-multilingual-MiniLM-L12-v2`, 384-dim, ~470 MB peak vs the previous 5+ GB). When VS is up, it still wins (this code path is gated on `not vector_search_configured`). When it's down or unconfigured, embeddings still work — that's the new behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)