### PR TITLE
fix(migration): inline UniqueConstraint for SQLite compat

### DIFF
--- a/alembic/versions/20260427_0001_add_rss_feeds.py
+++ b/alembic/versions/20260427_0001_add_rss_feeds.py
@@ -71,16 +71,13 @@ def upgrade() -> None:
         ),
         sa.Column("pub_date", sa.DateTime(), nullable=True),
         sa.Column("created", sa.DateTime(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.UniqueConstraint("feed_id", "guid", name="uq_rss_feed_items_feed_guid"),
     )
     op.create_index("ix_rss_feed_items_feed_id", "rss_feed_items", ["feed_id"])
     op.create_index("ix_rss_feed_items_guid", "rss_feed_items", ["guid"])
-    op.create_unique_constraint(
-        "uq_rss_feed_items_feed_guid", "rss_feed_items", ["feed_id", "guid"]
-    )
 
 
 def downgrade() -> None:
-    op.drop_constraint("uq_rss_feed_items_feed_guid", "rss_feed_items", type_="unique")
     op.drop_index("ix_rss_feed_items_guid", table_name="rss_feed_items")
     op.drop_index("ix_rss_feed_items_feed_id", table_name="rss_feed_items")
     op.drop_table("rss_feed_items")


### PR DESCRIPTION
## Summary
- Move `UniqueConstraint(feed_id, guid)` inline into `create_table` so SQLite's no-ALTER-CONSTRAINT limitation doesn't block the upgrade.
- Server `alembic upgrade head` failed with `NotImplementedError: No support for ALTER of constraints in SQLite dialect` after merging #749.

## Test plan
- [ ] `alembic upgrade head` runs cleanly on the production SQLite DB
- [ ] `rss_feeds` and `rss_feed_items` tables created with constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)