### PR TITLE
fix(mobile): FCM push не показывались — создаём notification channel (v2.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [![Сайт и демо админки](https://img.shields.io/badge/Сайт_и_демо_админки-ai--sekretar24.ru-4285F4?style=for-the-badge&logo=google-chrome&logoColor=white)](https://ai-sekretar24.ru/)
 [![Telegram поддержка](https://img.shields.io/badge/Поддержка_и_ассистент-@ai__sekretar24bot-26A5E4?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/ai_sekretar24bot)
-[![Android APK](https://img.shields.io/badge/Android_APK-v2.1-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v2.1/ai-secretary-2.1.apk)
+[![Android APK](https://img.shields.io/badge/Android_APK-v2.2-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v2.2/ai-secretary-2.2.apk)
 
 [Сайт проекта и демо админки](https://ai-sekretar24.ru/) (логин/пароль: `admin` / `admin`) | [Telegram поддержки и ассистент проекта](https://t.me/ai_sekretar24bot) | [Wiki](https://github.com/ShaerWare/AI_Secretary_System/wiki) | [Issues](https://github.com/ShaerWare/AI_Secretary_System/issues) | [Android APK](https://github.com/ShaerWare/AI_Secretary_System/releases/latest)
 
@@ -563,13 +563,13 @@ curl -X POST http://localhost:8002/admin/telegram/instances/{id}/start
 
 **Скачать APK:**
 
-📱 [**ai-secretary-2.1.apk**](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v2.1/ai-secretary-2.1.apk) — последняя сборка (debug, не подписана для Play Store)
+📱 [**ai-secretary-2.2.apk**](https://github.com/ShaerWare/AI_Secretary_System/releases/download/mobile-v2.2/ai-secretary-2.2.apk) — последняя сборка (debug, не подписана для Play Store)
 
 Все релизы: [github.com/ShaerWare/AI_Secretary_System/releases](https://github.com/ShaerWare/AI_Secretary_System/releases)
 
 **Установка через adb:**
 ```bash
-adb install -r ai-secretary-2.1.apk
+adb install -r ai-secretary-2.2.apk
 ```
 
 Или скопируйте APK на телефон и откройте в файловом менеджере (разрешите «Установка из неизвестных источников»). При ошибке `INSTALL_FAILED_UPDATE_INCOMPATIBLE` сначала удалите старую версию: `adb uninstall com.shaerware.aisecretary`.

--- a/admin/src/views/LoginView.vue
+++ b/admin/src/views/LoginView.vue
@@ -22,9 +22,9 @@ const showAbout = ref(false)
 const activeTab = ref<'ai' | 'privacy' | 'features' | 'channels' | 'cases'>('cases')
 
 // Mobile app version — fetched from /admin/mobile/version (driven by MOBILE_LATEST_* env on server)
-const mobileVersion = ref('2.1')
+const mobileVersion = ref('2.2')
 const mobileApkUrl = ref(
-  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.1.apk',
+  'https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk',
 )
 
 async function fetchMobileVersion() {

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.shaerware.aisecretary"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 24
-        versionName "2.1"
+        versionCode 25
+        versionName "2.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -33,6 +33,12 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths"></meta-data>
         </provider>
+
+        <!-- Firebase fallback channel: if FCM payload omits channel_id, use this one.
+             We also create the channel programmatically in usePush.ts before register(). -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="default" />
     </application>
 
     <!-- Permissions -->

--- a/mobile/src/composables/usePush.ts
+++ b/mobile/src/composables/usePush.ts
@@ -37,6 +37,24 @@ export async function initPush(): Promise<void> {
       return;
     }
 
+    // Android 8+ requires an explicit notification channel — without it the
+    // system silently drops FCM messages that target channel_id="default".
+    // Server sends with channel_id="default", so we create it here.
+    try {
+      await PushNotifications.createChannel({
+        id: "default",
+        name: "Уведомления",
+        description: "Новости и обновления AI-Секретаря",
+        importance: 5,
+        visibility: 1,
+        lights: true,
+        vibration: true,
+        sound: "default",
+      });
+    } catch (e) {
+      console.warn("[push] createChannel failed (may already exist)", e);
+    }
+
     // Listeners must be registered before register()
     PushNotifications.addListener("registration", async (token) => {
       try {

--- a/mobile/src/views/SettingsView.vue
+++ b/mobile/src/views/SettingsView.vue
@@ -449,7 +449,7 @@ onActivated(refreshAll);
           О приложении
         </h2>
         <div class="bg-stone-800/50 rounded-xl p-4">
-          <p class="text-stone-400 text-sm">AI Секретарь v2.1</p>
+          <p class="text-stone-400 text-sm">AI Секретарь v2.2</p>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

**Root cause:** сервер шлёт FCM с `channel_id="default"` ([modules/channels/mobile/push_service.py:99](https://github.com/ShaerWare/AI_Secretary_System/blob/main/modules/channels/mobile/push_service.py#L99)), но мобилка нигде этот канал не создавала. На Android 8+ если канал не существует — система тихо дропает уведомление, в логах сервера всё «200 OK» (Firebase принял запрос, не доставил пользователю). Foreground-handler через `LocalNotifications.schedule({channelId: "default"})` падал по той же причине.

**Что сделано:**
- [`mobile/src/composables/usePush.ts`](https://github.com/ShaerWare/AI_Secretary_System/blob/main/mobile/src/composables/usePush.ts) — `PushNotifications.createChannel({id: "default", importance: 5, sound, lights, vibration})` перед `register()`. Создаётся после permission grant.
- [`mobile/android/app/src/main/AndroidManifest.xml`](https://github.com/ShaerWare/AI_Secretary_System/blob/main/mobile/android/app/src/main/AndroidManifest.xml) — `<meta-data android:name="com.google.firebase.messaging.default_notification_channel_id" android:value="default" />` как fallback, чтобы Firebase SDK не использовал низкоприоритетный «Miscellaneous», если серверный payload без `channel_id`.
- bump `versionCode` 24 → 25, `versionName` 2.1 → 2.2.
- README/LoginView/SettingsView: APK 2.1 → 2.2.

**Старые v2.0/v2.1 устройства** уже зарегистрированы в FCM без канала — для них прошлые пуши были «доставлены в Firebase, но не показаны». Этот фикс лечит ТОЛЬКО v2.2+. Юзеры v2.1 должны обновиться через ссылку из ленты, чтобы пуши заработали.

## NEWS

🔔 **Мобильное v2.2: исправили молчащие пуш-уведомления**

В предыдущих версиях Android-приложение получало уведомления от сервера, но не показывало их в трее — система тихо отбрасывала их из-за неправильно настроенного канала уведомлений. В v2.2 канал создаётся явно при первом запуске, со звуком и приоритетом heads-up (всплывающее окно сверху экрана). Теперь новости и обновления приходят как положено.

[📲 Скачать обновление](https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk)

После установки разреши уведомления, если система спросит — без этого push'ей не будет.

## Test plan

- [ ] Установи v2.2 на чистый девайс, логин → дай permission → проверь что в Settings → Apps → AI-Секретарь → Notifications появился канал «Уведомления» (importance: High)
- [ ] Сервер: `curl -X POST .../admin/mobile/push/test -d '{"to_all":true,"title":"тест","body":"проверка"}'` → пуш всплывает в трее со звуком
- [ ] Мердж этого PR → автоматический FCM-broadcast от GitHub-webhook → 5 устройств (после переустановки на v2.2) видят `🔔 Мобильное v2.2: исправили молчащие пуш-уведомления`
- [ ] Foreground: открой приложение, отправь тест-push → видишь heads-up через `LocalNotifications` (потому что FCM не показывает в трее когда app foreground)

🤖 Generated with [Claude Code](https://claude.com/claude-code)