### PR TITLE
feat(mobile): панель «Аккаунт» в списке чатов + чистка меню чата (v2.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [![Сайт и демо админки](https://img.shields.io/badge/Сайт_и_демо_админки-ai--sekretar24.ru-4285F4?style=for-the-badge&logo=google-chrome&logoColor=white)](https://ai-sekretar24.ru/)
 [![Telegram поддержка](https://img.shields.io/badge/Поддержка_и_ассистент-@ai__sekretar24bot-26A5E4?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/ai_sekretar24bot)
-[![Android APK](https://img.shields.io/badge/Android_APK-v2.0-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v2.0/ai-secretary-2.0.apk)
+[![Android APK](https://img.shields.io/badge/Android_APK-v2.1-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v2.1/ai-secretary-2.1.apk)
 
 [Сайт проекта и демо админки](https://ai-sekretar24.ru/) (логин/пароль: `admin` / `admin`) | [Telegram поддержки и ассистент проекта](https://t.me/ai_sekretar24bot) | [Wiki](https://github.com/ShaerWare/AI_Secretary_System/wiki) | [Issues](https://github.com/ShaerWare/AI_Secretary_System/issues) | [Android APK](https://github.com/ShaerWare/AI_Secretary_System/releases/latest)
 
@@ -563,13 +563,13 @@ curl -X POST http://localhost:8002/admin/telegram/instances/{id}/start
 
 **Скачать APK:**
 
-📱 [**ai-secretary-2.0.apk**](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v2.0/ai-secretary-2.0.apk) — последняя сборка (debug, не подписана для Play Store)
+📱 [**ai-secretary-2.1.apk**](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v2.1/ai-secretary-2.1.apk) — последняя сборка (debug, не подписана для Play Store)
 
 Все релизы: [github.com/ShaerWare/AI_Secretary_System/releases](https://github.com/ShaerWare/AI_Secretary_System/releases)
 
 **Установка через adb:**
 ```bash
-adb install -r ai-secretary-2.0.apk
+adb install -r ai-secretary-2.1.apk
 ```
 
 Или скопируйте APK на телефон и откройте в файловом менеджере (разрешите «Установка из неизвестных источников»). При ошибке `INSTALL_FAILED_UPDATE_INCOMPATIBLE` сначала удалите старую версию: `adb uninstall com.shaerware.aisecretary`.

--- a/admin/src/views/LoginView.vue
+++ b/admin/src/views/LoginView.vue
@@ -22,9 +22,9 @@ const showAbout = ref(false)
 const activeTab = ref<'ai' | 'privacy' | 'features' | 'channels' | 'cases'>('cases')
 
 // Mobile app version — fetched from /admin/mobile/version (driven by MOBILE_LATEST_* env on server)
-const mobileVersion = ref('2.0')
+const mobileVersion = ref('2.1')
 const mobileApkUrl = ref(
-  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.0.apk',
+  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.1.apk',
 )
 
 async function fetchMobileVersion() {

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.shaerware.aisecretary"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 15
-        versionName "2.0"
+        versionCode 24
+        versionName "2.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/mobile/src/views/ChatListView.vue
+++ b/mobile/src/views/ChatListView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from "vue";
+import { ref, computed, onMounted, onUnmounted } from "vue";
 import { useRouter } from "vue-router";
 import { chatApi, type ChatSessionSummary } from "@/api/chat";
 import {
@@ -11,6 +11,7 @@ import {
   type MobileInstance,
 } from "@/api/admin";
 import { useAuthStore } from "@/stores/auth";
+import AccountPanel from "@/components/AccountPanel.vue";
 
 const router = useRouter();
 const auth = useAuthStore();
@@ -48,6 +49,59 @@ const sessionRagIds = ref<number[]>([]);
 
 // Mobile instance attached to session
 const sessionMobileInstanceId = ref<string | null>(null);
+
+// Account panel — same UX as chat panels: portrait = bottom sheet with
+// height resize, landscape = right side panel with width resize.
+const showAccount = ref(false);
+const panelSize = ref(Math.round(window.innerHeight * 0.6));
+const isLandscape = ref(false);
+const isResizing = ref(false);
+const resizeStartPos = ref(0);
+const resizeStartSize = ref(0);
+
+function updateOrientation() {
+  isLandscape.value = window.innerWidth > window.innerHeight;
+}
+
+function toggleAccount() {
+  showAccount.value = !showAccount.value;
+}
+
+async function handleAccountLogout() {
+  showAccount.value = false;
+  await auth.logout();
+  router.replace("/login");
+}
+
+function onResizeStart(e: TouchEvent | MouseEvent) {
+  isResizing.value = true;
+  const pos = "touches" in e ? e.touches[0]! : e;
+  resizeStartPos.value = isLandscape.value ? pos.clientX : pos.clientY;
+  resizeStartSize.value = panelSize.value;
+  e.preventDefault();
+}
+
+function onResizeMove(e: TouchEvent | MouseEvent) {
+  if (!isResizing.value) return;
+  const pos = "touches" in e ? e.touches[0]! : e;
+  if (isLandscape.value) {
+    const delta = resizeStartPos.value - pos.clientX;
+    panelSize.value = Math.max(
+      200,
+      Math.min(window.innerWidth * 0.7, resizeStartSize.value + delta),
+    );
+  } else {
+    const delta = resizeStartPos.value - pos.clientY;
+    panelSize.value = Math.max(
+      200,
+      Math.min(window.innerHeight * 0.92, resizeStartSize.value + delta),
+    );
+  }
+}
+
+function onResizeEnd() {
+  isResizing.value = false;
+}
 
 // For non-admins: all chats shared with them (assistants assigned by
 // admin). They auto-land in the default one but can navigate back to
@@ -353,6 +407,20 @@ async function sendFromWelcome() {
 onMounted(() => {
   loadSessions();
   if (isAdmin.value) loadAdminData();
+  updateOrientation();
+  window.addEventListener("resize", updateOrientation);
+  window.addEventListener("mousemove", onResizeMove);
+  window.addEventListener("mouseup", onResizeEnd);
+  window.addEventListener("touchmove", onResizeMove, { passive: false });
+  window.addEventListener("touchend", onResizeEnd);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("resize", updateOrientation);
+  window.removeEventListener("mousemove", onResizeMove);
+  window.removeEventListener("mouseup", onResizeEnd);
+  window.removeEventListener("touchmove", onResizeMove);
+  window.removeEventListener("touchend", onResizeEnd);
 });
 </script>
 
@@ -376,7 +444,7 @@ onMounted(() => {
               <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
             </svg>
           </button>
-          <button class="text-stone-400 hover:text-white transition-colors" title="Профиль" @click="$router.push('/settings')">
+          <button class="text-stone-400 hover:text-white transition-colors" title="Профиль" @click="toggleAccount">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <circle cx="12" cy="12" r="3" />
               <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
@@ -678,7 +746,7 @@ onMounted(() => {
             <button
               class="p-1.5 rounded-lg text-stone-500 hover:text-white transition-colors"
               title="Профиль"
-              @click="$router.push('/settings')"
+              @click="toggleAccount"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="12" r="3" />
@@ -744,7 +812,7 @@ onMounted(() => {
               </button>
               <button
                 class="py-2.5 px-4 rounded-xl bg-stone-800 hover:bg-stone-700 active:bg-stone-600 text-stone-300 text-sm transition-colors flex items-center justify-center gap-2"
-                @click="$router.push('/settings')"
+                @click="toggleAccount"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
@@ -781,6 +849,71 @@ onMounted(() => {
             </div>
             <div class="flex-1" />
           </template>
+        </div>
+      </div>
+    </template>
+
+    <!-- Account panel overlay (same UX as ChatView panels) -->
+    <template v-if="showAccount">
+      <!-- Backdrop -->
+      <div
+        class="fixed inset-0 bg-black/40 z-40"
+        @click="toggleAccount"
+      />
+
+      <!-- Portrait: bottom sheet, height-resizable -->
+      <div
+        v-if="!isLandscape"
+        class="fixed left-0 right-0 bottom-0 z-50 bg-stone-900/95 border-t border-stone-700 flex flex-col"
+        :style="{ height: panelSize + 'px' }"
+      >
+        <div
+          class="shrink-0 h-3 flex items-center justify-center cursor-row-resize bg-stone-900/80 border-b border-stone-700 touch-none select-none"
+          @mousedown="onResizeStart"
+          @touchstart="onResizeStart"
+        >
+          <div class="w-10 h-1 rounded-full bg-stone-600" />
+        </div>
+        <div class="shrink-0 flex items-center justify-between px-3 py-2 border-b border-stone-800">
+          <span class="text-xs font-medium text-stone-400 uppercase tracking-wide">Аккаунт</span>
+          <button class="text-stone-500 hover:text-white transition-colors" @click="toggleAccount">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div class="flex-1 overflow-y-auto">
+          <AccountPanel :active="showAccount" @logout="handleAccountLogout" />
+        </div>
+      </div>
+
+      <!-- Landscape: right side panel, width-resizable -->
+      <div
+        v-else
+        class="fixed top-0 bottom-0 right-0 z-50 flex"
+      >
+        <div
+          class="shrink-0 w-3 flex items-center justify-center cursor-col-resize bg-stone-900/80 border-l border-stone-700 touch-none select-none"
+          @mousedown="onResizeStart"
+          @touchstart="onResizeStart"
+        >
+          <div class="h-10 w-1 rounded-full bg-stone-600" />
+        </div>
+        <div
+          class="bg-stone-900/95 border-l border-stone-700 flex flex-col"
+          :style="{ width: panelSize + 'px' }"
+        >
+          <div class="shrink-0 flex items-center justify-between px-3 py-2 border-b border-stone-800">
+            <span class="text-xs font-medium text-stone-400 uppercase tracking-wide">Аккаунт</span>
+            <button class="text-stone-500 hover:text-white transition-colors" @click="toggleAccount">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+          <div class="flex-1 overflow-y-auto">
+            <AccountPanel :active="showAccount" @logout="handleAccountLogout" />
+          </div>
         </div>
       </div>
     </template>

--- a/mobile/src/views/ChatView.vue
+++ b/mobile/src/views/ChatView.vue
@@ -1070,8 +1070,8 @@ onUnmounted(() => {
           @click="toggleAccount"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-            <circle cx="12" cy="7" r="4" />
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
           </svg>
         </button>
 
@@ -1083,17 +1083,6 @@ onUnmounted(() => {
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <polyline points="3 6 5 6 21 6" />
             <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-          </svg>
-        </button>
-
-        <button
-          class="p-1.5 rounded-lg text-stone-400 hover:text-white transition-colors"
-          title="Профиль"
-          @click="router.push('/settings')"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="3" />
-            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
           </svg>
         </button>
       </div>

--- a/mobile/src/views/SettingsView.vue
+++ b/mobile/src/views/SettingsView.vue
@@ -449,7 +449,7 @@ onActivated(refreshAll);
           О приложении
         </h2>
         <div class="bg-stone-800/50 rounded-xl p-4">
-          <p class="text-stone-400 text-sm">AI Секретарь v2.0</p>
+          <p class="text-stone-400 text-sm">AI Секретарь v2.1</p>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

- **ChatListView**: AccountPanel-overlay с тем же UX, что и в ChatView (portrait = bottom sheet с resize-ручкой, landscape = правая боковая панель). Кнопки «Профиль» в шапке/welcome/footer теперь открывают панель вместо навигации на `/settings`.
- **ChatView**: убрана дублирующаяся вторая шестерёнка-кнопка, которая вела на `/settings` и перекрывалась с уже существующей панелью «Настройки аккаунта». Иконка кнопки «Аккаунт» поменяна с человечка на шестерёнку для визуальной согласованности.
- **Версия**: `versionCode` 15→24 (с запасом, чтобы избежать downgrade-конфликтов с локальными dev-сборками), `versionName` 2.0→2.1.
- **Docs**: README/LoginView/SettingsView обновлены на 2.1.
- **Fix**: восстановлены имена моделей `gemini-2.0-flash` в README — раньше массовый replace 2.0→2.1 случайно поломал имена моделей в таблице провайдеров и в `.env` примере.

## NEWS

📱 **Мобильное v2.1: панель аккаунта прямо в списке чатов**

Теперь чтобы посмотреть свой профиль, лимиты токенов и выйти — не нужно уходить из списка чатов. Жми шестерёнку в шапке (или в welcome-экране) и панель «Аккаунт» откроется прямо поверх списка, как в самом чате — снизу с возможностью растянуть пальцем. В альбомной ориентации панель выезжает справа.

Меню в чате стало чище — убрали дублирующуюся кнопку, которая всё равно открывала ту же панель.

[📲 Скачать обновление](https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.1.apk)

Установи новую версию поверх старой — данные сохранятся.

## Test plan

- [ ] Open mobile app, ChatListView → tap gear icon in header → AccountPanel opens as bottom sheet
- [ ] Drag resize handle up/down → panel resizes
- [ ] Rotate to landscape → panel becomes right-side panel with horizontal resize
- [ ] Tap «Профиль» in welcome screen (non-admin) and footer → same panel opens
- [ ] Open chat → menu has 4 buttons (tree, settings, account-gear, delete) — no duplicate gear
- [ ] Logout from AccountPanel → returns to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)