### PR TITLE
fix(mobile): restore /admin/mobile/my-instances endpoint

### DIFF
--- a/db/repositories/mobile_app_instance.py
+++ b/db/repositories/mobile_app_instance.py
@@ -251,3 +251,21 @@ class MobileAppInstanceRepository(BaseRepository[MobileAppInstance]):
         if not instance or not instance.enabled:
             return None
         return instance.to_dict()
+
+    async def list_user_instances(self, user_id: int) -> List[dict]:
+        """List all enabled mobile instances shared with a user via ResourceShare."""
+        query = (
+            select(MobileAppInstance)
+            .join(
+                ResourceShare,
+                ResourceShare.resource_id == MobileAppInstance.id,
+            )
+            .where(
+                ResourceShare.resource_type == "mobile_app_instance",
+                ResourceShare.user_id == user_id,
+                MobileAppInstance.enabled.is_(True),
+            )
+            .order_by(ResourceShare.shared_at.asc())
+        )
+        result = await self.session.execute(query)
+        return [i.to_dict() for i in result.scalars().all()]

--- a/modules/channels/mobile/router.py
+++ b/modules/channels/mobile/router.py
@@ -229,6 +229,19 @@ async def get_my_mobile_config(user: User = Depends(require_permission("chat", "
     return {"instance": instance}
 
 
+@router.get("/my-instances")
+async def get_my_mobile_instances(user: User = Depends(require_permission("chat", "view"))):
+    """List all mobile app instances assigned to current user.
+
+    Used by the assistant switcher in admin web + mobile app: each instance
+    is a separate persona (system_prompt + RAG collections). Frontend
+    find-or-creates a per-user ChatSession with source="mobile" +
+    source_id=<instance_id> for each.
+    """
+    instances = await mobile_app_instance_service.list_user_instances(user.id)
+    return {"instances": instances}
+
+
 # ============== Version check ==============
 
 

--- a/modules/channels/mobile/service.py
+++ b/modules/channels/mobile/service.py
@@ -93,6 +93,12 @@ class MobileAppInstanceService:
             repo = MobileAppInstanceRepository(session)
             return await repo.get_user_instance(user_id)
 
+    async def list_user_instances(self, user_id: int) -> List[dict]:
+        """List all enabled mobile instances shared with a user."""
+        async with AsyncSessionLocal() as session:
+            repo = MobileAppInstanceRepository(session)
+            return await repo.list_user_instances(user_id)
+
 
 # Singleton
 mobile_app_instance_service = MobileAppInstanceService()


### PR DESCRIPTION
## Summary

Backend endpoint `/admin/mobile/my-instances` + `list_user_instances` repo/service methods were lost during a rebase chain. Frontend assistant switcher (PR #755) calls this endpoint; backend returned 404 → switcher rendered empty → users like `stalkerelectric` saw no Bot button despite having 4 shares in DB.

Restored:
- `MobileAppInstanceRepository.list_user_instances()` — JOIN ResourceShare, filter by user_id + enabled, ordered by shared_at
- Service async wrapper
- `GET /admin/mobile/my-instances` (chat:view permission)

## Test plan

- [ ] `curl http://localhost:8002/admin/mobile/my-instances` с JWT — 200 OK + `{"instances":[...]}`
- [ ] У `stalkerelectric` после рефреша появится Bot-кнопка с 4 ассистентами
- [ ] У admin'ов и web-юзеров с shares кнопка тоже появится

🤖 Generated with [Claude Code](https://claude.com/claude-code)