### PR TITLE
fix(chat): move branch tree toggle into input row, left of web search

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -3219,18 +3219,6 @@ class="w-4 h-4 rounded border flex items-center justify-center shrink-0"
             <Volume2 v-if="voiceMode" class="w-4 h-4" />
             <VolumeX v-else class="w-4 h-4" />
           </button>
-          <!-- Branch tree toggle -->
-          <button
-            v-if="!cc.isActive.value"
-            :class="[
-              'p-2 rounded-lg transition-colors',
-              showBranchTree ? 'bg-primary text-primary-foreground' : 'hover:bg-secondary'
-            ]"
-            :title="t('chatView.branchTree')"
-            @click="showBranchTree = !showBranchTree"
-          >
-            <GitBranch class="w-4 h-4" />
-          </button>
           <button
             v-if="!cc.isActive.value && !isReadOnly"
             :class="[
@@ -3581,6 +3569,18 @@ class="w-4 h-4 rounded border flex items-center justify-center shrink-0"
             inputPosition === 'bottom' ? 'items-stretch' : 'items-end',
           ]"
         >
+          <!-- Branch tree toggle -->
+          <button
+            v-if="!cc.isActive.value"
+            :class="[
+              'p-3 rounded-lg transition-colors shrink-0',
+              showBranchTree ? 'bg-primary/20 text-primary hover:bg-primary/30' : 'bg-secondary text-muted-foreground hover:bg-secondary/80'
+            ]"
+            :title="t('chatView.branchTree')"
+            @click="showBranchTree = !showBranchTree"
+          >
+            <GitBranch class="w-5 h-5" />
+          </button>
           <!-- Web search toggle -->
           <button
             v-if="currentSessionId && !isReadOnly"


### PR DESCRIPTION
## What

Moves the branch tree toggle (\`GitBranch\`) from the chat header toolbar into the input row, sitting immediately to the left of the web search globe.

Before: branch toggle lived in the header row alongside Settings/Voice/Branch tree (separate visual cluster from the input).
After: branch toggle is the first button in the input row → web search → textarea → file upload → mic → send.

User asked specifically for this layout — they wanted branch creation/navigation in the same div as the message-sending controls.

## Style

Adapted to match the input-row siblings:
- \`p-3 rounded-lg shrink-0\` (was \`p-2 rounded-lg\`)
- icon \`w-5 h-5\` (was \`w-4 h-4\`)
- off state: \`bg-secondary text-muted-foreground hover:bg-secondary/80\`
- on state: \`bg-primary/20 text-primary hover:bg-primary/30\` (blue, distinct from web search's orange)

## Test plan

- [ ] \`cd admin && npm run build\` — no errors (vue-tsc passes locally)
- [ ] In chat: branch toggle appears as the first button in the input row, left of the orange globe
- [ ] Toggling it opens/closes the BranchTree side panel as before
- [ ] Header no longer shows GitBranch — only Settings remains there
- [ ] Toggle is hidden when Claude Code orchestra mode is active (\`!cc.isActive.value\` preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)