### PR TITLE
feat(mobile): assistant switcher in chat header

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -24,7 +24,7 @@ import 'prismjs/components/prism-diff'
 import 'prismjs/components/prism-markdown'
 import 'prismjs/components/prism-jsx'
 import 'prismjs/components/prism-tsx'
-import { chatApi, ttsApi, llmApi, sttApi, wikiRagApi, type ChatSession, type ChatSessionPrompt, type ChatMessage, type ChatImage, type ChatSessionSummary, type CloudProvider, type BranchNode, type SiblingInfo, type TokenUsage, type ShareableUser } from '@/api'
+import { chatApi, ttsApi, llmApi, sttApi, wikiRagApi, api, type ChatSession, type ChatSessionPrompt, type ChatMessage, type ChatImage, type ChatSessionSummary, type CloudProvider, type BranchNode, type SiblingInfo, type TokenUsage, type ShareableUser } from '@/api'
 import BranchTree from '@/components/BranchTree.vue'
 import ChatShareDialog from '@/components/ChatShareDialog.vue'
 import ArtifactPanel, { type Artifact } from '@/components/ArtifactPanel.vue'
@@ -175,6 +175,73 @@ const editingMessageId = ref<string | null>(null)
 const editingContent = ref('')
 const showSettings = ref(false)
 const showUserProfile = ref(false)
+
+// Assistant switcher (mobile-app instances shared with the user via admin).
+// Each instance maps to a per-user ChatSession with source="mobile" +
+// source_id=instance_id, so dialog history is private per (user, assistant).
+type AvailableAssistant = {
+  id: string
+  title: string
+  sessionId: string | null
+}
+const availableAssistants = ref<AvailableAssistant[]>([])
+const showAssistantSwitcher = ref(false)
+const switchingToAssistantId = ref<string | null>(null)
+let assistantsLoaded = false
+
+async function loadAvailableAssistants() {
+  try {
+    const data = await api.get<{ instances: Array<{ id: string; name: string; enabled?: boolean }> }>('/admin/mobile/my-instances')
+    const instances = (data.instances || []).filter(i => i.enabled !== false)
+    if (instances.length === 0) {
+      availableAssistants.value = []
+      return
+    }
+    // Map existing mobile-source sessions to their instance for fast lookup
+    const sessionsRes = await chatApi.listSessions('mobile')
+    const sessionByInstance = new Map<string, string>()
+    for (const s of sessionsRes.sessions || []) {
+      const sid = (s as ChatSessionSummary & { source_id?: string }).source_id
+      if (sid && !sessionByInstance.has(sid)) sessionByInstance.set(sid, s.id)
+    }
+    availableAssistants.value = instances.map(i => ({
+      id: i.id,
+      title: i.name,
+      sessionId: sessionByInstance.get(i.id) || null,
+    }))
+  } catch {
+    availableAssistants.value = []
+  }
+}
+
+function toggleAssistantSwitcher() {
+  showAssistantSwitcher.value = !showAssistantSwitcher.value
+  if (showAssistantSwitcher.value && !assistantsLoaded) {
+    loadAvailableAssistants()
+    assistantsLoaded = true
+  }
+}
+
+async function switchToAssistant(a: AvailableAssistant) {
+  showAssistantSwitcher.value = false
+  if (a.sessionId && a.sessionId === currentSessionId.value) return
+  switchingToAssistantId.value = a.id
+  try {
+    let targetId = a.sessionId
+    if (!targetId) {
+      const created = await chatApi.createSession(undefined, undefined, 'mobile', a.id)
+      targetId = created.session.id
+    }
+    chatRouter.push(`/chat/${targetId}`)
+  } finally {
+    switchingToAssistantId.value = null
+  }
+}
+
+// Refresh assistant list once on mount so badge appears for users who have any.
+onMounted(() => {
+  loadAvailableAssistants().then(() => { assistantsLoaded = true })
+})
 const settingsTab = ref<'session' | 'files'>('session')
 const customPrompt = ref('')
 const sessionPrompts = ref<ChatSessionPrompt[]>([])
@@ -2647,6 +2714,54 @@ class="w-4 h-4 rounded border flex items-center justify-center shrink-0"
         <Moon v-else-if="themeStore.resolvedTheme === 'dark'" class="w-4 h-4" />
         <Palette v-else class="w-4 h-4" />
       </button>
