### PR TITLE
fix(chat): replace branch-tree toggle with new-branch (+) in input row

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -3569,17 +3569,15 @@ class="w-4 h-4 rounded border flex items-center justify-center shrink-0"
             inputPosition === 'bottom' ? 'items-stretch' : 'items-end',
           ]"
         >
-          <!-- Branch tree toggle -->
+          <!-- New branch button (yellow) -->
           <button
-            v-if="!cc.isActive.value"
-            :class="[
-              'p-3 rounded-lg transition-colors shrink-0',
-              showBranchTree ? 'bg-primary/20 text-primary hover:bg-primary/30' : 'bg-secondary text-muted-foreground hover:bg-secondary/80'
-            ]"
-            :title="t('chatView.branchTree')"
-            @click="showBranchTree = !showBranchTree"
+            v-if="currentSessionId"
+            :disabled="newBranchMutation.isPending.value"
+            class="p-3 rounded-lg bg-amber-500 hover:bg-amber-600 text-white transition-colors disabled:opacity-50 shrink-0"
+            :title="t('chatView.newBranch')"
+            @click="startNewBranchAndShowTree"
           >
-            <GitBranch class="w-5 h-5" />
+            <Plus class="w-5 h-5" />
           </button>
           <!-- Web search toggle -->
           <button
@@ -3649,16 +3647,6 @@ class="w-4 h-4 rounded border flex items-center justify-center shrink-0"
             <Loader2 v-else class="w-5 h-5 animate-spin" />
           </button>
         </div>
-        <!-- New branch button (yellow, pinned to right edge) -->
-        <button
-          v-if="currentSessionId"
-          :disabled="newBranchMutation.isPending.value"
-          class="absolute right-4 top-1/2 -translate-y-1/2 p-3 rounded-lg bg-amber-500 hover:bg-amber-600 text-white transition-colors disabled:opacity-50"
-          :title="t('chatView.newBranch')"
-          @click="startNewBranchAndShowTree"
-        >
-          <Plus class="w-5 h-5" />
-        </button>
         <!-- Recording indicator -->
         <div v-if="isRecording" class="mt-2 flex items-center gap-2 text-sm text-red-500">
           <span class="w-2 h-2 bg-red-500 rounded-full animate-pulse"></span>


### PR DESCRIPTION
## What

Replaces the leftmost button in the input row from \`GitBranch\` (toggle BranchTree panel) to \`Plus\` (create new branch). The yellow \`+\` button that was absolute-positioned to the right edge of the input area moves into the flex row at the leftmost position.

Per user feedback: the read-only \"open tree\" toggle was redundant — \`startNewBranchAndShowTree()\` already opens the tree after creating a branch, so the dedicated toggle was duplicate UX.

## Layout

Before (after PR #742):
\`[branch-tree]  [globe]  [textarea]  [paperclip]  [mic]  [send]\` + abs-right yellow \`+\`

After:
\`[+ new branch]  [globe]  [textarea]  [paperclip]  [mic]  [send]\`

## Style

The \`+\` button keeps its existing amber/yellow palette (\`bg-amber-500 hover:bg-amber-600\`) — no other changes. Just dropped \`absolute right-4 top-1/2 -translate-y-1/2\` and added \`shrink-0\`.

## Test plan

- [x] vue-tsc passes locally
- [ ] After deploy: leftmost button is yellow \`+\`, click creates a new branch and opens the tree side panel
- [ ] No more absolute-positioned \`+\` overlapping the right edge of the input area
- [ ] \`GitBranch\` is no longer in the input row, but still used elsewhere in the file (fork button, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)