### PR TITLE
feat(mobile): редизайн топбара + новый ассистент + диагностика логина (v1.8)

### DIFF
--- a/.claude/skills/пр/SKILL.md
+++ b/.claude/skills/пр/SKILL.md
@@ -30,6 +30,7 @@ gh issue list --state open --limit 30
 - Какие файлы изменены
 - На какой ветке мы (main или feature)
 - Какие open issues связаны с изменениями
+- **Затронуто ли мобильное приложение** (`mobile/**`, `mobile/android/**`, `mobile/src/**`). Если да — включается полный мобильный цикл (см. шаг 7.5: bump версии, build APK, GitHub Release, обновление ссылок в `LoginView.vue` + `README.md` + wiki, FCM-пуши). Чисто backend-изменения, не влияющие на mobile API контракт, не требуют пересборки APK.
 
 ### 2. Обнови документацию проекта (ОБЯЗАТЕЛЬНО)
 
@@ -54,6 +55,12 @@ gh issue list --state open --limit 30
 - НЕ раздувай документацию — только факты, которые помогают ориентироваться в коде
 
 **Если ничего из перечисленного не изменилось** (чистый багфикс, стилевые правки, мелкий рефакторинг) — пропусти, но осознанно: проверь и убедись что docs актуальны.
+
+**Если затронуто мобильное приложение** (флаг из шага 1) — обнови ВСЕ ссылки на APK в одном коммите:
+- `mobile/android/app/build.gradle`: подними `versionCode` (на 1) и `versionName` (на патч/минор)
+- `admin/src/views/LoginView.vue`: `mobileApkUrl` → `https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-<NEW_VERSION>.apk`
+- `README.md`: бейдж и блок «📱 ai-secretary-X.Y.apk» — поменяй на новую версию (и тег `mobile-vX.Y` в URL, и имя файла, и команду `adb install`)
+- Если изменились screens/UX/permissions — обнови соответствующую страницу wiki (см. шаг 9: «Mobile App.md» / `Home.md`)
 
 ### 3. Коммит
 
@@ -86,6 +93,9 @@ EOF
 - Объясни пользу для конечного пользователя, не технические детали
 - 2-4 предложения, как пост в Telegram-канале
 - Начинай с эмодзи + жирного заголовка
+- **Если затронуто мобильное приложение** — в конце NEWS-блока добавь markdown-кнопку со ссылкой на скачивание новой APK в формате:
+  `[📲 Скачать обновление](https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-<NEW_VERSION>.apk)`
+  и одну строку про то, что нужно установить новую версию. FCM-пуш отрендерит body как plain text, но в Telegram-канале и в админке кнопка будет кликабельна. (Сами FCM-пуши с этим текстом разлетятся автоматически после merge — см. шаг 7.5.)
 
 ### 4. Push + PR
 
