### PR TITLE
chore(mobile): bump version to 1.62 + LoginView fallback URL

### DIFF
--- a/admin/src/views/LoginView.vue
+++ b/admin/src/views/LoginView.vue
@@ -22,9 +22,9 @@ const showAbout = ref(false)
 const activeTab = ref<'ai' | 'privacy' | 'features' | 'channels' | 'cases'>('cases')
 
 // Mobile app version — fetched from /admin/mobile/version (driven by MOBILE_LATEST_* env on server)
-const mobileVersion = ref('1.61')
+const mobileVersion = ref('1.62')
 const mobileApkUrl = ref(
-  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-1.61.apk',
+  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-1.62.apk',
 )
 
 async function fetchMobileVersion() {

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.shaerware.aisecretary"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10
-        versionName "1.61"
+        versionCode 11
+        versionName "1.62"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.


### PR DESCRIPTION
## Summary

- `mobile/android/app/build.gradle`: versionCode 10→11, versionName 1.61→1.62
- `admin/src/views/LoginView.vue`: fallback APK download URL bumped to `ai-secretary-1.62.apk` (used only if `/admin/mobile/version` request fails)

## Release artefact

[mobile-v1.62 release](https://github.com/ShaerWare/AI_Secretary_System/releases/tag/mobile-v1.62) with the rebuilt debug-signed APK is already published.

Server env (`MOBILE_LATEST_VERSION_NAME=1.62`, `MOBILE_LATEST_VERSION_CODE=11`, `MOBILE_LATEST_APK_URL=...ai-secretary-1.62.apk`) is also already bumped and `ai-secretary` restarted, so `/admin/mobile/version` returns the new URL right now even before this PR is deployed. This PR just keeps the in-code fallback in sync.

Ships changes from PR #744 (foreground push notifications + welcome message rewrite).

## NEWS

📲 **Мобильное приложение v1.62**

Новая версия мобильного приложения с пуш-уведомлениями, которые приходят даже когда приложение открыто, и обновлённым приветствием на главном экране чата. Скачать можно прямо со страницы входа в админ-панель.

⚠️ Если у вас уже стоит v1.61 — её нужно удалить перед установкой v1.62 (новая сборка имеет другую подпись).

## Test plan

- [x] APK builds via `./gradlew assembleDebug` (mobile/android), 5.6 MB
- [x] Release published, asset reachable via `releases/latest/download/ai-secretary-1.62.apk`
- [x] Server `/admin/mobile/version` returns 1.62
- [ ] Login page on prod: download link shows v1.62 + APK installs
- [ ] Foreground push: open app, send push from server → tray notification appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)