### PR TITLE
feat(mobile): chevron + resizable-панель ассистентов как у настроек чата (v1.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [![Сайт и демо админки](https://img.shields.io/badge/Сайт_и_демо_админки-ai--sekretar24.ru-4285F4?style=for-the-badge&logo=google-chrome&logoColor=white)](https://ai-sekretar24.ru/)
 [![Telegram поддержка](https://img.shields.io/badge/Поддержка_и_ассистент-@ai__sekretar24bot-26A5E4?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/ai_sekretar24bot)
-[![Android APK](https://img.shields.io/badge/Android_APK-v1.8-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.8/ai-secretary-1.8.apk)
+[![Android APK](https://img.shields.io/badge/Android_APK-v1.9-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.9/ai-secretary-1.9.apk)
 
 [Сайт проекта и демо админки](https://ai-sekretar24.ru/) (логин/пароль: `admin` / `admin`) | [Telegram поддержки и ассистент проекта](https://t.me/ai_sekretar24bot) | [Wiki](https://github.com/ShaerWare/AI_Secretary_System/wiki) | [Issues](https://github.com/ShaerWare/AI_Secretary_System/issues) | [Android APK](https://github.com/ShaerWare/AI_Secretary_System/releases/latest)
 
@@ -563,13 +563,13 @@ curl -X POST http://localhost:8002/admin/telegram/instances/{id}/start
 
 **Скачать APK:**
 
-📱 [**ai-secretary-1.8.apk**](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.8/ai-secretary-1.8.apk) — последняя сборка (debug, не подписана для Play Store)
+📱 [**ai-secretary-1.9.apk**](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.9/ai-secretary-1.9.apk) — последняя сборка (debug, не подписана для Play Store)
 
 Все релизы: [github.com/ShaerWare/AI_Secretary_System/releases](https://github.com/ShaerWare/AI_Secretary_System/releases)
 
 **Установка через adb:**
 ```bash
-adb install -r ai-secretary-1.8.apk
+adb install -r ai-secretary-1.9.apk
 ```
 
 Или скопируйте APK на телефон и откройте в файловом менеджере (разрешите «Установка из неизвестных источников»). При ошибке `INSTALL_FAILED_UPDATE_INCOMPATIBLE` сначала удалите старую версию: `adb uninstall com.shaerware.aisecretary`.

--- a/admin/src/views/LoginView.vue
+++ b/admin/src/views/LoginView.vue
@@ -22,9 +22,9 @@ const showAbout = ref(false)
 const activeTab = ref<'ai' | 'privacy' | 'features' | 'channels' | 'cases'>('cases')
 
 // Mobile app version — fetched from /admin/mobile/version (driven by MOBILE_LATEST_* env on server)
-const mobileVersion = ref('1.8')
+const mobileVersion = ref('1.9')
 const mobileApkUrl = ref(
-  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-1.8.apk',
+  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-1.9.apk',
 )
 
 async function fetchMobileVersion() {

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.shaerware.aisecretary"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 13
-        versionName "1.8"
+        versionCode 14
+        versionName "1.9"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/mobile/src/views/ChatView.vue
+++ b/mobile/src/views/ChatView.vue
@@ -203,10 +203,15 @@ async function loadAvailableAssistants() {
 }
 
 function toggleAssistantSwitcher() {
-  if (!showAssistantSwitcher.value) {
-    loadAvailableAssistants();
+  if (showAssistantSwitcher.value) {
+    showAssistantSwitcher.value = false;
+    return;
   }
-  showAssistantSwitcher.value = !showAssistantSwitcher.value;
+  showBranches.value = false;
+  showContextFiles.value = false;
+  showSettings.value = false;
+  showAssistantSwitcher.value = true;
+  loadAvailableAssistants();
 }
 
 async function switchToAssistant(id: string) {
@@ -448,6 +453,7 @@ async function loadBranches() {
 function toggleBranches() {
   showContextFiles.value = false;
   showSettings.value = false;
+  showAssistantSwitcher.value = false;
   showBranches.value = !showBranches.value;
   if (showBranches.value) loadBranches();
 }
@@ -669,6 +675,7 @@ async function deleteBranchNode(nodeId: string) {
 function toggleSettings() {
   showBranches.value = false;
   showContextFiles.value = false;
+  showAssistantSwitcher.value = false;
   showSettings.value = !showSettings.value;
 }
 
@@ -847,6 +854,7 @@ function handleSaveToContext(_messageId: string, content: string) {
   showContextFiles.value = true;
   showBranches.value = false;
   showSettings.value = false;
+  showAssistantSwitcher.value = false;
 }
 
 async function handleSummarizeBranch(messageId: string) {
@@ -858,6 +866,7 @@ async function handleSummarizeBranch(messageId: string) {
     showContextFiles.value = true;
     showBranches.value = false;
     showSettings.value = false;
+    showAssistantSwitcher.value = false;
   } catch (e) {
     error.value = e instanceof Error ? e.message : "Не удалось суммаризировать";
   }
@@ -891,8 +900,11 @@ async function handleDeleteFromMessage(messageId: string) {
   }
 }
 
-const anyPanelOpen = computed(() => showBranches.value || showContextFiles.value || showSettings.value);
+const anyPanelOpen = computed(
+  () => showBranches.value || showContextFiles.value || showSettings.value || showAssistantSwitcher.value,
+);
 const activePanelName = computed(() => {
+  if (showAssistantSwitcher.value) return "Ассистенты";
   if (showBranches.value) return "Дерево веток";
   if (showContextFiles.value) return "Файлы контекста";
   if (showSettings.value) return "Настройки";
@@ -903,6 +915,7 @@ function closePanel() {
   showBranches.value = false;
   showContextFiles.value = false;
   showSettings.value = false;
+  showAssistantSwitcher.value = false;
 }
 
 watch(streamingContent, () => {
@@ -966,62 +979,33 @@ onUnmounted(() => {
             <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
           </svg>
         </button>
-        <!-- Title + assistant switcher -->
-        <div class="relative flex-1 min-w-0">
-          <button
-            class="w-full text-left"
-            title="Переключить ассистента"
-            @click="toggleAssistantSwitcher"
+        <!-- Title + chevron (both open assistant panel) -->
+        <button
+          class="flex-1 min-w-0 text-left flex items-center gap-1"
+          title="Переключить ассистента"
+          @click="toggleAssistantSwitcher"
+        >
+          <h1 class="text-sm font-medium text-white truncate">
+            {{ title }}
+          </h1>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="shrink-0 transition-transform"
+            :class="[
+              showAssistantSwitcher ? 'rotate-180 text-amber-400' : 'text-stone-400',
+            ]"
           >
-            <h1 class="text-sm font-medium text-white truncate">
-              {{ title }}
-            </h1>
-          </button>
-
-          <!-- Dropdown -->
-          <div
-            v-if="showAssistantSwitcher"
-            class="absolute left-0 right-0 top-full mt-1 bg-stone-900 border border-stone-700 rounded-lg shadow-2xl z-50 max-h-[60vh] overflow-y-auto"
-          >
-            <div class="px-3 py-2 text-[10px] uppercase tracking-wide text-stone-500 border-b border-stone-800 sticky top-0 bg-stone-900">
-              Переключить ассистента
-            </div>
-            <button
-              class="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-stone-800 transition-colors border-b border-stone-800"
-              :disabled="isCreatingAssistant"
-              @click="createNewAssistant"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="text-amber-400 shrink-0">
-                <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
-              </svg>
-              <span class="text-sm flex-1 truncate text-amber-300 font-medium">Создать нового ассистента</span>
-              <span
-                v-if="isCreatingAssistant"
-                class="w-3 h-3 border-2 border-amber-400 border-t-transparent rounded-full animate-spin shrink-0"
-              />
-            </button>
-            <button
-              v-for="a in availableAssistants"
-              :key="a.id"
-              class="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-stone-800 transition-colors"
-              :class="a.id === sessionId ? 'bg-amber-600/15' : ''"
-              @click="switchToAssistant(a.id)"
-            >
-              <span
-                class="w-1.5 h-1.5 rounded-full shrink-0"
-                :class="a.id === sessionId ? 'bg-amber-400' : 'bg-stone-600'"
-              />
-              <span
-                class="text-sm flex-1 truncate"
-                :class="a.id === sessionId ? 'text-amber-300 font-medium' : 'text-stone-200'"
-              >{{ a.title }}</span>
-              <span
-                v-if="a.is_default_mobile"
-                class="text-[10px] uppercase tracking-wide text-stone-500 shrink-0"
-              >по умолч.</span>
-            </button>
-          </div>
-        </div>
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </button>
 
         <button
           class="p-1.5 rounded-lg transition-colors"
@@ -1077,6 +1061,53 @@ onUnmounted(() => {
           class="shrink-0 bg-stone-900/95 border-b border-stone-700 overflow-y-auto flex flex-col"
           :style="{ height: panelSize + 'px' }"
         >
+          <!-- Assistants -->
+          <template v-if="showAssistantSwitcher">
+            <div class="px-3 py-2 flex items-center gap-2 border-b border-stone-800 sticky top-0 bg-stone-900/95 backdrop-blur z-10">
+              <span class="text-xs font-medium text-stone-400 uppercase tracking-wide flex-1">Ассистенты</span>
+              <button class="text-stone-500 hover:text-white transition-colors" @click="closePanel">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+            <button
+              class="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-stone-800 transition-colors border-b border-stone-800"
+              :disabled="isCreatingAssistant"
+              @click="createNewAssistant"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="text-amber-400 shrink-0">
+                <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+              <span class="text-sm flex-1 truncate text-amber-300 font-medium">Создать нового ассистента</span>
+              <span
+                v-if="isCreatingAssistant"
+                class="w-3 h-3 border-2 border-amber-400 border-t-transparent rounded-full animate-spin shrink-0"
+              />
+            </button>
+            <div v-if="!availableAssistants.length" class="px-3 py-3 text-sm text-stone-500">Других ассистентов пока нет</div>
+            <button
+              v-for="a in availableAssistants"
+              :key="a.id"
+              class="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-stone-800 transition-colors"
+              :class="a.id === sessionId ? 'bg-amber-600/15' : ''"
+              @click="switchToAssistant(a.id)"
+            >
+              <span
+                class="w-1.5 h-1.5 rounded-full shrink-0"
+                :class="a.id === sessionId ? 'bg-amber-400' : 'bg-stone-600'"
+              />
+              <span
+                class="text-sm flex-1 truncate"
+                :class="a.id === sessionId ? 'text-amber-300 font-medium' : 'text-stone-200'"
+              >{{ a.title }}</span>
+              <span
+                v-if="a.is_default_mobile"
+                class="text-[10px] uppercase tracking-wide text-stone-500 shrink-0"
+              >по умолч.</span>
+            </button>
+          </template>
+
           <!-- Branch Tree -->
           <template v-if="showBranches">
             <div class="px-3 py-2 flex items-center gap-2">
@@ -1484,6 +1515,47 @@ onUnmounted(() => {
             </svg>
           </button>
         </div>
+
+        <!-- Assistants (landscape) -->
+        <template v-if="showAssistantSwitcher">
+          <button
+            class="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-stone-800 transition-colors border-b border-stone-800"
+            :disabled="isCreatingAssistant"
+            @click="createNewAssistant"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="text-amber-400 shrink-0">
+              <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+            <span class="text-sm flex-1 truncate text-amber-300 font-medium">Создать нового ассистента</span>
+            <span
+              v-if="isCreatingAssistant"
+              class="w-3 h-3 border-2 border-amber-400 border-t-transparent rounded-full animate-spin shrink-0"
+            />
+          </button>
+          <div v-if="!availableAssistants.length" class="px-3 py-3 text-sm text-stone-500">Других ассистентов пока нет</div>
+          <div v-else class="flex-1 overflow-y-auto">
+            <button
+              v-for="a in availableAssistants"
+              :key="a.id"
+              class="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-stone-800 transition-colors"
+              :class="a.id === sessionId ? 'bg-amber-600/15' : ''"
+              @click="switchToAssistant(a.id)"
+            >
+              <span
+                class="w-1.5 h-1.5 rounded-full shrink-0"
+                :class="a.id === sessionId ? 'bg-amber-400' : 'bg-stone-600'"
+              />
+              <span
+                class="text-sm flex-1 truncate"
+                :class="a.id === sessionId ? 'text-amber-300 font-medium' : 'text-stone-200'"
+              >{{ a.title }}</span>
+              <span
+                v-if="a.is_default_mobile"
+                class="text-[10px] uppercase tracking-wide text-stone-500 shrink-0"
+              >по умолч.</span>
+            </button>
+          </div>
+        </template>
 
         <!-- Branch Tree (landscape) -->
         <template v-if="showBranches">


### PR DESCRIPTION
## Summary

Раньше переключение ассистента жило в маленьком плавающем dropdown под названием чата. Теперь это полноценная **четвёртая панель** в одном ряду с ветками / файлами контекста / настройками — с тем же resizable-механизмом, ориентационной логикой и close-кнопкой.

- Справа от названия чата в шапке — chevron-↓ (`<polyline points="6 9 12 15 18 9" />`). Клик по chevron и клик по самому названию открывают одну и ту же панель. При открытом состоянии стрелочка `rotate-180` и подсвечена янтарным.
- Старый абсолютный dropdown под названием **удалён**, чтобы не было двух конкурирующих UI у одного флага `showAssistantSwitcher`.
- **Portrait** (вертикально): панель выезжает сверху во всю ширину, размер тянется пальцем за нижний resize-handle (`cursor-row-resize`).
- **Landscape** (горизонтально): панель выезжает справа во всю высоту, размер тянется за левый resize-handle (`cursor-col-resize`).
- Используется существующий `panelSize` / `onResizeStart/Move/End` (общий с другими панелями) — никаких новых listener-ов / refs.
- Заголовок панели «Ассистенты» добавлен в `activePanelName`, флаг — в `anyPanelOpen`.
- Симметричный close-flow: `toggleAssistantSwitcher`, `toggleBranches`, `toggleSettings`, `handleSaveToContext`, `handleSummarizeBranch`, `closePanel` — все обновлены, чтобы при открытии любой из четырёх панелей остальные закрывались.
- Внутри панели — кнопка «Создать нового ассистента» (как и раньше), список доступных ассистентов с indicator-точкой / бейджем «по умолч.» и graceful empty-state «Других ассистентов пока нет».

Версия мобилки **1.8 → 1.9** (`versionCode 13 → 14`). Ссылки на APK обновлены в `admin/src/views/LoginView.vue` и `README.md` (бейдж + блок установки + `adb install`).

## NEWS

📲 **Обновление AI-Секретаря для Android — версия 1.9**

В мобильном чате стало проще переключаться между ассистентами: справа от названия появилась маленькая стрелочка-↓, нажмите на неё (или по самому названию) — и снизу выедет полноценная панель со списком всех ваших ассистентов и кнопкой создания нового. В альбомной ориентации та же панель открывается справа во всю высоту. Размер можно подхватить пальцем за тонкую полоску и подогнать под себя — точно так же как у других панелей чата.

[📲 Скачать обновление](https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-1.9.apk)

Установите новую версию, чтобы получить эти улучшения.

## Test plan

- [ ] Portrait: тап по названию чата ИЛИ по chevron → выезжает большая панель сверху, chevron поворачивается и подсвечивается
- [ ] Portrait: тянем нижний resize-handle вверх/вниз — высота меняется, минимум 100px, максимум 90% экрана
- [ ] Landscape: то же самое — панель справа, тянем левый handle, ширина 150–70% экрана
- [ ] Открыть ассистенты → кликнуть «Дерево веток» / «Настройки» → панель ассистентов закрывается, открывается выбранная (без двух открытых одновременно)
- [ ] Открыть «Дерево веток» → кликнуть по названию чата → ветки закрываются, ассистенты открываются
- [ ] В панели нажать «Создать нового ассистента» → создаётся чистая сессия, панель закрывается
- [ ] В панели нажать на другого ассистента → переход в его чат, панель закрывается
- [ ] Когда других ассистентов нет — показывается «Других ассистентов пока нет», но кнопка создания работает
- [ ] X-кнопка (portrait) и close-X (landscape) закрывают панель ассистентов

🤖 Generated with [Claude Code](https://claude.com/claude-code)