### PR TITLE
fix(landing): кнопка «Войти» → /login

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -97,7 +97,7 @@
       </nav>
 
       <div class="header__actions">
-        <a href="/admin/" class="btn btn--ghost">Войти</a>
+        <a href="/login" class="btn btn--ghost">Войти</a>
         <a href="#start" class="btn btn--primary">Попробовать бесплатно</a>
       </div>
 
@@ -407,7 +407,7 @@
         <h4>Контакты</h4>
         <a href="https://t.me/ai_sekretar24bot" target="_blank" rel="noopener">Поддержка в Telegram</a>
         <a href="https://github.com/ShaerWare/AI_Secretary_System" target="_blank" rel="noopener">GitHub проекта</a>
-        <a href="/admin/">Вход в кабинет</a>
+        <a href="/login">Вход в кабинет</a>
       </nav>
       <nav class="footer__col">
         <h4>Правовое</h4>


### PR DESCRIPTION
## Summary

Кнопки «Войти» на лендинге теперь ведут на `/login` вместо `/admin/`.

**Причина:** `/admin/` на проде проксируется на FastAPI, который отдаёт билд админки с base path `/full/` (видимо, остаток `--mode demo`). Запрашиваемые `/full/assets/*.js` файлы не существуют на диске → nginx SPA-fallback возвращает HTML → браузер ждёт JS, получает HTML → SPA не стартует → белый экран.

`/login` (любой несуществующий путь) триггерит nginx SPA-fallback на `/var/www/admin-ai-sekretar24/index.html` — корректный билд с base `/assets/`, SPA нормально загружается.

## Notes

- Изменение уже применено на проде через `sed` — этот PR синхронизирует репо, чтобы следующий git pull не вернул баг.
- Без NEWS-блока (не для мобильных юзеров).

## Test plan

- [x] /login возвращает админ-SPA, JS грузится
- [x] / возвращает лендинг
- [x] /assets/index-*.js → реальный JS (не HTML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)