@@ -148,6 +158,84 @@ systemctl restart ai-secretary
 curl -s http://localhost:8002/health
 ```
 
+### 7.5. Мобильное приложение: сборка APK + GitHub Release + пуши (только если затронут `mobile/**`)
+
+Этот шаг выполняется ТОЛЬКО когда из шага 1 поднят флаг «затронуто мобильное приложение». Иначе — пропусти.
+
+**a) Собрать APK локально (на машине с GPU/dev — на сервере Android SDK нет):**
+
+```bash
+cd /home/shaerware/Documents/AI_Secretary_System/mobile
+npm ci
+npm run build
+npx cap sync android
+cd android
+./gradlew assembleRelease   # либо assembleDebug если релизный keystore не настроен
+```
+
+APK появится в `mobile/android/app/build/outputs/apk/release/app-release.apk` (или `debug/app-debug.apk`). Переименуй в `ai-secretary-<NEW_VERSION>.apk` (версия должна совпадать со значением `versionName` из `mobile/android/app/build.gradle`, поднятым в шаге 2).
+
+Если build упал — починить и пересобрать; не выкатывай старую APK как новую версию.
+
+**b) Создать GitHub Release с тегом `mobile-v<NEW_VERSION>`:**
+
+```bash
+cd /home/shaerware/Documents/AI_Secretary_System
+gh release create mobile-v<NEW_VERSION> \
+  /path/to/ai-secretary-<NEW_VERSION>.apk \
+  --title "Mobile v<NEW_VERSION>" \
+  --notes "$(cat <<'EOF'
+## Что нового
+<скопируй сюда блок NEWS из коммита/PR — без эмодзи-заголовка лишний раз>
+
+## Установка
+Скачай APK по ссылке ниже, открой на Android-устройстве, разреши установку из неизвестных источников, обнови приложение.
+
+📲 [Скачать ai-secretary-<NEW_VERSION>.apk](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v<NEW_VERSION>/ai-secretary-<NEW_VERSION>.apk)
+EOF
+)"
+```
+
+**Важно:** ссылка `releases/latest/download/ai-secretary-<NEW_VERSION>.apk` (которую мы прописали в `LoginView.vue` на шаге 2) работает ТОЛЬКО если этот релиз помечен как latest — `gh release create` без `--prerelease` делает это по умолчанию. Если релиз был случайно помечен как pre-release — `gh release edit mobile-v<NEW_VERSION> --latest`.
+
+**c) Обновить env с актуальной версией для эндпоинта `GET /admin/mobile/version`** (мобилка опрашивает его на старте и показывает баннер обновления):
+
+```bash
+# на проде:
+ssh root@155.212.231.7 "
+  sed -i 's/^MOBILE_LATEST_VERSION_NAME=.*/MOBILE_LATEST_VERSION_NAME=<NEW_VERSION>/;
+          s/^MOBILE_LATEST_VERSION_CODE=.*/MOBILE_LATEST_VERSION_CODE=<NEW_VERSION_CODE>/;
+          s|^MOBILE_LATEST_APK_URL=.*|MOBILE_LATEST_APK_URL=https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v<NEW_VERSION>/ai-secretary-<NEW_VERSION>.apk|' \
+    /opt/ai-secretary/.env
+  systemctl restart ai-secretary
+"
+```
+
+Если переменных в `.env` ещё нет — допиши их в конец файла (см. `modules/channels/mobile/router.py:get_latest_version` для дефолтов).
+
+**d) FCM-пуши пользователям.**
+
+При merge PR с секцией `## NEWS` GitHub-webhook автоматически разсылает пуш всем подписанным мобильным устройствам (см. `modules/admin/router_github_webhook.py` + `project_mobile_push.md`). Текст NEWS должен ВКЛЮЧАТЬ ссылку-кнопку на скачивание (правило из шага 3) — тогда пуш сам по себе является «нажми → скачай → установи → обнови».
+
+Проверь, что пуши ушли:
+
+```bash
+ssh root@155.212.231.7 "journalctl -u ai-secretary -n 200 | grep -i 'fcm\\|push' | tail -30"
+# или вручную:
+curl -s http://155.212.231.7:8002/admin/mobile/push/status -H "Authorization: Bearer $TOKEN"
+# fcm_enabled должно быть true, total_tokens — число подписанных устройств
+```
+
+Если `fcm_enabled=false` или пушей не было — проверь `/opt/ai-secretary/firebase-service-account.json` и row в `bot_github_configs` (см. `project_mobile_push.md`, шаги 1–3).
+
+**e) Дополнительно (если автоматика подвела) — ручной broadcast:**
+
+```bash
+curl -X POST http://155.212.231.7:8002/admin/mobile/push/test \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"to_all":true,"title":"Доступно обновление AI-Секретаря","body":"Новая версия <NEW_VERSION>. Скачай и установи: https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-<NEW_VERSION>.apk"}'
+```
+
 ### 8. Deploy demo
 
 ```
@@ -169,6 +257,12 @@ git clone https://github.com/ShaerWare/AI_Secretary_System.wiki.git wiki-update
 - Новая фича → обнови соответствующую страницу (Chat.md, Widget.md, etc.)
 - Новая страница → создай файл + добавь в `_Sidebar.md`
 - Home.md → обнови список фич если добавилась крупная
+- **Если затронуто мобильное приложение** (флаг из шага 1) — ОБЯЗАТЕЛЬНО:
+  - Найди страницу про мобилку (`Mobile-App.md`, `Mobile.md` или аналог; если её нет — создай и добавь в `_Sidebar.md`)
+  - Обнови блок «Текущая версия»: номер `versionName`/`versionCode`, дату релиза
+  - Обнови прямую ссылку на APK на `https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v<NEW_VERSION>/ai-secretary-<NEW_VERSION>.apk` И добавь markdown-кнопку «📲 Скачать ai-secretary-<NEW_VERSION>.apk»
+  - Опиши, что нового в этой версии (можно скопировать из NEWS), укажи что старая версия устарела и обновление обязательно
+  - Если изменились permissions/системные требования/процесс установки — обнови соответствующие секции
 
 ```
 cd /tmp/wiki-update