+
+      <!-- Assistant switcher (visible when any pre-configured assistant is shared) -->
+      <div v-if="availableAssistants.length > 0" class="relative shrink-0">
+        <button
+          :class="[
+            'w-8 h-8 rounded-lg flex items-center justify-center transition-colors',
+            showAssistantSwitcher
+              ? 'bg-primary/20 text-primary'
+              : 'text-muted-foreground hover:bg-secondary/50 hover:text-foreground'
+          ]"
+          :title="t('chatView.switchAssistant', 'Сменить ассистента')"
+          @click="toggleAssistantSwitcher"
+        >
+          <Bot class="w-4 h-4" />
+        </button>
+        <div
+          v-if="showAssistantSwitcher"
+          class="absolute left-full ml-2 top-0 zen-glass rounded-xl shadow-2xl py-1 z-50 min-w-[220px] max-w-[280px] animate-scale-in"
+          @click.stop
+        >
+          <div class="px-3 py-1.5 text-[10px] uppercase tracking-wide text-muted-foreground border-b border-border/50">
+            {{ t('chatView.switchAssistant', 'Сменить ассистента') }}
+          </div>
+          <button
+            v-for="a in availableAssistants"
+            :key="a.id"
+            :disabled="switchingToAssistantId === a.id"
+            class="w-full px-3 py-1.5 text-sm text-left hover:bg-secondary/30 transition-colors flex items-center gap-2 disabled:opacity-50"
+            :class="(a.sessionId && a.sessionId === currentSessionId) ? 'bg-primary/10' : ''"
+            @click="switchToAssistant(a)"
+          >
+            <span
+              class="w-1.5 h-1.5 rounded-full shrink-0"
+              :class="(a.sessionId && a.sessionId === currentSessionId) ? 'bg-primary' : 'bg-muted-foreground/40'"
+            />
+            <span
+              class="flex-1 truncate"
+              :class="(a.sessionId && a.sessionId === currentSessionId) ? 'text-primary font-medium' : ''"
+            >{{ a.title }}</span>
+            <Loader2 v-if="switchingToAssistantId === a.id" class="w-3 h-3 animate-spin shrink-0" />
+            <span
+              v-else-if="!a.sessionId"
+              class="text-[10px] uppercase tracking-wide text-muted-foreground/70 shrink-0"
+              :title="t('chatView.assistantNew', 'Сессия будет создана при открытии')"
+            >{{ t('chatView.assistantNewBadge', 'new') }}</span>
+          </button>
+        </div>
+      </div>
 
       <div v-if="isChatOnly" class="w-6 h-px bg-border/50 my-1 shrink-0"></div>
 

