### PR TITLE
fix(mobile): show foreground push notifications + reword welcome

### DIFF
--- a/mobile/android/app/capacitor.build.gradle
+++ b/mobile/android/app/capacitor.build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(':capacitor-app')
     implementation project(':capacitor-haptics')
     implementation project(':capacitor-keyboard')
+    implementation project(':capacitor-local-notifications')
     implementation project(':capacitor-preferences')
     implementation project(':capacitor-push-notifications')
     implementation project(':capacitor-status-bar')

--- a/mobile/android/capacitor.settings.gradle
+++ b/mobile/android/capacitor.settings.gradle
@@ -11,6 +11,9 @@ project(':capacitor-haptics').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-keyboard'
 project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor/keyboard/android')
 
+include ':capacitor-local-notifications'
+project(':capacitor-local-notifications').projectDir = new File('../node_modules/@capacitor/local-notifications/android')
+
 include ':capacitor-preferences'
 project(':capacitor-preferences').projectDir = new File('../node_modules/@capacitor/preferences/android')
 

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -14,6 +14,7 @@
         "@capacitor/core": "^8.2.0",
         "@capacitor/haptics": "^8.0.1",
         "@capacitor/keyboard": "^8.0.1",
+        "@capacitor/local-notifications": "^8.0.2",
         "@capacitor/preferences": "^8.0.1",
         "@capacitor/push-notifications": "^8.0.3",
         "@capacitor/status-bar": "^8.0.1",
@@ -154,6 +155,15 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-8.0.1.tgz",
       "integrity": "sha512-HDf4qrvvhLRMsgBoqeqIld6hP8JMK/WPbCYMvz8ajhY6TaibYt6B+NQyky4oIPCOfHTz5OcVsuHkbb8fQvGDAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/local-notifications": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/local-notifications/-/local-notifications-8.0.2.tgz",
+      "integrity": "sha512-X7KE/I4ZutMTGVHNUyTjIugYcQEcHJRLks+TsPnOriuS+lo0geSTuaRln6zAZlJSSXSoVMSSzHexdSbIjR/8iw==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,6 +15,7 @@
     "@capacitor/core": "^8.2.0",
     "@capacitor/haptics": "^8.0.1",
     "@capacitor/keyboard": "^8.0.1",
+    "@capacitor/local-notifications": "^8.0.2",
     "@capacitor/preferences": "^8.0.1",
     "@capacitor/push-notifications": "^8.0.3",
     "@capacitor/status-bar": "^8.0.1",

--- a/mobile/src/composables/usePush.ts
+++ b/mobile/src/composables/usePush.ts
@@ -1,5 +1,6 @@
 import { Capacitor } from "@capacitor/core";
 import { PushNotifications } from "@capacitor/push-notifications";
+import { LocalNotifications } from "@capacitor/local-notifications";
 import { App as CapApp } from "@capacitor/app";
 import { api } from "@/api/client";
 import { useAuthStore } from "@/stores/auth";
@@ -56,9 +57,26 @@ export async function initPush(): Promise<void> {
       console.error("[push] registration error", err);
     });
 
-    PushNotifications.addListener("pushNotificationReceived", (notification) => {
-      // Foreground: just log, system tray shows nothing while app open
+    PushNotifications.addListener("pushNotificationReceived", async (notification) => {
+      // Foreground: FCM does NOT show system tray while app is open, so we manually
+      // schedule a local notification so the user still sees it in the tray.
       console.log("[push] received", notification);
+      try {
+        await LocalNotifications.schedule({
+          notifications: [
+            {
+              id: Date.now() % 2147483647,
+              title: notification.title || "AI-Секретарь",
+              body: notification.body || "",
+              extra: notification.data || {},
+              smallIcon: "ic_stat_icon_config_sample",
+              channelId: "default",
+            },
+          ],
+        });
+      } catch (e) {
+        console.error("[push] local notify failed", e);
+      }
     });
 
     PushNotifications.addListener("pushNotificationActionPerformed", (action) => {

--- a/mobile/src/views/ChatListView.vue
+++ b/mobile/src/views/ChatListView.vue
@@ -707,7 +707,9 @@ onMounted(() => {
               <h1 class="text-2xl font-bold text-white mb-2">
                 Привет, {{ auth.user?.username }}
               </h1>
-              <p class="text-stone-400 text-sm">Чем могу помочь?</p>
+              <p class="text-stone-400 text-sm leading-relaxed max-w-sm mx-auto">
+                Я — ваш AI-ассистент. Помогу настроить чат под себя: от написания системного промпта до работы с массивами контекста. Просто опишите задачу — и я проведу вас по шагам.
+              </p>
             </div>
             <div class="w-full max-w-sm mx-auto mb-6">
               <div class="flex items-end gap-2">


### PR DESCRIPTION
## Summary

- Add `@capacitor/local-notifications@8.0.2` (Android Gradle + package.json)
- `usePush.ts`: when a push arrives in foreground, schedule a LocalNotification so the system tray shows it. FCM suppresses tray notifications for active apps, so previously the user saw nothing.
- `ChatListView.vue`: reword welcome from "Чем могу помочь?" to a longer onboarding sentence that frames the assistant's role.

## NEWS

📲 **Уведомления приходят даже когда приложение открыто**

Раньше push-уведомления в мобильном приложении не показывались, если оно было запущено и активно — Android просто игнорировал их. Теперь алерт появляется в системной шторке независимо от того, открыто приложение или нет, чтобы вы не пропускали важные сообщения.

А ещё на главном экране чата встретит обновлённое приветствие, которое сразу подсказывает, что AI-ассистент умеет и как с ним работать.

## Test plan

- [ ] Open APK with app in foreground, send a push from server → notification appears in system tray
- [ ] Open APK with app in background → push appears as before (no regression)
- [ ] Welcome screen on `/chat` (mobile) shows the new copy
- [ ] Tap notification → app opens / chat focuses correctly (existing behaviour)

## Notes

This change ships only via Android Studio APK rebuild — no web admin/server deploy required, so `/пр` cycle skips production/demo deploy steps for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)