@@ -178,7 +272,7 @@ git push
 rm -rf /tmp/wiki-update
 ```
 
-**Пропусти этот шаг если изменения мелкие (багфикс, рефакторинг, стилевые правки).**
+**Пропусти этот шаг если изменения мелкие (багфикс, рефакторинг, стилевые правки)** — НО для мобильного релиза wiki обновляется всегда (страница с APK-ссылкой должна указывать на актуальную версию).
 
 ### 10. Закрой issues
 
@@ -200,3 +294,8 @@ gh issue close <N> --comment "Done in PR #<PR_NUMBER>"
 - Статус деплоя (production + demo)
 - Обновлена ли wiki
 - Ссылку на NEWS (если была) для проверки в Telegram
+- **Если был мобильный релиз** (выполнялся шаг 7.5):
+  - Новая версия (`versionName` + `versionCode`)
+  - Ссылку на GitHub Release `mobile-v<NEW_VERSION>` и прямую ссылку на APK
+  - Сколько устройств получили FCM-пуш (`delivered: N` из `/admin/mobile/push/status` или ручного `/admin/mobile/push/test`)
+  - Подтверждение, что `LoginView.vue`, `README.md` и wiki-страница про мобилку указывают на новую версию

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [![Сайт и демо админки](https://img.shields.io/badge/Сайт_и_демо_админки-ai--sekretar24.ru-4285F4?style=for-the-badge&logo=google-chrome&logoColor=white)](https://ai-sekretar24.ru/)
 [![Telegram поддержка](https://img.shields.io/badge/Поддержка_и_ассистент-@ai__sekretar24bot-26A5E4?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/ai_sekretar24bot)
-[![Android APK](https://img.shields.io/badge/Android_APK-v1.3-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.3/ai-secretary-1.3.apk)
+[![Android APK](https://img.shields.io/badge/Android_APK-v1.8-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.8/ai-secretary-1.8.apk)
 
 [Сайт проекта и демо админки](https://ai-sekretar24.ru/) (логин/пароль: `admin` / `admin`) | [Telegram поддержки и ассистент проекта](https://t.me/ai_sekretar24bot) | [Wiki](https://github.com/ShaerWare/AI_Secretary_System/wiki) | [Issues](https://github.com/ShaerWare/AI_Secretary_System/issues) | [Android APK](https://github.com/ShaerWare/AI_Secretary_System/releases/latest)
 
@@ -563,13 +563,13 @@ curl -X POST http://localhost:8002/admin/telegram/instances/{id}/start
 
 **Скачать APK:**
 
-📱 [**ai-secretary-1.3.apk**](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.3/ai-secretary-1.3.apk) — последняя сборка (debug, не подписана для Play Store)
+📱 [**ai-secretary-1.8.apk**](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.8/ai-secretary-1.8.apk) — последняя сборка (debug, не подписана для Play Store)
 
 Все релизы: [github.com/ShaerWare/AI_Secretary_System/releases](https://github.com/ShaerWare/AI_Secretary_System/releases)
 
 **Установка через adb:**
 ```bash
