### PR TITLE
feat(mobile): панель «Аккаунт» в шапке чата + webhook URL fix (v2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [![Сайт и демо админки](https://img.shields.io/badge/Сайт_и_демо_админки-ai--sekretar24.ru-4285F4?style=for-the-badge&logo=google-chrome&logoColor=white)](https://ai-sekretar24.ru/)
 [![Telegram поддержка](https://img.shields.io/badge/Поддержка_и_ассистент-@ai__sekretar24bot-26A5E4?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/ai_sekretar24bot)
-[![Android APK](https://img.shields.io/badge/Android_APK-v1.9-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.9/ai-secretary-1.9.apk)
+[![Android APK](https://img.shields.io/badge/Android_APK-v2.0-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v2.0/ai-secretary-2.0.apk)
 
 [Сайт проекта и демо админки](https://ai-sekretar24.ru/) (логин/пароль: `admin` / `admin`) | [Telegram поддержки и ассистент проекта](https://t.me/ai_sekretar24bot) | [Wiki](https://github.com/ShaerWare/AI_Secretary_System/wiki) | [Issues](https://github.com/ShaerWare/AI_Secretary_System/issues) | [Android APK](https://github.com/ShaerWare/AI_Secretary_System/releases/latest)
 
@@ -563,13 +563,13 @@ curl -X POST http://localhost:8002/admin/telegram/instances/{id}/start
 
 **Скачать APK:**
 
-📱 [**ai-secretary-1.9.apk**](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v1.9/ai-secretary-1.9.apk) — последняя сборка (debug, не подписана для Play Store)
+📱 [**ai-secretary-2.0.apk**](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v2.0/ai-secretary-2.0.apk) — последняя сборка (debug, не подписана для Play Store)
 
 Все релизы: [github.com/ShaerWare/AI_Secretary_System/releases](https://github.com/ShaerWare/AI_Secretary_System/releases)
 
 **Установка через adb:**
 ```bash
-adb install -r ai-secretary-1.9.apk
+adb install -r ai-secretary-2.0.apk
 ```
 
 Или скопируйте APK на телефон и откройте в файловом менеджере (разрешите «Установка из неизвестных источников»). При ошибке `INSTALL_FAILED_UPDATE_INCOMPATIBLE` сначала удалите старую версию: `adb uninstall com.shaerware.aisecretary`.

--- a/admin/src/views/LoginView.vue
+++ b/admin/src/views/LoginView.vue
@@ -22,9 +22,9 @@ const showAbout = ref(false)
 const activeTab = ref<'ai' | 'privacy' | 'features' | 'channels' | 'cases'>('cases')
 
 // Mobile app version — fetched from /admin/mobile/version (driven by MOBILE_LATEST_* env on server)
-const mobileVersion = ref('1.9')
+const mobileVersion = ref('2.0')
 const mobileApkUrl = ref(
-  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-1.9.apk',
+  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.0.apk',
 )
 
 async function fetchMobileVersion() {

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.shaerware.aisecretary"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 14
-        versionName "1.9"
+        versionCode 15
+        versionName "2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/mobile/src/components/AccountPanel.vue
+++ b/mobile/src/components/AccountPanel.vue
@@ -1,0 +1,317 @@
+<script setup lang="ts">
+import { ref, onMounted, watch } from "vue";
+import { useAuthStore } from "@/stores/auth";
+import {
+  profileApi,
+  googleApi,
+  type UserProfile,
+  type GoogleOAuthStatus,
+} from "@/api/profile";
+
+const props = defineProps<{
+  // Re-load profile/google status when this prop changes (e.g. when panel toggles open).
+  active?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "logout"): void;
+}>();
+
+const auth = useAuthStore();
+
+const profile = ref<UserProfile | null>(null);
+const profileLoading = ref(false);
+const displayName = ref("");
+const displaySaving = ref(false);
+const displayMessage = ref<{ type: "ok" | "err"; text: string } | null>(null);
+
+const oldPassword = ref("");
+const newPassword = ref("");
+const confirmPassword = ref("");
+const passwordSaving = ref(false);
+const passwordMessage = ref<{ type: "ok" | "err"; text: string } | null>(null);
+
+const googleStatus = ref<GoogleOAuthStatus>({
+  connected: false,
+  google_email: null,
+  scopes: [],
+});
+const googleLoading = ref(false);
+const googleMessage = ref<{ type: "ok" | "err"; text: string } | null>(null);
+
+async function loadProfile() {
+  profileLoading.value = true;
+  try {
+    profile.value = await profileApi.getProfile();
+    displayName.value = profile.value?.display_name || "";
+  } catch {
+    // best-effort
+  } finally {
+    profileLoading.value = false;
+  }
+}
+
+async function loadGoogleStatus() {
+  try {
+    googleStatus.value = await googleApi.getStatus();
+  } catch {
+    // optional feature
+  }
+}
+
+async function refreshAll() {
+  await Promise.all([loadProfile(), loadGoogleStatus()]);
+}
+
+async function saveDisplayName() {
+  displaySaving.value = true;
+  displayMessage.value = null;
+  try {
+    const updated = await profileApi.updateDisplayName(
+      displayName.value.trim() || null,
+    );
+    profile.value = updated;
+    displayMessage.value = { type: "ok", text: "Сохранено" };
+    setTimeout(() => (displayMessage.value = null), 2500);
+  } catch (e) {
+    displayMessage.value = {
+      type: "err",
+      text: (e as Error).message || "Ошибка",
+    };
+  } finally {
+    displaySaving.value = false;
+  }
+}
+
+async function changePassword() {
+  passwordMessage.value = null;
+  if (!oldPassword.value || !newPassword.value || !confirmPassword.value) {
+    passwordMessage.value = { type: "err", text: "Заполните все поля" };
+    return;
+  }
+  if (newPassword.value !== confirmPassword.value) {
+    passwordMessage.value = { type: "err", text: "Пароли не совпадают" };
+    return;
+  }
+  if (newPassword.value.length < 6) {
+    passwordMessage.value = {
+      type: "err",
+      text: "Пароль слишком короткий (мин. 6 символов)",
+    };
+    return;
+  }
+  passwordSaving.value = true;
+  try {
+    await profileApi.changePassword(oldPassword.value, newPassword.value);
+    oldPassword.value = "";
+    newPassword.value = "";
+    confirmPassword.value = "";
+    passwordMessage.value = { type: "ok", text: "Пароль изменён" };
+    setTimeout(() => (passwordMessage.value = null), 2500);
+  } catch (e) {
+    passwordMessage.value = {
+      type: "err",
+      text: (e as Error).message || "Ошибка",
+    };
+  } finally {
+    passwordSaving.value = false;
+  }
+}
+
+async function connectGoogle() {
+  googleLoading.value = true;
+  googleMessage.value = null;
+  try {
+    const { auth_url } = await googleApi.getAuthUrl();
+    window.open(auth_url, "_system");
+    googleMessage.value = {
+      type: "ok",
+      text: "Открыт браузер. Когда закончите — обновите.",
+    };
+  } catch (e) {
+    googleMessage.value = {
+      type: "err",
+      text: (e as Error).message || "Не удалось открыть",
+    };
+  } finally {
+    googleLoading.value = false;
+  }
+}
+
+async function disconnectGoogle() {
+  if (!confirm("Отключить Google-аккаунт?")) return;
+  googleLoading.value = true;
+  googleMessage.value = null;
+  try {
+    await googleApi.disconnect();
+    googleStatus.value = { connected: false, google_email: null, scopes: [] };
+    googleMessage.value = { type: "ok", text: "Отключён" };
+    setTimeout(() => (googleMessage.value = null), 2500);
+  } catch (e) {
+    googleMessage.value = {
+      type: "err",
+      text: (e as Error).message || "Ошибка",
+    };
+  } finally {
+    googleLoading.value = false;
+  }
+}
+
+onMounted(refreshAll);
+
+watch(
+  () => props.active,
+  (now) => {
+    if (now) refreshAll();
+  },
+);
+</script>
+
+<template>
+  <div class="flex flex-col">
+    <!-- Account info (read-only) -->
+    <div class="px-3 py-2 border-b border-stone-800 flex items-center gap-3">
+      <div class="w-9 h-9 rounded-full bg-amber-600/20 text-amber-400 flex items-center justify-center text-sm font-medium shrink-0">
+        {{ (profile?.display_name || profile?.username || auth.user?.username || "?").substring(0, 1).toUpperCase() }}
+      </div>
+      <div class="flex-1 min-w-0">
+        <p class="text-sm text-white truncate">{{ profile?.display_name || profile?.username || auth.user?.username }}</p>
+        <p class="text-[10px] uppercase tracking-wide text-stone-500">{{ profile?.role || auth.user?.role }}</p>
+      </div>
+      <button
+        class="p-1.5 rounded-lg text-stone-400 hover:text-amber-400 transition-colors shrink-0"
+        title="Обновить"
+        @click="refreshAll"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="23 4 23 10 17 10" /><polyline points="1 20 1 14 7 14" /><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+        </svg>
+      </button>
+    </div>
+
+    <!-- Display name -->
+    <div class="px-3 py-2.5 border-b border-stone-800 space-y-2">
+      <p class="text-[10px] uppercase tracking-wide text-stone-500">Никнейм</p>
+      <input
+        v-model="displayName"
+        type="text"
+        class="w-full px-2.5 py-1.5 bg-stone-900 border border-stone-700 rounded text-white text-sm placeholder-stone-500 outline-none focus:border-amber-500"
+        placeholder="Как к вам обращаться"
+        :disabled="profileLoading"
+      />
+      <button
+        class="w-full px-3 py-1.5 rounded bg-amber-600 text-white text-xs hover:bg-amber-500 transition-colors disabled:opacity-50"
+        :disabled="displaySaving"
+        @click="saveDisplayName"
+      >
+        {{ displaySaving ? "Сохранение..." : "Сохранить" }}
+      </button>
+      <p
+        v-if="displayMessage"
+        class="text-[11px]"
+        :class="displayMessage.type === 'ok' ? 'text-emerald-400' : 'text-red-400'"
+      >{{ displayMessage.text }}</p>
+    </div>
+
+    <!-- Change password -->
+    <div class="px-3 py-2.5 border-b border-stone-800 space-y-2">
+      <p class="text-[10px] uppercase tracking-wide text-stone-500">Смена пароля</p>
+      <input
+        v-model="oldPassword"
+        type="password"
+        autocomplete="current-password"
+        class="w-full px-2.5 py-1.5 bg-stone-900 border border-stone-700 rounded text-white text-sm placeholder-stone-500 outline-none focus:border-amber-500"
+        placeholder="Текущий пароль"
+      />
+      <input
+        v-model="newPassword"
+        type="password"
+        autocomplete="new-password"
+        class="w-full px-2.5 py-1.5 bg-stone-900 border border-stone-700 rounded text-white text-sm placeholder-stone-500 outline-none focus:border-amber-500"
+        placeholder="Новый пароль"
+      />
+      <input
+        v-model="confirmPassword"
+        type="password"
+        autocomplete="new-password"
+        class="w-full px-2.5 py-1.5 bg-stone-900 border border-stone-700 rounded text-white text-sm placeholder-stone-500 outline-none focus:border-amber-500"
+        placeholder="Повторите новый"
+      />
+      <button
+        class="w-full px-3 py-1.5 rounded bg-amber-600 text-white text-xs hover:bg-amber-500 transition-colors disabled:opacity-50"
+        :disabled="passwordSaving"
+        @click="changePassword"
+      >
+        {{ passwordSaving ? "Сохранение..." : "Изменить пароль" }}
+      </button>
+      <p
+        v-if="passwordMessage"
+        class="text-[11px]"
+        :class="passwordMessage.type === 'ok' ? 'text-emerald-400' : 'text-red-400'"
+      >{{ passwordMessage.text }}</p>
+    </div>
+
+    <!-- Google -->
+    <div class="px-3 py-2.5 border-b border-stone-800 space-y-2">
+      <p class="text-[10px] uppercase tracking-wide text-stone-500">Google (Drive, Docs, Sheets, Gmail)</p>
+      <template v-if="googleStatus.connected">
+        <div class="flex items-center gap-2">
+          <svg class="w-4 h-4 shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.27-4.74 3.27-8.1z"/>
+            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+          </svg>
+          <p class="text-sm text-white truncate flex-1 min-w-0">{{ googleStatus.google_email }}</p>
+        </div>
+        <div class="flex flex-wrap gap-1 text-[9px]">
+          <span v-if="googleStatus.scopes.some((s) => s.includes('drive'))" class="px-1.5 py-0.5 rounded-full bg-blue-500/15 text-blue-300">Drive</span>
+          <span v-if="googleStatus.scopes.some((s) => s.includes('documents'))" class="px-1.5 py-0.5 rounded-full bg-emerald-500/15 text-emerald-300">Docs</span>
+          <span v-if="googleStatus.scopes.some((s) => s.includes('spreadsheets'))" class="px-1.5 py-0.5 rounded-full bg-green-500/15 text-green-300">Sheets</span>
+          <span v-if="googleStatus.scopes.some((s) => s.includes('gmail'))" class="px-1.5 py-0.5 rounded-full bg-red-500/15 text-red-300">Gmail</span>
+        </div>
+        <button
+          class="w-full px-3 py-1.5 rounded bg-red-800/20 text-red-300 text-xs hover:bg-red-800/30 transition-colors disabled:opacity-50"
+          :disabled="googleLoading"
+          @click="disconnectGoogle"
+        >Отключить Google</button>
+      </template>
+      <template v-else>
+        <p class="text-stone-400 text-xs">Подключите Google, чтобы ассистент мог читать ваши Drive / Docs / Sheets.</p>
+        <button
+          class="w-full flex items-center justify-center gap-2 px-3 py-1.5 rounded bg-white text-stone-800 text-xs font-medium hover:bg-stone-100 transition-colors disabled:opacity-50"
+          :disabled="googleLoading"
+          @click="connectGoogle"
+        >
+          <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.27-4.74 3.27-8.1z"/>
+            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+          </svg>
+          {{ googleLoading ? "Открытие..." : "Подключить Google" }}
+        </button>
+      </template>
+      <p
+        v-if="googleMessage"
+        class="text-[11px]"
+        :class="googleMessage.type === 'ok' ? 'text-emerald-400' : 'text-red-400'"
+      >{{ googleMessage.text }}</p>
+    </div>
+
+    <!-- Logout -->
+    <div class="px-3 py-2.5">
+      <button
+        class="w-full px-3 py-2 rounded-lg bg-red-800/20 text-red-300 text-sm font-medium hover:bg-red-800/30 transition-colors flex items-center justify-center gap-2"
+        @click="emit('logout')"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+          <polyline points="16 17 21 12 16 7" />
+          <line x1="21" y1="12" x2="9" y2="12" />
+        </svg>
+        Выйти из аккаунта
+      </button>
+    </div>
+  </div>
+</template>

--- a/mobile/src/views/ChatView.vue
+++ b/mobile/src/views/ChatView.vue
@@ -16,6 +16,7 @@ import { useAuthStore } from "@/stores/auth";
 import MessageBubble from "@/components/MessageBubble.vue";
 import ChatInput from "@/components/ChatInput.vue";
 import ContextFilesPanel from "@/components/ContextFilesPanel.vue";
+import AccountPanel from "@/components/AccountPanel.vue";
 
 const route = useRoute();
 const router = useRouter();
@@ -47,6 +48,7 @@ const isCreatingAssistant = ref(false);
 const showBranches = ref(false);
 const showContextFiles = ref(false);
 const showSettings = ref(false);
+const showAccount = ref(false);
 const settingsTab = ref<"files" | "prompt">("files");
 const customPrompt = ref("");
 const sessionPrompts = ref<ChatSessionPrompt[]>([]);
@@ -210,6 +212,7 @@ function toggleAssistantSwitcher() {
   showBranches.value = false;
   showContextFiles.value = false;
   showSettings.value = false;
+  showAccount.value = false;
   showAssistantSwitcher.value = true;
   loadAvailableAssistants();
 }
@@ -454,6 +457,7 @@ function toggleBranches() {
   showContextFiles.value = false;
   showSettings.value = false;
   showAssistantSwitcher.value = false;
+  showAccount.value = false;
   showBranches.value = !showBranches.value;
   if (showBranches.value) loadBranches();
 }
@@ -676,6 +680,7 @@ function toggleSettings() {
   showBranches.value = false;
   showContextFiles.value = false;
   showAssistantSwitcher.value = false;
+  showAccount.value = false;
   showSettings.value = !showSettings.value;
 }
 
@@ -855,6 +860,7 @@ function handleSaveToContext(_messageId: string, content: string) {
   showBranches.value = false;
   showSettings.value = false;
   showAssistantSwitcher.value = false;
+  showAccount.value = false;
 }
 
 async function handleSummarizeBranch(messageId: string) {
@@ -867,6 +873,7 @@ async function handleSummarizeBranch(messageId: string) {
     showBranches.value = false;
     showSettings.value = false;
     showAssistantSwitcher.value = false;
+    showAccount.value = false;
   } catch (e) {
     error.value = e instanceof Error ? e.message : "Не удалось суммаризировать";
   }
@@ -901,10 +908,16 @@ async function handleDeleteFromMessage(messageId: string) {
 }
 
 const anyPanelOpen = computed(
-  () => showBranches.value || showContextFiles.value || showSettings.value || showAssistantSwitcher.value,
+  () =>
+    showBranches.value ||
+    showContextFiles.value ||
+    showSettings.value ||
+    showAssistantSwitcher.value ||
+    showAccount.value,
 );
 const activePanelName = computed(() => {
   if (showAssistantSwitcher.value) return "Ассистенты";
+  if (showAccount.value) return "Аккаунт";
   if (showBranches.value) return "Дерево веток";
   if (showContextFiles.value) return "Файлы контекста";
   if (showSettings.value) return "Настройки";
@@ -916,6 +929,24 @@ function closePanel() {
   showContextFiles.value = false;
   showSettings.value = false;
   showAssistantSwitcher.value = false;
+  showAccount.value = false;
+}
+
+function toggleAccount() {
+  if (showAccount.value) {
+    showAccount.value = false;
+    return;
+  }
+  showBranches.value = false;
+  showContextFiles.value = false;
+  showSettings.value = false;
+  showAssistantSwitcher.value = false;
+  showAccount.value = true;
+}
+
+async function handleAccountLogout() {
+  await auth.logout();
+  router.replace("/login");
 }
 
 watch(streamingContent, () => {
@@ -1033,6 +1064,18 @@ onUnmounted(() => {
         </button>
 
         <button
+          class="p-1.5 rounded-lg transition-colors"
+          :class="showAccount ? 'bg-amber-600/20 text-amber-400' : 'text-stone-400 hover:text-white'"
+          title="Настройки аккаунта"
+          @click="toggleAccount"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+            <circle cx="12" cy="7" r="4" />
+          </svg>
+        </button>
+
+        <button
           class="p-1.5 rounded-lg text-stone-400 hover:text-red-400 transition-colors"
           title="Удалить ветку"
           @click="deleteBranch"
@@ -1106,6 +1149,19 @@ onUnmounted(() => {
                 class="text-[10px] uppercase tracking-wide text-stone-500 shrink-0"
               >по умолч.</span>
             </button>
+          </template>
+
+          <!-- Account -->
+          <template v-if="showAccount">
+            <div class="px-3 py-2 flex items-center gap-2 border-b border-stone-800 sticky top-0 bg-stone-900/95 backdrop-blur z-10">
+              <span class="text-xs font-medium text-stone-400 uppercase tracking-wide flex-1">Аккаунт</span>
+              <button class="text-stone-500 hover:text-white transition-colors" @click="closePanel">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+            <AccountPanel :active="showAccount" @logout="handleAccountLogout" />
           </template>
 
           <!-- Branch Tree -->
@@ -1554,6 +1610,13 @@ onUnmounted(() => {
                 class="text-[10px] uppercase tracking-wide text-stone-500 shrink-0"
               >по умолч.</span>
             </button>
+          </div>
+        </template>
+
+        <!-- Account (landscape) -->
+        <template v-if="showAccount">
+          <div class="flex-1 overflow-y-auto">
+            <AccountPanel :active="showAccount" @logout="handleAccountLogout" />
           </div>
         </template>
 

--- a/mobile/src/views/SettingsView.vue
+++ b/mobile/src/views/SettingsView.vue
@@ -449,7 +449,7 @@ onActivated(refreshAll);
           О приложении
         </h2>
         <div class="bg-stone-800/50 rounded-xl p-4">
-          <p class="text-stone-400 text-sm">AI Секретарь v1.7</p>
+          <p class="text-stone-400 text-sm">AI Секретарь v2.0</p>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

Пятая панель в `ChatView` с тем же resizable-механизмом, что у веток / файлов / настроек / ассистентов. Открывается кнопкой-«человечком» в шапке между «Настройки сессии» и «Удалить ветку». Не нужно больше выходить в отдельный экран `/settings` чтобы поменять никнейм, пароль, Google или выйти.

- **AccountPanel.vue** (новый компонент) — компактная вёрстка из `SettingsView` без header/back. `active` prop триггерит refresh профиля + google-статуса при открытии. Logout — через `emit("logout")`, route'ит наверх (`auth.logout()` + `router.replace("/login")`).
- **ChatView**: новый `showAccount` ref, `toggleAccount()`, `handleAccountLogout()`. `activePanelName` / `anyPanelOpen` / `closePanel` обновлены. Все toggle-функции (`toggleAssistantSwitcher`, `toggleBranches`, `toggleSettings`, `handleSaveToContext`, `handleSummarizeBranch`) сбрасывают `showAccount`.
- Кнопка-«человечек» в шапке: `<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" />`, активный стейт amber.
- В **portrait** панель выезжает сверху во всю ширину со sticky-заголовком и кнопкой close (X). В **landscape** — справа во всю высоту, заголовок «Аккаунт» уже в общем header панели; контент скроллится. Размер тянется пальцем за общий resize-handle (минимум 100px, максимум 90% экрана).
- **`SettingsView.vue`**: версия в блоке «О приложении» обновлена с устаревшего v1.7 на v2.0.
- Версия мобилки **1.9 → 2.0** (`versionCode 14 → 15`). Ссылки на APK обновлены в `admin/src/views/LoginView.vue` и `README.md`.

### 🔧 Бонус: GitHub webhook URL fix (вне репо)

Параллельно с этим PR сменил URL вебхука id=595620064 с `admin.ai-sekretar24.ru/webhooks/github` (DNS указывал на inactive сервер 155.212.227.26) на `ai-sekretar24.ru/webhooks/github` (155.212.231.7, активный). Test-ping: `POST /webhooks/github HTTP 200`. После merge этого PR FCM-broadcast при `## NEWS` должен сработать впервые корректно — при следующих релизах автоматическая рассылка пушей будет работать.

## NEWS

⚙️ **Настройки аккаунта прямо в чате — обновление 2.0**

Теперь, чтобы поменять никнейм, пароль, подключить Google или выйти из аккаунта, не нужно покидать чат: справа в шапке появилась кнопка-«человечек», и при нажатии выезжает та же удобная панель что у веток и настроек. В портрете — сверху, в ландшафте — справа, размер подгоняется пальцем. Работает мгновенно, контекст разговора не теряется.

[📲 Скачать обновление](https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.0.apk)

Установите новую версию, чтобы получить эти улучшения.

## Test plan

- [ ] Кнопка-«человечек» появляется в шапке между «Настройки сессии» и «Удалить ветку», тап открывает большую панель
- [ ] При открытом аккаунте кнопка-человечек подсвечивается amber
- [ ] Portrait: панель выезжает сверху, есть sticky-заголовок «Аккаунт» + close (X), контент скроллится при переполнении, resize-handle снизу тянется пальцем
- [ ] Landscape: панель справа, заголовок «Аккаунт» в общем header панели, content area скроллится, resize-handle слева тянется пальцем
- [ ] При открытии аккаунта другие панели (ветки/файлы/настройки/ассистенты) закрываются, и наоборот
- [ ] Никнейм: ввод → Сохранить → ОК-сообщение пропадает через 2.5с
- [ ] Смена пароля: проверки на пустые поля / совпадение / минимум 6 символов / правильный старый пароль
- [ ] Google: статус показывает scope-чипы (Drive/Docs/Sheets/Gmail) если подключён, иначе кнопка «Подключить» открывает `_system` браузер с auth_url
- [ ] «Выйти из аккаунта» → очищает JWT и редиректит на `/login`
- [ ] FCM-пуш на тестовое устройство должен прийти при merge (после фикса webhook URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)