--- a/scripts/seed_legal_assistants.py
+++ b/scripts/seed_legal_assistants.py
@@ -1,0 +1,264 @@
+"""
+Seed 4 mobile-app-instance assistants and share them with users:
+
+  - lawyer-ru        (РФ-юрист, кодексы РФ)
+  - lawyer-kz        (РК-юрист, кодексы РК)
+  - accountant-ru    (РФ-бухгалтер, УСН-набор)
+  - accountant-kz    (РК-бухгалтер, НК РК + практика)
+
+KZ variants are shared only with admins and the username `stalkerelectric`
+("пока нет языка"). RU variants are shared with every active user.
+
+Idempotent: re-running updates existing instances and skips duplicate shares.
+
+Usage:
+  venv/bin/python scripts/seed_legal_assistants.py
+  venv/bin/python scripts/seed_legal_assistants.py --dry-run
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+# Project root on sys.path
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("seed_legal_assistants")
+
+
+def _read_prompt(filename: str, fallback: str) -> str:
+    path = PROJECT_ROOT / "prompts" / filename
+    if path.exists():
+        return path.read_text(encoding="utf-8")
+    log.warning("prompts/%s not found, using inline fallback", filename)
+    return fallback
+
+
+# ---------------------------------------------------------------------------
+# Assistant catalog
+# ---------------------------------------------------------------------------
+
+# Slug → (display name, prompt-file or fallback, knowledge-collection slugs, kazakh?)
+ACCOUNTANT_RU_FALLBACK = (
+    "Ты — бухгалтерский ассистент по Российской Федерации. Объясняй нормы НК РФ "
+    "и УСН со ссылками на статьи, не давай налоговых заключений."
+)
+
+ASSISTANTS: list[dict] = [
+    {
+        "id": "lawyer-ru",
+        "name": "Юрист РФ",
+        "description": "Юридический ассистент по праву РФ (УК, КоАП, УПК, ГК, ТК, СК, ЖК).",
+        "prompt_file": "lawyer-ru.md",
+        "prompt_fallback": "Ты — юридический ассистент по праву РФ. Цитируй статьи кодексов.",
+        "collection_slugs": [
+            "ru-uk-rf",
+            "ru-koap-rf",
+            "ru-upk-rf",
+            "ru-gk-rf-1",
+            "ru-gk-rf-2",
+            "ru-gk-rf-3",
+            "ru-gk-rf-4",
+            "ru-tk-rf",
+            "ru-sk-rf",
+            "ru-zhk-rf",
+            "ru-nk-rf-glava-26-2",
+        ],
+        "kazakh": False,
+    },
+    {
+        "id": "lawyer-kz",
+        "name": "Юрист РК",
+        "description": "Юридический ассистент по праву РК (УК, КоАП, УПК, ГК, ТК, НК).",
+        "prompt_file": "lawyer-kz.md",
+        "prompt_fallback": "Ты — юридический ассистент по праву РК. Цитируй статьи кодексов РК.",
+        "collection_slugs": [
+            "kz-uk-rk",
+            "kz-koap-rk",
+            "kz-upk-rk",
+            "kz-gk-rk-general",
+            "kz-gk-rk-special",
+            "kz-tk-rk",
+            "kz-nk-rk",
+        ],
+        "kazakh": True,
+    },
+    {
+        "id": "accountant-ru",
+        "name": "Бухгалтер РФ",
+        "description": "Бухгалтерский ассистент по РФ (УСН + НК РФ глава 26.2).",
+        "prompt_file": "accountant-ru.md",
+        "prompt_fallback": ACCOUNTANT_RU_FALLBACK,
+        "collection_slugs": ["ru-fns-usn", "ru-nk-rf-glava-26-2", "ru-moedelo-usn"],
+        "kazakh": False,
+    },
+    {
+        "id": "accountant-kz",
+        "name": "Бухгалтер РК",
+        "description": "Бухгалтерский ассистент по РК (НК РК + практика КГД).",
+        "prompt_file": "accountant-kz.md",
+        "prompt_fallback": "Ты — бухгалтерский ассистент по РК. Используй НК РК.",
+        "collection_slugs": ["kz-nk-rk", "kz-tk-rk"],
+        "kazakh": True,
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Logic
+# ---------------------------------------------------------------------------
+
+
+async def run(dry_run: bool = False) -> None:
+    from sqlalchemy import select
+
+    from db.database import AsyncSessionLocal
+    from db.models import (
+        KnowledgeCollection,
+        MobileAppInstance,
+        ResourceShare,
+        User,
+    )
+
+    async with AsyncSessionLocal() as session:
+        # Map collection slug → id
+        rows = (await session.execute(select(KnowledgeCollection))).scalars().all()
+        slug_to_id = {c.slug: c.id for c in rows}
+
+        # Eligible users: admin role gets everything; others get RU only,
+        # kz also goes to user `stalkerelectric` (until language preference lands).
+        users = (
+            (await session.execute(select(User).where(User.is_active.is_(True)))).scalars().all()
+        )
+        users = [u for u in users if u.role in ("admin", "user", "web", "guest")]
+
+        log.info("Eligible users: %d", len(users))
+
+        for spec in ASSISTANTS:
+            instance_id = spec["id"]
+            log.info("=== %s (%s) ===", spec["name"], instance_id)
+
+            # Resolve collection IDs
+            collection_ids: list[int] = []
+            for slug in spec["collection_slugs"]:
+                cid = slug_to_id.get(slug)
+                if cid:
+                    collection_ids.append(cid)
+                else:
+                    log.warning("  skip missing collection: %s", slug)
+
+            # Read system prompt
+            prompt_text = _read_prompt(spec["prompt_file"], spec["prompt_fallback"])
+
+            # Upsert instance
+            existing = await session.get(MobileAppInstance, instance_id)
+            now = datetime.utcnow()
+            payload = {
+                "name": spec["name"],
+                "description": spec["description"],
+                "enabled": True,
+                "system_prompt": prompt_text,
+                "rag_mode": "selected" if collection_ids else "all",
+                "knowledge_collection_ids": json.dumps(collection_ids) if collection_ids else None,
+                "updated": now,
+            }
+
+            if existing:
+                if dry_run:
+                    log.info("  [dry] would update instance %s", instance_id)
+                else:
+                    for k, v in payload.items():
+                        setattr(existing, k, v)
+                    log.info("  updated instance (%d collections)", len(collection_ids))
+            elif dry_run:
+                log.info("  [dry] would create instance %s", instance_id)
+            else:
+                instance = MobileAppInstance(
+                    id=instance_id,
+                    created=now,
+                    # Keep defaults the orchestrator's chat facade tolerates;
+                    # admin can refine LLM/TTS later via the Mobile-App view.
+                    llm_backend="cloud",
+                    llm_persona="anna",
+                    tts_engine="xtts",
+                    tts_voice="anna",
+                    **payload,
+                )
+                session.add(instance)
+                log.info("  created instance (%d collections)", len(collection_ids))
+
+            # Decide who should see this assistant
+            if spec["kazakh"]:
+                target_users = [
+                    u for u in users if u.role == "admin" or u.username == "stalkerelectric"
+                ]
+            else:
+                target_users = list(users)
+
+            log.info("  share targets: %d users", len(target_users))
+
+            # Existing shares for this resource
+            existing_shares = (
+                (
+                    await session.execute(
+                        select(ResourceShare).where(
+                            ResourceShare.resource_type == "mobile_app_instance",
+                            ResourceShare.resource_id == instance_id,
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            shared_user_ids = {s.user_id for s in existing_shares}
+
+            new_shares = 0
+            for u in target_users:
+                if u.id in shared_user_ids:
+                    continue
+                if dry_run:
+                    log.info("  [dry] would share with %s (id=%d)", u.username, u.id)
+                else:
+                    session.add(
+                        ResourceShare(
+                            resource_type="mobile_app_instance",
+                            resource_id=instance_id,
+                            user_id=u.id,
+                            permission="view",
+                            shared_by=None,
+                            shared_at=now,
+                        )
+                    )
+                new_shares += 1
+
+            log.info("  +%d new shares (skipped %d existing)", new_shares, len(shared_user_ids))
+
+        if dry_run:
+            log.info("dry-run: rolling back")
+            await session.rollback()
+        else:
+            await session.commit()
+            log.info("committed")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed legal/accountant mobile assistants")
+    parser.add_argument("--dry-run", action="store_true", help="Show planned changes only")
+    args = parser.parse_args()
+
+    asyncio.run(run(dry_run=args.dry_run))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- New Bot button in the admin ChatView right-side zen toolbar (under the theme toggle)
- Lists `MobileAppInstance` rows shared with the current user via `ResourceShare`
- On switch → `findOrCreate` a `ChatSession` with `source=mobile` + `source_id=<instance_id>` and route to it
- Mobile app already renders the same switcher in its header — picks up new instances after seed
- `scripts/seed_legal_assistants.py` creates 4 personas: `lawyer-ru`, `lawyer-kz`, `accountant-ru`, `accountant-kz`, wired to legal/accounting RAG collections, idempotent
- KZ variants are shared only with `admin` role + `stalkerelectric` username (until language preference lands)

## NEWS

🧑‍⚖️ **Готовые ассистенты-юристы и -бухгалтеры в чате**

В правом меню чата появилась кнопка-робот для быстрого переключения между готовыми ассистентами. Юзеры одним кликом открывают «Юриста РФ», «Юриста РК», «Бухгалтера РФ» или «Бухгалтера РК» — каждый со своим системным промптом и подключёнными кодексами/налоговой базой. История диалогов хранится отдельно для каждого ассистента.

## Test plan

- [ ] `venv/bin/python scripts/seed_legal_assistants.py --dry-run` показывает план без изменений
- [ ] После seed — у `shaerware` (admin) видно 4 ассистента, у `stalkerelectric` тоже 4, у `demo` — только 2 RU-варианта
- [ ] Зен-меню админ-чата: появилась шестерёнка-робот под палитрой → выпадающий список → клик по ассистенту → новая сессия
- [ ] Mobile app (chat header dropdown) — те же ассистенты появились
- [ ] Сообщение в `Юрист РФ` инстансе — knowledge_search ходит по `ru-uk-rf`/etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)