-adb install -r ai-secretary-1.3.apk
+adb install -r ai-secretary-1.8.apk
 ```
 
 Или скопируйте APK на телефон и откройте в файловом менеджере (разрешите «Установка из неизвестных источников»). При ошибке `INSTALL_FAILED_UPDATE_INCOMPATIBLE` сначала удалите старую версию: `adb uninstall com.shaerware.aisecretary`.

--- a/admin/src/views/LoginView.vue
+++ b/admin/src/views/LoginView.vue
@@ -22,9 +22,9 @@ const showAbout = ref(false)
 const activeTab = ref<'ai' | 'privacy' | 'features' | 'channels' | 'cases'>('cases')
 
 // Mobile app version — fetched from /admin/mobile/version (driven by MOBILE_LATEST_* env on server)
-const mobileVersion = ref('1.7')
+const mobileVersion = ref('1.8')
 const mobileApkUrl = ref(
-  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-1.7.apk',
+  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-1.8.apk',
 )
 
 async function fetchMobileVersion() {

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.shaerware.aisecretary"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 12
-        versionName "1.7"
+        versionCode 13
+        versionName "1.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/mobile/src/api/chat.ts
+++ b/mobile/src/api/chat.ts
@@ -130,14 +130,16 @@ export const chatApi = {
       `/admin/chat/sessions/${id}`,
     ),
 
-  createSession: (title?: string) => {
+  createSession: (title?: string, options?: { skipInstancePrompt?: boolean }) => {
     const config = useMobileConfigStore();
     const instanceId = config.instance?.id;
     return api.post<{ session: ChatSession }>("/admin/chat/sessions", {
       title,
       source: "mobile",
       source_id: instanceId || undefined,
-      system_prompt: config.instance?.system_prompt || undefined,
+      system_prompt: options?.skipInstancePrompt
+        ? undefined
+        : config.instance?.system_prompt || undefined,
     });
   },
 

--- a/mobile/src/stores/auth.ts
+++ b/mobile/src/stores/auth.ts
@@ -84,8 +84,10 @@ export const useAuthStore = defineStore("auth", () => {
       };
 
       return true;
-    } catch {
-      error.value = "Connection error";
+    } catch (e) {
+      const msg = e instanceof Error ? `${e.name}: ${e.message}` : String(e);
+      console.error("[login] failed", e);
+      error.value = `Connection error — ${msg}`;
       return false;
     } finally {
       isLoading.value = false;

--- a/mobile/src/views/ChatView.vue
+++ b/mobile/src/views/ChatView.vue
@@ -41,6 +41,7 @@ type AvailableAssistant = {
 };
 const availableAssistants = ref<AvailableAssistant[]>([]);
 const showAssistantSwitcher = ref(false);
+const isCreatingAssistant = ref(false);
 
 // Panels
 const showBranches = ref(false);
@@ -224,6 +225,28 @@ async function switchToAssistant(id: string) {
   // (Vue Router reuses the same component instance for same-named routes)
   await loadSession();
   if (showBranches.value) await loadBranches();
+}
+
+async function createNewAssistant() {
+  if (isCreatingAssistant.value) return;
+  isCreatingAssistant.value = true;
+  try {
+    const data = await chatApi.createSession(undefined, { skipInstancePrompt: true });
+    showAssistantSwitcher.value = false;
+    closePanel();
+    messages.value = [];
+    branches.value = [];
+    contextFiles.value = [];
+    sessionPrompts.value = [];
+    selectedPromptId.value = null;
+    streamingContent.value = "";
+    await router.replace(`/chat/${data.session.id}`);
+    await loadSession();
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Не удалось создать";
+  } finally {
+    isCreatingAssistant.value = false;
+  }
 }
 
 function toggleWebSearch() {
@@ -935,20 +958,18 @@ onUnmounted(() => {
         class="shrink-0 flex items-center gap-2 px-3 py-2.5 border-b border-stone-800 bg-stone-950/95 backdrop-blur relative z-30"
       >
         <button
-          class="shrink-0 hover:opacity-80 transition-opacity"
-          title="Переключить ассистента"
-          @click="toggleAssistantSwitcher"
+          class="w-8 h-8 rounded-lg border border-amber-500 bg-amber-600 text-white hover:bg-amber-500 flex items-center justify-center transition-colors shrink-0"
+          title="Новая ветка"
+          @click="createNewBranch"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-6 h-6">
-            <defs><linearGradient id="hg" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#F0A830"/><stop offset="100%" stop-color="#C27010"/></linearGradient></defs>
-            <path fill="url(#hg)" fill-rule="evenodd" d="M 431.8 217.4 L 484.1 226.3 L 484.1 285.7 L 431.8 294.6 L 407.6 353.0 L 438.3 396.3 L 396.3 438.3 L 353.0 407.6 L 294.6 431.8 L 285.7 484.1 L 226.3 484.1 L 217.4 431.8 L 159.0 407.6 L 115.7 438.3 L 73.7 396.3 L 104.4 353.0 L 80.2 294.6 L 27.9 285.7 L 27.9 226.3 L 80.2 217.4 L 104.4 159.0 L 73.7 115.7 L 115.7 73.7 L 159.0 104.4 L 217.4 80.2 L 226.3 27.9 L 285.7 27.9 L 294.6 80.2 L 353.0 104.4 L 396.3 73.7 L 438.3 115.7 L 407.6 159.0 Z M 341.0 256.0 A 85 85 0 1 0 171.0 256.0 A 85 85 0 1 0 341.0 256.0 Z"/>
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
           </svg>
         </button>
         <!-- Title + assistant switcher -->
         <div class="relative flex-1 min-w-0">
           <button
             class="w-full text-left"
-            :disabled="availableAssistants.length <= 1"
             title="Переключить ассистента"
             @click="toggleAssistantSwitcher"
           >
@@ -959,12 +980,26 @@ onUnmounted(() => {
 
           <!-- Dropdown -->
           <div
-            v-if="showAssistantSwitcher && availableAssistants.length > 1"
+            v-if="showAssistantSwitcher"
             class="absolute left-0 right-0 top-full mt-1 bg-stone-900 border border-stone-700 rounded-lg shadow-2xl z-50 max-h-[60vh] overflow-y-auto"
           >
             <div class="px-3 py-2 text-[10px] uppercase tracking-wide text-stone-500 border-b border-stone-800 sticky top-0 bg-stone-900">
               Переключить ассистента
             </div>
+            <button
+              class="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-stone-800 transition-colors border-b border-stone-800"
+              :disabled="isCreatingAssistant"
+              @click="createNewAssistant"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="text-amber-400 shrink-0">
+                <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+              <span class="text-sm flex-1 truncate text-amber-300 font-medium">Создать нового ассистента</span>
+              <span
+                v-if="isCreatingAssistant"
+                class="w-3 h-3 border-2 border-amber-400 border-t-transparent rounded-full animate-spin shrink-0"
+              />
+            </button>
             <button
               v-for="a in availableAssistants"
               :key="a.id"
@@ -987,17 +1022,6 @@ onUnmounted(() => {
             </button>
           </div>
         </div>
-
-        <!-- Toolbar buttons -->
-        <button
-          class="w-8 h-8 rounded-lg border border-amber-500 bg-amber-600 text-white hover:bg-amber-500 flex items-center justify-center transition-colors shrink-0"
-          title="Новая ветка"
-          @click="createNewBranch"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
-          </svg>
-        </button>
 
         <button
           class="p-1.5 rounded-lg transition-colors"

--- a/mobile/src/views/LoginView.vue
+++ b/mobile/src/views/LoginView.vue
@@ -24,9 +24,14 @@ onMounted(async () => {
 
 async function handleLogin() {
   const ok = await auth.login(username.value, password.value);
-  if (ok) {
+  if (!ok) return;
+  try {
     await mobileConfig.load();
-    router.replace("/chats");
+    await router.replace("/chats");
+  } catch (e) {
+    const msg = e instanceof Error ? `${e.name}: ${e.message}` : String(e);
+    console.error("[login] post-login step failed", e);
+    auth.error = `После логина: ${msg}`;
   }
 }
 </script>


### PR DESCRIPTION
## Summary

- Мобильный UX чата: кнопка «новая ветка» переехала слева от названия ассистента (единое место для быстрых действий, шестерёнка-индикатор убрана)
- В дропдауне переключения ассистентов появился пункт **«Создать нового ассистента»** — создаёт чистую сессию без instance `system_prompt` (через новый параметр `skipInstancePrompt` у `chatApi.createSession`)
- Лучше диагностика ошибок логина: `LoginView` теперь показывает реальную причину сбоя (имя ошибки + сообщение) вместо абстрактного «Connection error», в т.ч. ошибки пост-логин шага (`mobileConfig.load`, `router.replace`)
- Версия мобилки поднята: **1.7 → 1.8**, `versionCode 12 → 13`
- Обновлены ссылки на APK: `admin/src/views/LoginView.vue` (mobileApkUrl) и `README.md` (бейдж + блок установки + `adb install`) — последний отставал ещё с v1.3
- В скилл `/пр` добавлен расширенный мобильный цикл: build APK → GitHub Release → FCM-пуши → обновление login/wiki/README

## NEWS

📲 **Обновление AI-Секретаря для Android — версия 1.8**

В чате теперь удобнее: кнопка «Новая ветка» переехала влево, в один клик от названия ассистента. А в меню переключения ассистентов появилась опция «Создать нового ассистента» — нажмите и получите чистый чат с персональным системным промптом. Если возникнут проблемы со входом — приложение теперь точно скажет, что пошло не так.

[📲 Скачать обновление](https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-1.8.apk)

Установите новую версию, чтобы получить эти улучшения.

## Test plan

- [ ] Открыть чат → кнопка «+» (новая ветка) видна слева, создаёт ветку
- [ ] Нажать на название ассистента → дропдаун открывается даже если ассистент один
- [ ] В дропдауне нажать «Создать нового ассистента» → переход в новую сессию без system_prompt от instance, кнопка показывает спиннер во время создания
- [ ] Логин с правильными credentials → переход в `/chats`
- [ ] Логин с неправильным паролем / при отключённой сети → отображается полное сообщение об ошибке (`TypeError: ...`, `HTTPError: 401 ...` и т.п.)
- [ ] APK 1.8 устанавливается поверх 1.7 без `INSTALL_FAILED_UPDATE_INCOMPATIBLE`
- [ ] `GET /admin/mobile/version` возвращает `version_name: "1.8"`, `apk_url: ...mobile-v1.8/ai-secretary-1.8.apk`
- [ ] На login-странице веб-админки кнопка «Скачать Android-приложение» ведёт на 1.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)