### PR TITLE
fix(chat): assistant switcher must skip read-only sessions

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -197,12 +197,18 @@ async function loadAvailableAssistants() {
       availableAssistants.value = []
       return
     }
-    // Map existing mobile-source sessions to their instance for fast lookup
+    // Map mobile-source sessions to their instance. Only consider sessions
+    // the current user can edit — chat-only / non-owner shared sessions
+    // would open in read-only mode, which is wrong for "switch to my
+    // private dialog with this assistant".
     const sessionsRes = await chatApi.listSessions('mobile')
     const sessionByInstance = new Map<string, string>()
     for (const s of sessionsRes.sessions || []) {
-      const sid = (s as ChatSessionSummary & { source_id?: string }).source_id
-      if (sid && !sessionByInstance.has(sid)) sessionByInstance.set(sid, s.id)
+      const ext = s as ChatSessionSummary & { source_id?: string; is_shared_with_me?: boolean }
+      if (ext.is_shared_with_me) continue
+      if (ext.source_id && !sessionByInstance.has(ext.source_id)) {
+        sessionByInstance.set(ext.source_id, s.id)
+      }
     }
     availableAssistants.value = instances.map(i => ({
       id: i.id,


### PR DESCRIPTION
## Summary

When clicking an assistant in the switcher, the user's own private session must open. Before this fix, loadAvailableAssistants matched the FIRST mobile session by source_id — which could be a session shared from another user (admin-shared chat, or another admin's session with owner_id=NULL). Opening that session put the chat in read-only mode (is_shared_with_me=true, default permission='read').

After: the switcher ignores shared sessions, so every (user, assistant) pair always lands on its private dialog with full edit rights.

## Test plan

- [ ] Логин non-admin'ом → клик «Юрист РФ» → открывается своя сессия (не «Только для чтения»)
- [ ] Если у юзера ещё нет сессии — создаётся новая (бейдж `new` в дропдауне)
- [ ] Существующая «своя» сессия по этому ассистенту переоткрывается, история сохраняется

🤖 Generated with [Claude Code](https://claude.com/claude-code)