### PR TITLE
fix(chat): restore branch tree toggle in regular chat header

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -3195,6 +3195,18 @@ class="w-4 h-4 rounded border flex items-center justify-center shrink-0"
               </button>
             </div>
           </div>
+          <!-- Branch tree toggle (non-CC) -->
+          <button
+            v-if="!cc.isActive.value"
+            :class="[
+              'p-2 rounded-lg transition-colors',
+              showBranchTree ? 'bg-primary text-primary-foreground' : 'hover:bg-secondary'
+            ]"
+            :title="t('chatView.branchTree')"
+            @click="showBranchTree = !showBranchTree"
+          >
+            <GitBranch class="w-4 h-4" />
+          </button>
           <!-- Input position toggle (hidden on small screens) -->
           <button
             class="hidden sm:inline-flex p-2 rounded-lg hover:bg-secondary transition-colors"


### PR DESCRIPTION
## Summary
- Restore GitBranch toggle in the regular (non-fullscreen) chat header — it was lost in #743 (`23e72c3`) when the input-row toggle got replaced by the new-branch (+) button.
- Zen mode toolbar already has the toggle; regular header now mirrors that.
- Placement: between Export dropdown and Input position toggle.

## Test plan
- [ ] Open a chat session in non-zen mode → confirm GitBranch icon appears next to Export
- [ ] Click toggle → BranchTree side panel opens
- [ ] Click again → panel closes
- [ ] Verify CC mode hides the button (`v-if="!cc.isActive.value"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)