### PR TITLE
chore(mobile): bump versionCode/versionName to 12/1.7

### DIFF
--- a/admin/src/views/LoginView.vue
+++ b/admin/src/views/LoginView.vue
@@ -22,9 +22,9 @@ const showAbout = ref(false)
 const activeTab = ref<'ai' | 'privacy' | 'features' | 'channels' | 'cases'>('cases')
 
 // Mobile app version — fetched from /admin/mobile/version (driven by MOBILE_LATEST_* env on server)
-const mobileVersion = ref('1.62')
+const mobileVersion = ref('1.7')
 const mobileApkUrl = ref(
-  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-1.62.apk',
+  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-1.7.apk',
 )
 
 async function fetchMobileVersion() {

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.shaerware.aisecretary"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 11
-        versionName "1.62"
+        versionCode 12
+        versionName "1.7"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/mobile/src/views/SettingsView.vue
+++ b/mobile/src/views/SettingsView.vue
@@ -449,7 +449,7 @@ onActivated(refreshAll);
           О приложении
         </h2>
         <div class="bg-stone-800/50 rounded-xl p-4">
-          <p class="text-stone-400 text-sm">AI Секретарь v1.0.0</p>
+          <p class="text-stone-400 text-sm">AI Секретарь v1.7</p>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
Release v1.7 — bumps versionCode 11 → 12 and versionName 1.62 → 1.7. Updates the LoginView default APK URL and the version label in mobile SettingsView.

Stack of mobile changes shipped since v1.62:
- #757 per-user Claude period token indicator
- #760 expanded assistant-switcher tap zone (logo + title + back arrow)
- #762 profile screen (display name / password / Google Drive/Docs/Sheets)
- #763 z-index + reliable assistant switching
- #764 cleaned up header icons (only logo + title)

GitHub release \`mobile-v1.7\` with debug-signed APK will be created right after merge.

## NEWS

📲 **Новая версия мобильного приложения v1.7**

Главное: под индикатором контекста — счётчик токенов Claude за период, в шапке чата клик по логотипу или названию открывает переключатель ассистентов, в настройках появился полноценный профиль (никнейм, пароль, подключение Google Drive/Docs/Sheets). Скачать APK — на странице входа в админку или из релизов GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)