### PR TITLE
feat(landing): мультиязычность RU/EN/KK + переключатель

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -7,12 +7,35 @@ SEO-разметка, тарифы, лид-форма. Без сборки — �
 
 | Файл | Назначение |
 |------|-----------|
-| `index.html` | Вся страница + SEO-разметка (Open Graph, JSON-LD: Organization, SoftwareApplication, FAQPage) |
-| `styles.css` | Стили (тёмная тема zinc + оранжевые акценты — наследует кабинет) |
-| `main.js` | Интерактив: меню, переключатель тарифов, лид-форма |
-| `favicon.svg` | Логотип-шестерёнка |
-| `robots.txt` | Открыт `/`, закрыт `/admin/` |
-| `sitemap.xml` | Карта сайта |
+| `index.html` | Лендинг на **русском** (отдаётся с `/`). Inline-скрипт авто-редиректит на `/en/` или `/kk/` по `navigator.language` при первом визите. |
+| `en/index.html` | Английская версия (URL `/en/`). |
+| `kk/index.html` | Казахская версия (URL `/kk/`). |
+| `styles.css` | Общие стили (тёмная тема zinc + оранжевые акценты). Включают `.lang-switcher`. |
+| `main.js` | Общий интерактив: меню, переключатель тарифов, лид-форма, запоминание выбора языка. |
+| `favicon.svg` | Логотип-шестерёнка. |
+| `robots.txt` | Открыт весь сайт, закрыт `/admin/`. |
+| `sitemap.xml` | 3 URL (ru/en/kk) с `hreflang`-альтернативами. |
+
+## Мультиязычность
+
+3 отдельных HTML-файла, по одному на язык — для нормальной индексации каждой версии.
+В `<head>` каждой страницы — `hreflang`-альтернативы.
+
+**Логика переключения:**
+1. Прямой переход (по ссылке/закладке) на `/en/`, `/kk/` или `/` — отдаётся соответствующая HTML.
+2. Первый визит на `/`: inline-скрипт читает `navigator.language` и редиректит на `/en/`/`/kk/` если совпало.
+3. Клик по переключателю RU/EN/KK сохраняет выбор в `localStorage.s24_lang` — после этого авто-редирект больше не срабатывает.
+
+**Добавить новый язык:**
+1. Создать `<lang>/index.html` копией с переводами.
+2. Добавить `<link rel="alternate" hreflang="<lang>">` во все три существующих файла.
+3. Добавить URL в `sitemap.xml`.
+4. Добавить пункт `<a hreflang="<lang>">…</a>` в `.lang-switcher` каждого файла.
+5. Расширить логику авто-детекта в inline-скрипте `index.html`.
+6. Добавить nginx `location = /<lang>/` (см. ниже).
+
+> 🛠️ TODO: вынести строки в `translations.json` и генерировать HTML из шаблона —
+> ручное синхронное редактирование 3+ файлов плохо масштабируется.
 
 ## Посмотреть локально
 
@@ -32,12 +55,18 @@ python -m http.server 8090
 rsync -av --delete site/ /var/www/landing-ai-sekretar24/
 ```
 
-Блок nginx (location `/` — лендинг, location `/admin/` — кабинет):
+Блок nginx (упрощённо):
 
 ```nginx
-root /var/www/landing-ai-sekretar24;
-location = / { try_files /index.html =404; }
-location /admin/ { root /var/www; try_files $uri $uri/ /admin/index.html; }
+root /var/www/admin-ai-sekretar24;    # default: SPA-админка
+location = /        { root /var/www/landing-ai-sekretar24; try_files /index.html =404; }
+location = /en      { return 301 /en/; }
+location = /en/     { root /var/www/landing-ai-sekretar24; try_files /en/index.html =404; }
+location = /kk      { return 301 /kk/; }
+location = /kk/     { root /var/www/landing-ai-sekretar24; try_files /kk/index.html =404; }
+# + location = /styles.css /main.js /robots.txt /sitemap.xml /favicon.svg → landing
+location /          { try_files $uri $uri/ /index.html; }   # SPA fallback
+location /admin/    { proxy_pass http://127.0.0.1:8002; }   # API
 ```
 
 ## TODO перед публикацией

--- a/site/en/index.html
+++ b/site/en/index.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#09090b" />
+
+  <title>Sekretar24 — AI Assistant for Business: Calls, Chats and Leads 24/7</title>
+  <meta name="description" content="Sekretar24 — virtual AI assistant for your business. Replies to customers on Telegram, WhatsApp, your website and over the phone, works from your knowledge base and pushes hot leads into CRM. Free 14-day trial." />
+  <meta name="keywords" content="AI assistant for business, AI chatbot Telegram, AI WhatsApp bot, voice AI for calls, call center automation, AI lawyer assistant, AI accountant assistant" />
+  <link rel="canonical" href="https://ai-sekretar24.ru/en/" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+  <link rel="alternate" hreflang="ru" href="https://ai-sekretar24.ru/" />
+  <link rel="alternate" hreflang="en" href="https://ai-sekretar24.ru/en/" />
+  <link rel="alternate" hreflang="kk" href="https://ai-sekretar24.ru/kk/" />
+  <link rel="alternate" hreflang="x-default" href="https://ai-sekretar24.ru/" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Sekretar24" />
+  <meta property="og:title" content="Sekretar24 — AI Assistant for Business 24/7" />
+  <meta property="og:description" content="Virtual AI assistant: Telegram, WhatsApp, web widget, phone calls. Free 14-day trial." />
+  <meta property="og:url" content="https://ai-sekretar24.ru/en/" />
+  <meta property="og:image" content="https://ai-sekretar24.ru/og-image.png" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:locale:alternate" content="ru_RU" />
+  <meta property="og:locale:alternate" content="kk_KZ" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Sekretar24 — AI Assistant for Business 24/7" />
+  <meta name="twitter:description" content="Virtual AI assistant: Telegram, WhatsApp, web, phone. 14-day trial." />
+  <meta name="twitter:image" content="https://ai-sekretar24.ru/og-image.png" />
+
+  <link rel="stylesheet" href="/styles.css" />
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Sekretar24",
+    "url": "https://ai-sekretar24.ru/",
+    "logo": "https://ai-sekretar24.ru/favicon.svg",
+    "description": "AI assistant platform for business.",
+    "sameAs": ["https://t.me/ai_sekretar24bot", "https://github.com/ShaerWare/AI_Secretary_System"]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Sekretar24",
+    "applicationCategory": "BusinessApplication",
+    "operatingSystem": "Web, Android",
+    "description": "Virtual AI assistant for business: Telegram, WhatsApp, web widget, telephony, knowledge base and CRM integrations.",
+    "offers": [
+      { "@type": "Offer", "name": "Start", "price": "2900", "priceCurrency": "RUB" },
+      { "@type": "Offer", "name": "Business", "price": "12900", "priceCurrency": "RUB" },
+      { "@type": "Offer", "name": "Team", "price": "29900", "priceCurrency": "RUB" }
+    ],
+    "aggregateRating": { "@type": "AggregateRating", "ratingValue": "4.9", "reviewCount": "37" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      { "@type": "Question", "name": "How is this different from a regular chatbot?", "acceptedAnswer": { "@type": "Answer", "text": "Regular bots run rigid scenario trees. Sekretar24 is real AI: it understands free text, remembers conversation context and answers from your knowledge base, not from a script." } },
+      { "@type": "Question", "name": "Is my data safe?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. You can run on cloud models or deploy the AI entirely on your own server — your customers' data never leaves your perimeter." } },
+      { "@type": "Question", "name": "Do I need my own server?", "acceptedAnswer": { "@type": "Answer", "text": "No. The Start, Business and Team plans all run in the cloud. A dedicated server is only needed for on-premise deployment with local AI (Enterprise)." } },
+      { "@type": "Question", "name": "Which channels does the assistant work on?", "acceptedAnswer": { "@type": "Answer", "text": "Telegram, WhatsApp, web chat widget, telephony and the Android app. One assistant — every channel at once." } },
+      { "@type": "Question", "name": "Can I connect telephony?", "acceptedAnswer": { "@type": "Answer", "text": "Yes, starting with the Business plan. The assistant takes and makes calls, recognizes speech and answers in voice." } },
+      { "@type": "Question", "name": "What happens after the trial?", "acceptedAnswer": { "@type": "Answer", "text": "Two weeks free, no credit card. Then pick the plan that fits — your data and settings carry over." } }
+    ]
+  }
+  </script>
+</head>
+<body>
+
+  <header class="header" id="header">
+    <div class="container header__inner">
+      <a href="/en/" class="logo" aria-label="Sekretar24">
+        <svg class="logo__mark" viewBox="0 0 512 512" aria-hidden="true">
+          <defs>
+            <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#F0A830" />
+              <stop offset="100%" stop-color="#C27010" />
+            </linearGradient>
+          </defs>
+          <path fill="url(#g)" fill-rule="evenodd" d="M 431.8 217.4 L 484.1 226.3 L 484.1 285.7 L 431.8 294.6 L 407.6 353.0 L 438.3 396.3 L 396.3 438.3 L 353.0 407.6 L 294.6 431.8 L 285.7 484.1 L 226.3 484.1 L 217.4 431.8 L 159.0 407.6 L 115.7 438.3 L 73.7 396.3 L 104.4 353.0 L 80.2 294.6 L 27.9 285.7 L 27.9 226.3 L 80.2 217.4 L 104.4 159.0 L 73.7 115.7 L 115.7 73.7 L 159.0 104.4 L 217.4 80.2 L 226.3 27.9 L 285.7 27.9 L 294.6 80.2 L 353.0 104.4 L 396.3 73.7 L 438.3 115.7 L 407.6 159.0 Z M 341.0 256.0 A 85 85 0 1 0 171.0 256.0 A 85 85 0 1 0 341.0 256.0 Z" />
+        </svg>
+        <span class="logo__text">Sekretar<span class="logo__accent">24</span></span>
+      </a>
+
+      <nav class="nav" id="nav">
+        <a href="#features">Features</a>
+        <a href="#roles">Roles</a>
+        <a href="#pricing">Pricing</a>
+        <a href="#faq">FAQ</a>
+      </nav>
+
+      <nav class="lang-switcher" aria-label="Language">
+        <a href="/" hreflang="ru" lang="ru">RU</a>
+        <a href="/en/" hreflang="en" lang="en" class="is-active" aria-current="page">EN</a>
+        <a href="/kk/" hreflang="kk" lang="kk">KK</a>
+      </nav>
+
+      <div class="header__actions">
+        <a href="/login" class="btn btn--ghost">Sign in</a>
+        <a href="#start" class="btn btn--primary">Try free</a>
+      </div>
+
+      <button class="burger" id="burger" aria-label="Menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </header>
+
+  <main>
+
+    <section class="hero">
+      <div class="hero__glow" aria-hidden="true"></div>
+      <div class="container hero__inner">
+        <div class="hero__badge">⚡ Launch in 5 minutes · no developers needed</div>
+        <h1 class="hero__title">
+          AI assistant for business:<br />
+          <span class="accent">calls, chats and leads</span> — 24/7
+        </h1>
+        <p class="hero__subtitle">
+          Sekretar24 is a virtual AI assistant for your business. It replies to customers on
+          Telegram, WhatsApp, your website and over the phone, works from your knowledge base
+          and pushes hot leads straight into your CRM.
+        </p>
+        <div class="hero__cta">
+          <a href="#start" class="btn btn--primary btn--lg">Start 14-day free trial</a>
+          <a href="#pricing" class="btn btn--outline btn--lg">See pricing</a>
+        </div>
+        <p class="hero__trust">No credit card · Full-feature trial · Cancel in one click</p>
+
+        <div class="hero__channels">
+          <span>Works on:</span>
+          <div class="hero__channels-list">
+            <span class="chip">Telegram</span>
+            <span class="chip">WhatsApp</span>
+            <span class="chip">Web widget</span>
+            <span class="chip">Telephony</span>
+            <span class="chip">Android</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section problem">
+      <div class="container">
+        <h2 class="section__title">Every unanswered chat is lost revenue</h2>
+        <div class="grid grid-3">
+          <article class="pain">
+            <div class="pain__icon">📵</div>
+            <h3>Missed call = lost customer</h3>
+            <p>Nights, weekends, lunch breaks — calls go unanswered and prospects move on to your competitor.</p>
+          </article>
+          <article class="pain">
+            <div class="pain__icon">🐌</div>
+            <h3>Your team replies in an hour</h3>
+            <p>By the time they get back, the customer has cooled off or already bought elsewhere. Reply speed wins deals.</p>
+          </article>
+          <article class="pain">
+            <div class="pain__icon">🔁</div>
+            <h3>Half the day goes to repeat questions</h3>
+            <p>The same FAQs, manual qualification, copy-pasting into CRM — instead of selling and growing.</p>
+          </article>
+        </div>
+        <p class="problem__solution">
+          <strong>Sekretar24</strong> answers instantly and 24/7 across every channel,
+          qualifies the lead and creates a deal in your CRM — so your team can focus on what matters.
+        </p>
+      </div>
+    </section>
+
+    <section class="section roles" id="roles">
+      <div class="container">
+        <p class="eyebrow">AI Employees</p>
+        <h2 class="section__title">One engine — any role</h2>
+        <p class="section__lead">
+          From a single platform you can build an AI employee for any job — with its own prompt,
+          knowledge base, voice and integrations. Proven scenarios:
+        </p>
+        <div class="grid grid-4">
+          <article class="role-card"><div class="role-card__icon">📞</div><h3>Call center</h3><p>Inbound and outbound calls, speech recognition, voice replies, lead qualification, smooth handoff of complex cases to a human.</p></article>
+          <article class="role-card"><div class="role-card__icon">🛠️</div><h3>Tech support</h3><p>24/7 L1 line on Telegram, WhatsApp and your website chat. Answers from your knowledge base, ticketing, escalation to engineers, quality analytics.</p></article>
+          <article class="role-card"><div class="role-card__icon">📇</div><h3>Secretary</h3><p>Phone reception, booking meetings into Google Calendar, spam filtering, reminders, conversation and email summaries.</p></article>
+          <article class="role-card"><div class="role-card__icon">⚖️</div><h3>Lawyer</h3><p>Legal advice grounded in an up-to-date base (codes and case law for RU and KZ), contract review, document templates.</p></article>
+          <article class="role-card"><div class="role-card__icon">📊</div><h3>Accountant</h3><p>Answers on taxes and reporting, USN/VAT calculations, deadline reminders, first-pass document processing.</p></article>
+          <article class="role-card"><div class="role-card__icon">💼</div><h3>Sales manager</h3><p>Sales funnel on Telegram, WhatsApp and your widget, qualification, upsells, accepting payments, amoCRM integration.</p></article>
+          <article class="role-card"><div class="role-card__icon">🎨</div><h3>Web agency</h3><p>AI briefs, generating spec docs, stack selection, landing-page prototyping, ongoing client-site support.</p></article>
+          <article class="role-card"><div class="role-card__icon">👨‍💻</div><h3>Dev team</h3><p>Bridge to Claude Code: writes and reviews code, works with git, runs tests and deploys — right from chat.</p></article>
+        </div>
+        <p class="roles__note">
+          Need a role that isn't on the list? <a href="#start">Get in touch</a> — we'll build one for your case.
+        </p>
+      </div>
+    </section>
+
+    <section class="section how" id="how">
+      <div class="container">
+        <p class="eyebrow">How it works</p>
+        <h2 class="section__title">From sign-up to a working assistant in one evening</h2>
+        <div class="grid grid-4 steps">
+          <article class="step"><div class="step__num">1</div><h3>Sign up</h3><p>Create an account — your 14-day free trial starts immediately.</p></article>
+          <article class="step"><div class="step__num">2</div><h3>Configure the assistant</h3><p>Pick a ready-made role, upload your knowledge base, set the prompt and voice.</p></article>
+          <article class="step"><div class="step__num">3</div><h3>Connect your channels</h3><p>Telegram, WhatsApp, web widget and telephony — all in a few clicks.</p></article>
+          <article class="step"><div class="step__num">4</div><h3>Runs 24/7</h3><p>Your assistant replies around the clock; hot leads fly straight into your CRM.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section features" id="features">
+      <div class="container">
+        <p class="eyebrow">Features</p>
+        <h2 class="section__title">Not a scripted bot — real AI</h2>
+        <div class="grid grid-3">
+          <article class="feature"><div class="feature__icon">🧠</div><h3>Knowledge base (RAG)</h3><p>Upload documents, websites or RSS — your assistant answers strictly from your data, not hallucinations.</p></article>
+          <article class="feature"><div class="feature__icon">🎙️</div><h3>Voice</h3><p>Speech synthesis and voice cloning — your assistant sounds like a real member of your team.</p></article>
+          <article class="feature"><div class="feature__icon">🔒</div><h3>Local and cloud AI</h3><p>Run on cloud models or deploy the AI on your own server — data never leaves your perimeter.</p></article>
+          <article class="feature"><div class="feature__icon">🔗</div><h3>Integrations</h3><p>amoCRM, WooCommerce, Google Calendar, Drive and Gmail — your assistant lives inside your tools.</p></article>
+          <article class="feature"><div class="feature__icon">🌍</div><h3>Multilingual</h3><p>Russian, English and Kazakh — your assistant speaks to customers in their language.</p></article>
+          <article class="feature"><div class="feature__icon">🎯</div><h3>Fine-tuning</h3><p>LoRA fine-tuning on your data — the assistant picks up your company's tone and expertise.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section demo">
+      <div class="container demo__inner">
+        <div class="demo__text">
+          <p class="eyebrow">Live example</p>
+          <h2 class="section__title section__title--left">What a real conversation looks like</h2>
+          <p class="section__lead section__lead--left">
+            The assistant grasps the question, asks clarifying details and drives the customer to the next action —
+            booking, request or payment. No "command not recognized", no menu trees.
+          </p>
+          <a href="#start" class="btn btn--primary btn--lg">Try it with your own questions</a>
+        </div>
+        <div class="chat-mock" aria-hidden="true">
+          <div class="chat-mock__head"><span class="dot"></span> Assistant · Sekretar24</div>
+          <div class="chat-mock__body">
+            <div class="msg msg--in">Hi! I'd like to book a consultation.</div>
+            <div class="msg msg--out">Hi! Happy to set that up. Would tomorrow morning or afternoon work better for you?</div>
+            <div class="msg msg--in">Afternoon, around 4pm.</div>
+            <div class="msg msg--out">Done — I've booked you for 4pm tomorrow. I'll send a reminder on Telegram an hour before. What's your name and best contact number?</div>
+            <div class="msg msg--in">Alex, +1 555 123 4567</div>
+            <div class="msg msg--out">Thanks, Alex! Your booking is confirmed ✅ I've passed your details to the manager.</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section pricing" id="pricing">
+      <div class="container">
+        <p class="eyebrow">Pricing</p>
+        <h2 class="section__title">Chat, WhatsApp and voice bot — in one subscription</h2>
+        <p class="section__lead">Competitors charge for chat and voice separately. We bundle them.</p>
+
+        <div class="billing-toggle">
+          <span class="billing-toggle__label is-active" id="lblMonthly">Monthly</span>
+          <button class="billing-toggle__switch" id="billingSwitch" role="switch" aria-checked="false" aria-label="Toggle billing period">
+            <span class="billing-toggle__knob"></span>
+          </button>
+          <span class="billing-toggle__label" id="lblYearly">Yearly <em>−20%</em></span>
+        </div>
+
+        <div class="grid grid-3 pricing__grid">
+          <article class="plan">
+            <h3 class="plan__name">Start</h3>
+            <p class="plan__for">For solo & micro businesses</p>
+            <div class="plan__price"><span class="plan__amount" data-monthly="2 900" data-yearly="2 320">2 900</span> <span class="plan__per">₽/mo</span></div>
+            <p class="plan__note" data-monthly="billed monthly" data-yearly="billed yearly">billed monthly</p>
+            <a href="#start" class="btn btn--outline btn--block">Try free</a>
+            <ul class="plan__list">
+              <li>1 AI assistant</li>
+              <li>Channels: Telegram + web widget</li>
+              <li>1 500 AI replies per month</li>
+              <li>Knowledge base: 1 collection, 50 docs</li>
+              <li>Cloud AI — base models</li>
+              <li>1 user</li>
+              <li>Chat support (business hours)</li>
+            </ul>
+          </article>
+
+          <article class="plan plan--featured">
+            <div class="plan__badge">Best seller</div>
+            <h3 class="plan__name">Business</h3>
+            <p class="plan__for">Full omnichannel + telephony</p>
+            <div class="plan__price"><span class="plan__amount" data-monthly="12 900" data-yearly="10 320">12 900</span> <span class="plan__per">₽/mo</span></div>
+            <p class="plan__note" data-monthly="billed monthly" data-yearly="billed yearly">billed monthly</p>
+            <a href="#start" class="btn btn--primary btn--block">Try free</a>
+            <ul class="plan__list">
+              <li>Up to 3 AI assistants</li>
+              <li>All channels + <strong>voice & telephony</strong></li>
+              <li>10 000 AI replies + 300 voice minutes</li>
+              <li>Knowledge base: 5 collections + auto-update</li>
+              <li>Integrations: amoCRM, Google, WooCommerce</li>
+              <li>Any AI model + fallback</li>
+              <li>Up to 5 users · priority support</li>
+            </ul>
+          </article>
+
+          <article class="plan">
+            <h3 class="plan__name">Team</h3>
+            <p class="plan__for">For agencies & larger teams</p>
+            <div class="plan__price"><span class="plan__amount" data-monthly="29 900" data-yearly="23 920">29 900</span> <span class="plan__per">₽/mo</span></div>
+            <p class="plan__note" data-monthly="billed monthly" data-yearly="billed yearly">billed monthly</p>
+            <a href="#start" class="btn btn--outline btn--block">Try free</a>
+            <ul class="plan__list">
+              <li>Up to 10 AI assistants</li>
+              <li>All channels, no instance limits</li>
+              <li>40 000 AI replies + 1 500 voice minutes</li>
+              <li>Unlimited knowledge base</li>
+              <li>Voice cloning + LoRA fine-tuning</li>
+              <li>White-label · up to 20 users</li>
+              <li>Dedicated manager + SLA</li>
+            </ul>
+          </article>
+        </div>
+
+        <div class="plan-enterprise">
+          <div>
+            <h3>Enterprise / On-premise</h3>
+            <p>Deploy on your server — data stays inside your perimeter. Local AI, custom roles and integrations (1C, your own APIs), industry-specific model training, 24/7 SLA and an onboarding team.</p>
+          </div>
+          <a href="#start" class="btn btn--outline btn--lg">Talk to sales</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="section faq" id="faq">
+      <div class="container container--narrow">
+        <p class="eyebrow">Questions</p>
+        <h2 class="section__title">Frequently asked questions</h2>
+        <div class="faq__list">
+          <details class="faq-item"><summary>How is this different from a regular chatbot?</summary><p>Regular bots run rigid scenario trees. Sekretar24 is real AI: it understands free text, remembers conversation context and answers from your knowledge base, not from a script.</p></details>
+          <details class="faq-item"><summary>Is my data safe?</summary><p>Yes. You can run on cloud models or deploy the AI entirely on your own server — your customers' data never leaves your perimeter.</p></details>
+          <details class="faq-item"><summary>Do I need my own server?</summary><p>No. The Start, Business and Team plans all run in the cloud. A dedicated server is only needed for on-premise deployment with local AI (Enterprise).</p></details>
+          <details class="faq-item"><summary>Which channels does the assistant work on?</summary><p>Telegram, WhatsApp, web chat widget, telephony and the Android app. One assistant — every channel at once.</p></details>
+          <details class="faq-item"><summary>Can I connect telephony?</summary><p>Yes, starting with the Business plan. The assistant takes and makes calls, recognizes speech and answers in voice.</p></details>
+          <details class="faq-item"><summary>What happens after the trial?</summary><p>Two weeks free, no credit card. Then pick the plan that fits — your data and settings carry over.</p></details>
+        </div>
+      </div>
+    </section>
+
+    <section class="section cta-final" id="start">
+      <div class="container container--narrow">
+        <div class="cta-card">
+          <h2 class="section__title">Launch your AI employee today</h2>
+          <p class="section__lead">
+            Leave a request — we'll get you set up and activate your 14-day free trial.
+          </p>
+          <form class="lead-form" id="leadForm" novalidate>
+            <div class="lead-form__row">
+              <input type="text" name="name" placeholder="Your name" required autocomplete="name" />
+              <input type="text" name="contact" placeholder="Phone or @Telegram" required autocomplete="tel" />
+            </div>
+            <select name="role" aria-label="What role do you need">
+              <option value="">What role do you need? (optional)</option>
+              <option>Call center</option>
+              <option>Tech support</option>
+              <option>Secretary</option>
+              <option>Lawyer</option>
+              <option>Accountant</option>
+              <option>Sales manager</option>
+              <option>Other</option>
+            </select>
+            <button type="submit" class="btn btn--primary btn--lg btn--block">Get access</button>
+            <p class="lead-form__hint">We'll reply within one business day. By clicking submit you agree to our privacy policy.</p>
+          </form>
+          <div class="lead-form__success" id="leadSuccess" hidden>
+            ✅ Request received! We'll be in touch shortly.
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="footer">
+    <div class="container footer__inner">
+      <div class="footer__col footer__col--brand">
+        <a href="/en/" class="logo">
+          <svg class="logo__mark" viewBox="0 0 512 512" aria-hidden="true"><defs><linearGradient id="gf" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#F0A830" /><stop offset="100%" stop-color="#C27010" /></linearGradient></defs><path fill="url(#gf)" fill-rule="evenodd" d="M 431.8 217.4 L 484.1 226.3 L 484.1 285.7 L 431.8 294.6 L 407.6 353.0 L 438.3 396.3 L 396.3 438.3 L 353.0 407.6 L 294.6 431.8 L 285.7 484.1 L 226.3 484.1 L 217.4 431.8 L 159.0 407.6 L 115.7 438.3 L 73.7 396.3 L 104.4 353.0 L 80.2 294.6 L 27.9 285.7 L 27.9 226.3 L 80.2 217.4 L 104.4 159.0 L 73.7 115.7 L 115.7 73.7 L 159.0 104.4 L 217.4 80.2 L 226.3 27.9 L 285.7 27.9 L 294.6 80.2 L 353.0 104.4 L 396.3 73.7 L 438.3 115.7 L 407.6 159.0 Z M 341.0 256.0 A 85 85 0 1 0 171.0 256.0 A 85 85 0 1 0 341.0 256.0 Z" /></svg>
+          <span class="logo__text">Sekretar<span class="logo__accent">24</span></span>
+        </a>
+        <p>Virtual AI assistants for business. Calls, chats and leads — 24/7.</p>
+      </div>
+      <nav class="footer__col">
+        <h4>Product</h4>
+        <a href="#features">Features</a>
+        <a href="#roles">Roles</a>
+        <a href="#pricing">Pricing</a>
+        <a href="#faq">FAQ</a>
+      </nav>
+      <nav class="footer__col">
+        <h4>Contacts</h4>
+        <a href="https://t.me/ai_sekretar24bot" target="_blank" rel="noopener">Telegram support</a>
+        <a href="https://github.com/ShaerWare/AI_Secretary_System" target="_blank" rel="noopener">Project on GitHub</a>
+        <a href="/login">Sign in</a>
+      </nav>
+      <nav class="footer__col">
+        <h4>Legal</h4>
+        <a href="#">Privacy policy</a>
+        <a href="#">Terms of service</a>
+      </nav>
+    </div>
+    <div class="container footer__bottom">
+      <span>© 2026 Sekretar24. All rights reserved.</span>
+      <span>Powered by AI Secretary System</span>
+    </div>
+  </footer>
+
+  <script src="/main.js" defer></script>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -9,7 +9,27 @@
   <meta name="description" content="Секретарь24 — виртуальный AI-ассистент для бизнеса. Отвечает клиентам в Telegram, WhatsApp, на сайте и по телефону, работает по вашей базе знаний и передаёт горячие лиды в CRM. Бесплатный триал 14 дней." />
   <meta name="keywords" content="ИИ секретарь, AI-секретарь, виртуальный ассистент для бизнеса, чат-бот для Telegram, чат-бот WhatsApp, голосовой робот, автоматизация колл-центра, AI ассистент юрист, AI ассистент бухгалтер" />
   <link rel="canonical" href="https://ai-sekretar24.ru/" />
-  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+  <link rel="alternate" hreflang="ru" href="https://ai-sekretar24.ru/" />
+  <link rel="alternate" hreflang="en" href="https://ai-sekretar24.ru/en/" />
+  <link rel="alternate" hreflang="kk" href="https://ai-sekretar24.ru/kk/" />
+  <link rel="alternate" hreflang="x-default" href="https://ai-sekretar24.ru/" />
+
+  <!-- Auto-detect browser language and redirect (only on first visit, on the root URL) -->
+  <script>
+    (function () {
+      try {
+        if (location.pathname !== '/' && location.pathname !== '/index.html') return;
+        if (localStorage.getItem('s24_lang')) return;
+        var lang = (navigator.language || navigator.userLanguage || '').toLowerCase();
+        var target = null;
+        if (lang.indexOf('en') === 0) target = '/en/';
+        else if (lang.indexOf('kk') === 0 || lang.indexOf('kz') === 0) target = '/kk/';
+        if (target) location.replace(target);
+      } catch (e) { /* no-op */ }
+    })();
+  </script>
 
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
@@ -19,6 +39,8 @@
   <meta property="og:url" content="https://ai-sekretar24.ru/" />
   <meta property="og:image" content="https://ai-sekretar24.ru/og-image.png" />
   <meta property="og:locale" content="ru_RU" />
+  <meta property="og:locale:alternate" content="en_US" />
+  <meta property="og:locale:alternate" content="kk_KZ" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
@@ -26,7 +48,7 @@
   <meta name="twitter:description" content="Виртуальный AI-ассистент: Telegram, WhatsApp, сайт, телефония. Триал 14 дней." />
   <meta name="twitter:image" content="https://ai-sekretar24.ru/og-image.png" />
 
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="/styles.css" />
 
   <!-- SEO: структурированные данные -->
   <script type="application/ld+json">
@@ -94,6 +116,12 @@
         <a href="#roles">Роли</a>
         <a href="#pricing">Тарифы</a>
         <a href="#faq">FAQ</a>
+      </nav>
+
+      <nav class="lang-switcher" aria-label="Язык / Language">
+        <a href="/" hreflang="ru" lang="ru" class="is-active" aria-current="page">RU</a>
+        <a href="/en/" hreflang="en" lang="en">EN</a>
+        <a href="/kk/" hreflang="kk" lang="kk">KK</a>
       </nav>
 
       <div class="header__actions">
@@ -421,6 +449,6 @@
     </div>
   </footer>
 
-  <script src="main.js" defer></script>
+  <script src="/main.js" defer></script>
 </body>
 </html>

--- a/site/kk/index.html
+++ b/site/kk/index.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="kk">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#09090b" />
+
+  <title>Секретарь24 — Бизнеске арналған AI-хатшы: қоңыраулар, чаттар, өтінімдер 24/7</title>
+  <meta name="description" content="Секретарь24 — бизнесіңізге арналған виртуалды AI-көмекші. Telegram, WhatsApp, сайтыңызда және телефон арқылы клиенттерге жауап береді, сіздің білім қорыңыз бойынша жұмыс істейді және ыстық лидтерді CRM-ге жібереді. 14 күн тегін триал." />
+  <meta name="keywords" content="AI хатшы, виртуалды көмекші, Telegram бот, WhatsApp бот, дауыстық робот, колл-орталық автоматтандыру, AI заңгер, AI бухгалтер" />
+  <link rel="canonical" href="https://ai-sekretar24.ru/kk/" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+  <link rel="alternate" hreflang="ru" href="https://ai-sekretar24.ru/" />
+  <link rel="alternate" hreflang="en" href="https://ai-sekretar24.ru/en/" />
+  <link rel="alternate" hreflang="kk" href="https://ai-sekretar24.ru/kk/" />
+  <link rel="alternate" hreflang="x-default" href="https://ai-sekretar24.ru/" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Секретарь24" />
+  <meta property="og:title" content="Секретарь24 — Бизнеске арналған AI-хатшы 24/7" />
+  <meta property="og:description" content="Виртуалды AI-көмекші: Telegram, WhatsApp, сайт, телефония. 14 күн тегін триал." />
+  <meta property="og:url" content="https://ai-sekretar24.ru/kk/" />
+  <meta property="og:image" content="https://ai-sekretar24.ru/og-image.png" />
+  <meta property="og:locale" content="kk_KZ" />
+  <meta property="og:locale:alternate" content="ru_RU" />
+  <meta property="og:locale:alternate" content="en_US" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Секретарь24 — Бизнеске арналған AI-хатшы 24/7" />
+  <meta name="twitter:description" content="Виртуалды AI-көмекші: Telegram, WhatsApp, сайт, телефон. 14 күн триал." />
+  <meta name="twitter:image" content="https://ai-sekretar24.ru/og-image.png" />
+
+  <link rel="stylesheet" href="/styles.css" />
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Секретарь24",
+    "url": "https://ai-sekretar24.ru/",
+    "logo": "https://ai-sekretar24.ru/favicon.svg",
+    "description": "Бизнеске арналған виртуалды AI-көмекшілер платформасы.",
+    "sameAs": ["https://t.me/ai_sekretar24bot", "https://github.com/ShaerWare/AI_Secretary_System"]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Секретарь24",
+    "applicationCategory": "BusinessApplication",
+    "operatingSystem": "Web, Android",
+    "description": "Бизнеске арналған виртуалды AI-көмекшi: Telegram, WhatsApp, сайт виджеті, телефония, білім қоры және CRM интеграциясы.",
+    "offers": [
+      { "@type": "Offer", "name": "Старт", "price": "2900", "priceCurrency": "RUB" },
+      { "@type": "Offer", "name": "Бизнес", "price": "12900", "priceCurrency": "RUB" },
+      { "@type": "Offer", "name": "Команда", "price": "29900", "priceCurrency": "RUB" }
+    ],
+    "aggregateRating": { "@type": "AggregateRating", "ratingValue": "4.9", "reviewCount": "37" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      { "@type": "Question", "name": "Бұл әдеттегі чат-боттан несімен ерекшеленеді?", "acceptedAnswer": { "@type": "Answer", "text": "Әдеттегі бот қатаң сценарий-ағаш бойынша жұмыс істейді. Секретарь24 — бұл нағыз AI: еркін тілді түсінеді, диалог мәнмәтінін есте сақтайды және сценарий бойынша емес, сіздің білім қорыңыз бойынша жауап береді." } },
+      { "@type": "Question", "name": "Менің деректерім қауіпсіз бе?", "acceptedAnswer": { "@type": "Answer", "text": "Иә. Бұлттық модельдерде істеуге болады немесе AI-ды толық өз серверіңізде орналастыруға болады — сонда клиент деректері периметрден шықпайды." } },
+      { "@type": "Question", "name": "Өз серверіңіз керек пе?", "acceptedAnswer": { "@type": "Answer", "text": "Жоқ. Старт, Бизнес және Команда тарифтерінде бәрі бұлтта жұмыс істейді. Өз сервер тек on-premise (Enterprise) орналастыру үшін керек." } },
+      { "@type": "Question", "name": "Көмекші қандай арналарда жұмыс істейді?", "acceptedAnswer": { "@type": "Answer", "text": "Telegram, WhatsApp, сайт чат-виджеті, телефония және Android-қосымша. Бір көмекші — барлық арналар бір уақытта." } },
+      { "@type": "Question", "name": "Телефонияны қосуға бола ма?", "acceptedAnswer": { "@type": "Answer", "text": "Иә, Бизнес тарифінен бастап. Көмекші қоңырауларды қабылдайды және шығарады, сөзді таниды және дауыспен жауап береді." } },
+      { "@type": "Question", "name": "Триалдан кейін не болады?", "acceptedAnswer": { "@type": "Answer", "text": "14 күн тегін, картаны байланыстырусыз. Содан кейін сәйкес тарифті таңдаңыз. Деректер мен баптаулар сақталады." } }
+    ]
+  }
+  </script>
+</head>
+<body>
+
+  <header class="header" id="header">
+    <div class="container header__inner">
+      <a href="/kk/" class="logo" aria-label="Секретарь24">
+        <svg class="logo__mark" viewBox="0 0 512 512" aria-hidden="true">
+          <defs>
+            <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#F0A830" />
+              <stop offset="100%" stop-color="#C27010" />
+            </linearGradient>
+          </defs>
+          <path fill="url(#g)" fill-rule="evenodd" d="M 431.8 217.4 L 484.1 226.3 L 484.1 285.7 L 431.8 294.6 L 407.6 353.0 L 438.3 396.3 L 396.3 438.3 L 353.0 407.6 L 294.6 431.8 L 285.7 484.1 L 226.3 484.1 L 217.4 431.8 L 159.0 407.6 L 115.7 438.3 L 73.7 396.3 L 104.4 353.0 L 80.2 294.6 L 27.9 285.7 L 27.9 226.3 L 80.2 217.4 L 104.4 159.0 L 73.7 115.7 L 115.7 73.7 L 159.0 104.4 L 217.4 80.2 L 226.3 27.9 L 285.7 27.9 L 294.6 80.2 L 353.0 104.4 L 396.3 73.7 L 438.3 115.7 L 407.6 159.0 Z M 341.0 256.0 A 85 85 0 1 0 171.0 256.0 A 85 85 0 1 0 341.0 256.0 Z" />
+        </svg>
+        <span class="logo__text">Секретарь<span class="logo__accent">24</span></span>
+      </a>
+
+      <nav class="nav" id="nav">
+        <a href="#features">Мүмкіндіктер</a>
+        <a href="#roles">Рөлдер</a>
+        <a href="#pricing">Тарифтер</a>
+        <a href="#faq">Жиі сұрақтар</a>
+      </nav>
+
+      <nav class="lang-switcher" aria-label="Language">
+        <a href="/" hreflang="ru" lang="ru">RU</a>
+        <a href="/en/" hreflang="en" lang="en">EN</a>
+        <a href="/kk/" hreflang="kk" lang="kk" class="is-active" aria-current="page">KK</a>
+      </nav>
+
+      <div class="header__actions">
+        <a href="/login" class="btn btn--ghost">Кіру</a>
+        <a href="#start" class="btn btn--primary">Тегін көру</a>
+      </div>
+
+      <button class="burger" id="burger" aria-label="Мәзір" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </header>
+
+  <main>
+
+    <section class="hero">
+      <div class="hero__glow" aria-hidden="true"></div>
+      <div class="container hero__inner">
+        <div class="hero__badge">⚡ 5 минутта іске қосылады · бағдарламашысыз</div>
+        <h1 class="hero__title">
+          Бизнеске арналған AI-хатшы:<br />
+          <span class="accent">қоңыраулар, чаттар, өтінімдер</span> — 24/7
+        </h1>
+        <p class="hero__subtitle">
+          Секретарь24 — бизнесіңізге арналған виртуалды AI-көмекшi.
+          Telegram, WhatsApp, сайтта және телефон арқылы клиенттерге жауап береді,
+          сіздің білім қорыңыз бойынша жұмыс істейді және ыстық лидтерді CRM-ге жібереді.
+        </p>
+        <div class="hero__cta">
+          <a href="#start" class="btn btn--primary btn--lg">14 күн тегін көру</a>
+          <a href="#pricing" class="btn btn--outline btn--lg">Тарифтерді көру</a>
+        </div>
+        <p class="hero__trust">Картаны байланыстырусыз · Толық функционалды триал · Бір рет басу арқылы тоқтату</p>
+
+        <div class="hero__channels">
+          <span>Жұмыс істейтін арналар:</span>
+          <div class="hero__channels-list">
+            <span class="chip">Telegram</span>
+            <span class="chip">WhatsApp</span>
+            <span class="chip">Сайт виджеті</span>
+            <span class="chip">Телефония</span>
+            <span class="chip">Android</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section problem">
+      <div class="container">
+        <h2 class="section__title">Жауапсыз қалған әрбір диалог — жоғалған табыс</h2>
+        <div class="grid grid-3">
+          <article class="pain">
+            <div class="pain__icon">📵</div>
+            <h3>Қабылданбаған қоңырау = жоғалған клиент</h3>
+            <p>Түнде, демалыста, түскі үзілісте — қоңыраулар жауапсыз қалады, ал клиент бәсекеге кетеді.</p>
+          </article>
+          <article class="pain">
+            <div class="pain__icon">🐌</div>
+            <h3>Менеджер бір сағаттан кейін жауап береді</h3>
+            <p>Қызметкер босағанша клиент салқындап немесе басқа жерден сатып алады. Жауап жылдамдығы маңызды.</p>
+          </article>
+          <article class="pain">
+            <div class="pain__icon">🔁</div>
+            <h3>Күннің жартысы қайталанатын сұрақтарға кетеді</h3>
+            <p>Бір сұрақтар, қолмен квалификация, CRM-ге деректерді көшіру — сату мен дамудың орнына.</p>
+          </article>
+        </div>
+        <p class="problem__solution">
+          <strong>Секретарь24</strong> барлық арналарда лезде және тәулік бойы жауап береді,
+          клиентті өздігінен квалификациялайды және CRM-де сделка ашады — ал командаңыз маңыздымен айналысады.
+        </p>
+      </div>
+    </section>
+
+    <section class="section roles" id="roles">
+      <div class="container">
+        <p class="eyebrow">AI-қызметкерлер</p>
+        <h2 class="section__title">Бір қозғалтқыш — кез келген кәсіп</h2>
+        <p class="section__lead">
+          Бір платформадан кез келген тапсырмаға арналған AI-қызметкер құрастырылады:
+          өз промптымен, білім қорымен, дауысымен және интеграцияларымен. Тексерілген сценарийлер:
+        </p>
+        <div class="grid grid-4">
+          <article class="role-card"><div class="role-card__icon">📞</div><h3>Колл-орталық</h3><p>Кіріс және шығыс қоңыраулар, сөйлеуді тану, дауыстық жауаптар, лидтерді квалификациялау, күрделі диалогтарды операторға беру.</p></article>
+          <article class="role-card"><div class="role-card__icon">🛠️</div><h3>Техқолдау</h3><p>Telegram, WhatsApp және сайт чатында 24/7 L1-қолдау. Білім қоры бойынша жауаптар, тикеттер, инженерлерге эскалация, сапа аналитикасы.</p></article>
+          <article class="role-card"><div class="role-card__icon">📇</div><h3>Хатшы</h3><p>Қоңырауларды қабылдау, Google Calendar-ға кездесулерді жазу, спам сүзгісі, ескертулер, хат-хабар мен поштаның қысқа қорытындысы.</p></article>
+          <article class="role-card"><div class="role-card__icon">⚖️</div><h3>Заңгер</h3><p>Заңнама бойынша кеңестер актуалды базаға (РФ және ҚР кодекстері мен сот тәжірибесі) сүйеніп, шарттарды талдау, құжаттар үлгілері.</p></article>
+          <article class="role-card"><div class="role-card__icon">📊</div><h3>Бухгалтер</h3><p>Салықтар мен есеп беру бойынша жауаптар, ЖКС/ҚҚС есептеу, мерзімдерді ескерту, құжаттардың алғашқы өңдеуі.</p></article>
+          <article class="role-card"><div class="role-card__icon">💼</div><h3>Сатушы менеджер</h3><p>Telegram, WhatsApp және виджетте сату воронкасы, квалификация, қосымша сатулар, төлемдерді қабылдау, amoCRM интеграциясы.</p></article>
+          <article class="role-card"><div class="role-card__icon">🎨</div><h3>Веб-студия</h3><p>AI-бриф, ТТ генерациясы, стек таңдау, лендинг-парақшаларды прототиптеу, клиенттер сайттарын қолдау.</p></article>
+          <article class="role-card"><div class="role-card__icon">👨‍💻</div><h3>Әзірлеушілер тобы</h3><p>Claude Code көпірі: код жазу мен ревью, git-пен жұмыс, тесттерді іске қосу және деплой — тікелей чаттан.</p></article>
+        </div>
+        <p class="roles__note">
+          Тізімде жоқ рөл керек пе? <a href="#start">Жазыңыз</a> — сіздің тапсырмаңыз үшін жинаймыз.
+        </p>
+      </div>
+    </section>
+
+    <section class="section how" id="how">
+      <div class="container">
+        <p class="eyebrow">Қалай жұмыс істейді</p>
+        <h2 class="section__title">Тіркелуден жұмыс істейтін көмекшіге дейін — бір кеште</h2>
+        <div class="grid grid-4 steps">
+          <article class="step"><div class="step__num">1</div><h3>Тіркелу</h3><p>Аккаунт жасаңыз — 14 күндік тегін триал бірден іске қосылады.</p></article>
+          <article class="step"><div class="step__num">2</div><h3>Көмекшіні баптау</h3><p>Дайын рөлді таңдаңыз, білім қорын жүктеңіз, промпт пен дауысты беріңіз.</p></article>
+          <article class="step"><div class="step__num">3</div><h3>Арналарды қосу</h3><p>Telegram, WhatsApp, сайт виджеті, телефония — бірнеше басумен қосылады.</p></article>
+          <article class="step"><div class="step__num">4</div><h3>24/7 жұмыс</h3><p>Көмекші тәулік бойы клиенттерге жауап береді, ыстық лидтер CRM-ге ұшады.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section features" id="features">
+      <div class="container">
+        <p class="eyebrow">Мүмкіндіктер</p>
+        <h2 class="section__title">Сценарийлік емес, нағыз AI</h2>
+        <div class="grid grid-3">
+          <article class="feature"><div class="feature__icon">🧠</div><h3>Білім қоры (RAG)</h3><p>Құжаттарды, сайттарды немесе RSS-ті жүктеңіз — көмекші сіздің деректеріңіз бойынша қатаң жауап береді, ойдан шығармайды.</p></article>
+          <article class="feature"><div class="feature__icon">🎙️</div><h3>Дауыс</h3><p>Сөзді синтездеу және дауысты клондау — көмекші компанияңыздың тірі қызметкеріндей естіледі.</p></article>
+          <article class="feature"><div class="feature__icon">🔒</div><h3>Жергілікті және бұлттық AI</h3><p>Бұлттық модельдерде істеңіз немесе AI-ды өз серверіңізде орналастырыңыз — деректер периметрден шықпайды.</p></article>
+          <article class="feature"><div class="feature__icon">🔗</div><h3>Интеграциялар</h3><p>amoCRM, WooCommerce, Google Calendar, Drive және Gmail — көмекші жұмыс құралдарыңызға кірігеді.</p></article>
+          <article class="feature"><div class="feature__icon">🌍</div><h3>Көп тілділік</h3><p>Орысша, ағылшынша, қазақша — көмекші клиенттермен олардың тілінде сөйлеседі.</p></article>
+          <article class="feature"><div class="feature__icon">🎯</div><h3>Қосымша оқыту</h3><p>Сіздің деректер бойынша LoRA-баптау — көмекші компанияңыздың тонусы мен сараптамасын меңгереді.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section demo">
+      <div class="container demo__inner">
+        <div class="demo__text">
+          <p class="eyebrow">Тірі мысал</p>
+          <h2 class="section__title section__title--left">Көмекшімен диалог осылай көрінеді</h2>
+          <p class="section__lead section__lead--left">
+            Көмекші сұрақтың мәнін түсінеді, нақтылайды және клиентті мақсатты әрекетке жеткізеді —
+            жазылу, өтінім немесе төлем. «Команданы түсінбедім» мен мәзір ағаштарынсыз.
+          </p>
+          <a href="#start" class="btn btn--primary btn--lg">Өз сұрақтарыңызда көру</a>
+        </div>
+        <div class="chat-mock" aria-hidden="true">
+          <div class="chat-mock__head"><span class="dot"></span> Көмекші · Секретарь24</div>
+          <div class="chat-mock__body">
+            <div class="msg msg--in">Сәлеметсіз бе! Кеңеске жазылғым келеді.</div>
+            <div class="msg msg--out">Сәлеметсіз бе! Қуанышпен жазамын. Ертеңге таңертеңгі ме әлде түстен кейінгі қолайлы ма?</div>
+            <div class="msg msg--in">Түстен кейінгіге, шамамен 16:00.</div>
+            <div class="msg msg--out">Тамаша — сізді ертең 16:00-ге жаздым. Бір сағат бұрын Telegram-ға ескертпе жіберемін. Атыңыз кім және байланыс үшін қандай нөмір?</div>
+            <div class="msg msg--in">Алексей, +7 900 123-45-67</div>
+            <div class="msg msg--out">Рахмет, Алексей! Жазылу расталды ✅ Деректерді менеджерге жібердім.</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section pricing" id="pricing">
+      <div class="container">
+        <p class="eyebrow">Тарифтер</p>
+        <h2 class="section__title">Чат, WhatsApp және дауыстық бот — бір жазылымда</h2>
+        <p class="section__lead">Бәсекелестерде чат пен қоңыраулар — екі бөлек жазылым. Бізде бәрі бір тарифте.</p>
+
+        <div class="billing-toggle">
+          <span class="billing-toggle__label is-active" id="lblMonthly">Айлық</span>
+          <button class="billing-toggle__switch" id="billingSwitch" role="switch" aria-checked="false" aria-label="Төлем кезеңін ауыстыру">
+            <span class="billing-toggle__knob"></span>
+          </button>
+          <span class="billing-toggle__label" id="lblYearly">Жылдық <em>−20%</em></span>
+        </div>
+
+        <div class="grid grid-3 pricing__grid">
+          <article class="plan">
+            <h3 class="plan__name">Старт</h3>
+            <p class="plan__for">Жалғыз кәсіпкер мен микробизнеске</p>
+            <div class="plan__price"><span class="plan__amount" data-monthly="2 900" data-yearly="2 320">2 900</span> <span class="plan__per">₽/ай</span></div>
+            <p class="plan__note" data-monthly="айлық төлеммен" data-yearly="жылдық төлеммен">айлық төлеммен</p>
+            <a href="#start" class="btn btn--outline btn--block">Тегін көру</a>
+            <ul class="plan__list">
+              <li>1 AI-көмекшi</li>
+              <li>Арналар: Telegram + сайт виджеті</li>
+              <li>Айына 1 500 AI-жауап</li>
+              <li>Білім қоры: 1 коллекция, 50 құжат</li>
+              <li>Бұлттық AI — базалық модельдер</li>
+              <li>1 пайдаланушы</li>
+              <li>Чатта қолдау (жұмыс уақытында)</li>
+            </ul>
+          </article>
+
+          <article class="plan plan--featured">
+            <div class="plan__badge">Хит</div>
+            <h3 class="plan__name">Бизнес</h3>
+            <p class="plan__for">Толық омниарна + телефония</p>
+            <div class="plan__price"><span class="plan__amount" data-monthly="12 900" data-yearly="10 320">12 900</span> <span class="plan__per">₽/ай</span></div>
+            <p class="plan__note" data-monthly="айлық төлеммен" data-yearly="жылдық төлеммен">айлық төлеммен</p>
+            <a href="#start" class="btn btn--primary btn--block">Тегін көру</a>
+            <ul class="plan__list">
+              <li>3-ке дейін AI-көмекшi</li>
+              <li>Барлық арналар + <strong>дауыс және телефония</strong></li>
+              <li>10 000 AI-жауап + 300 минут дауыс</li>
+              <li>Білім қоры: 5 коллекция + автожаңарту</li>
+              <li>Интеграциялар: amoCRM, Google, WooCommerce</li>
+              <li>Кез келген AI-модель + резерв</li>
+              <li>5-ке дейін пайдаланушы · басымдылықпен қолдау</li>
+            </ul>
+          </article>
+
+          <article class="plan">
+            <h3 class="plan__name">Команда</h3>
+            <p class="plan__for">Агенттіктер мен үлкен командаларға</p>
+            <div class="plan__price"><span class="plan__amount" data-monthly="29 900" data-yearly="23 920">29 900</span> <span class="plan__per">₽/ай</span></div>
+            <p class="plan__note" data-monthly="айлық төлеммен" data-yearly="жылдық төлеммен">айлық төлеммен</p>
+            <a href="#start" class="btn btn--outline btn--block">Тегін көру</a>
+            <ul class="plan__list">
+              <li>10-ға дейін AI-көмекшi</li>
+              <li>Инстанс лимитісіз барлық арналар</li>
+              <li>40 000 AI-жауап + 1 500 минут дауыс</li>
+              <li>Шектеусіз білім қоры</li>
+              <li>Дауыс клондау + LoRA-баптау</li>
+              <li>White-label · 20-ға дейін пайдаланушы</li>
+              <li>Бөлінген менеджер + SLA</li>
+            </ul>
+          </article>
+        </div>
+
+        <div class="plan-enterprise">
+          <div>
+            <h3>Enterprise / On-premise</h3>
+            <p>Серверіңізде орналастыру — деректер периметрден шықпайды. Жергілікті AI, кастомды рөлдер мен интеграциялар (1С, өз API), сала бойынша модельдерді оқыту, 24/7 SLA және енгізу командасы.</p>
+          </div>
+          <a href="#start" class="btn btn--outline btn--lg">Енгізуді талқылау</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="section faq" id="faq">
+      <div class="container container--narrow">
+        <p class="eyebrow">Сұрақтар</p>
+        <h2 class="section__title">Жиі сұрақтар</h2>
+        <div class="faq__list">
+          <details class="faq-item"><summary>Бұл әдеттегі чат-боттан несімен ерекшеленеді?</summary><p>Әдеттегі бот қатаң сценарий-ағаш бойынша жұмыс істейді. Секретарь24 — бұл нағыз AI: еркін тілді түсінеді, диалог мәнмәтінін есте сақтайды және сценарий бойынша емес, сіздің білім қорыңыз бойынша жауап береді.</p></details>
+          <details class="faq-item"><summary>Менің деректерім қауіпсіз бе?</summary><p>Иә. Бұлттық модельдерде істеуге болады немесе AI-ды толық өз серверіңізде орналастыруға болады — сонда клиент деректері периметрден шықпайды.</p></details>
+          <details class="faq-item"><summary>Өз серверім керек пе?</summary><p>Жоқ. Старт, Бизнес және Команда тарифтерінде бәрі бұлтта жұмыс істейді. Өз сервер тек on-premise (Enterprise) орналастыру үшін керек.</p></details>
+          <details class="faq-item"><summary>Көмекшi қандай арналарда жұмыс істейді?</summary><p>Telegram, WhatsApp, сайт чат-виджеті, телефония және Android-қосымша. Бір көмекші — барлық арналар бір уақытта.</p></details>
+          <details class="faq-item"><summary>Телефонияны қосуға бола ма?</summary><p>Иә, Бизнес тарифінен бастап. Көмекші қоңырауларды қабылдайды және шығарады, сөзді таниды және дауыспен жауап береді.</p></details>
+          <details class="faq-item"><summary>Триалдан кейін не болады?</summary><p>14 күн тегін, картаны байланыстырусыз. Содан кейін сәйкес тарифті таңдаңыз. Деректер мен баптаулар сақталады.</p></details>
+        </div>
+      </div>
+    </section>
+
+    <section class="section cta-final" id="start">
+      <div class="container container--narrow">
+        <div class="cta-card">
+          <h2 class="section__title">AI-қызметкеріңізді бүгін іске қосыңыз</h2>
+          <p class="section__lead">
+            Өтінім қалдырыңыз — қосамыз, баптауға көмектесеміз және 14 күндік тегін триалды іске қосамыз.
+          </p>
+          <form class="lead-form" id="leadForm" novalidate>
+            <div class="lead-form__row">
+              <input type="text" name="name" placeholder="Атыңыз" required autocomplete="name" />
+              <input type="text" name="contact" placeholder="Телефон немесе @Telegram" required autocomplete="tel" />
+            </div>
+            <select name="role" aria-label="Қандай көмекші керек">
+              <option value="">Қандай көмекші керек? (міндетті емес)</option>
+              <option>Колл-орталық</option>
+              <option>Техқолдау</option>
+              <option>Хатшы</option>
+              <option>Заңгер</option>
+              <option>Бухгалтер</option>
+              <option>Сатушы менеджер</option>
+              <option>Басқа</option>
+            </select>
+            <button type="submit" class="btn btn--primary btn--lg btn--block">Қол жеткізу алу</button>
+            <p class="lead-form__hint">Жұмыс күні ішінде хабарласамыз. Батырманы басу арқылы құпиялылық саясатымен келісесіз.</p>
+          </form>
+          <div class="lead-form__success" id="leadSuccess" hidden>
+            ✅ Өтінім қабылданды! Жуық арада хабарласамыз.
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="footer">
+    <div class="container footer__inner">
+      <div class="footer__col footer__col--brand">
+        <a href="/kk/" class="logo">
+          <svg class="logo__mark" viewBox="0 0 512 512" aria-hidden="true"><defs><linearGradient id="gf" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#F0A830" /><stop offset="100%" stop-color="#C27010" /></linearGradient></defs><path fill="url(#gf)" fill-rule="evenodd" d="M 431.8 217.4 L 484.1 226.3 L 484.1 285.7 L 431.8 294.6 L 407.6 353.0 L 438.3 396.3 L 396.3 438.3 L 353.0 407.6 L 294.6 431.8 L 285.7 484.1 L 226.3 484.1 L 217.4 431.8 L 159.0 407.6 L 115.7 438.3 L 73.7 396.3 L 104.4 353.0 L 80.2 294.6 L 27.9 285.7 L 27.9 226.3 L 80.2 217.4 L 104.4 159.0 L 73.7 115.7 L 115.7 73.7 L 159.0 104.4 L 217.4 80.2 L 226.3 27.9 L 285.7 27.9 L 294.6 80.2 L 353.0 104.4 L 396.3 73.7 L 438.3 115.7 L 407.6 159.0 Z M 341.0 256.0 A 85 85 0 1 0 171.0 256.0 A 85 85 0 1 0 341.0 256.0 Z" /></svg>
+          <span class="logo__text">Секретарь<span class="logo__accent">24</span></span>
+        </a>
+        <p>Бизнеске арналған виртуалды AI-көмекшілер. Қоңыраулар, чаттар, өтінімдер — 24/7.</p>
+      </div>
+      <nav class="footer__col">
+        <h4>Өнім</h4>
+        <a href="#features">Мүмкіндіктер</a>
+        <a href="#roles">Рөлдер</a>
+        <a href="#pricing">Тарифтер</a>
+        <a href="#faq">Жиі сұрақтар</a>
+      </nav>
+      <nav class="footer__col">
+        <h4>Байланыс</h4>
+        <a href="https://t.me/ai_sekretar24bot" target="_blank" rel="noopener">Telegram-да қолдау</a>
+        <a href="https://github.com/ShaerWare/AI_Secretary_System" target="_blank" rel="noopener">Жобаның GitHub</a>
+        <a href="/login">Жеке кабинетке кіру</a>
+      </nav>
+      <nav class="footer__col">
+        <h4>Құқықтық</h4>
+        <a href="#">Құпиялылық саясаты</a>
+        <a href="#">Жария оферта</a>
+      </nav>
+    </div>
+    <div class="container footer__bottom">
+      <span>© 2026 Секретарь24. Барлық құқықтар қорғалған.</span>
+      <span>AI Secretary System платформасында жасалды</span>
+    </div>
+  </footer>
+
+  <script src="/main.js" defer></script>
+</body>
+</html>

--- a/site/main.js
+++ b/site/main.js
@@ -5,6 +5,14 @@
   var header = document.getElementById('header');
   var burger = document.getElementById('burger');
 
+  /* --- Переключатель языков: запоминаем выбор пользователя, чтобы авто-редирект
+         с корня по browser-language больше не срабатывал --- */
+  document.querySelectorAll('.lang-switcher a').forEach(function (a) {
+    a.addEventListener('click', function () {
+      try { localStorage.setItem('s24_lang', a.getAttribute('hreflang') || ''); } catch (e) {}
+    });
+  });
+
   /* --- Шапка: фон при скролле --- */
   function onScroll() {
     header.classList.toggle('scrolled', window.scrollY > 8);

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,10 +1,5 @@
 User-agent: *
-Allow: /$
-Allow: /index.html
-Allow: /styles.css
-Allow: /main.js
-Allow: /favicon.svg
-Allow: /og-image.png
+Allow: /
 Disallow: /admin/
 
 Sitemap: https://ai-sekretar24.ru/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,9 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://ai-sekretar24.ru/</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-05-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://ai-sekretar24.ru/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://ai-sekretar24.ru/en/" />
+    <xhtml:link rel="alternate" hreflang="kk" href="https://ai-sekretar24.ru/kk/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://ai-sekretar24.ru/" />
+  </url>
+  <url>
+    <loc>https://ai-sekretar24.ru/en/</loc>
+    <lastmod>2026-05-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://ai-sekretar24.ru/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://ai-sekretar24.ru/en/" />
+    <xhtml:link rel="alternate" hreflang="kk" href="https://ai-sekretar24.ru/kk/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://ai-sekretar24.ru/" />
+  </url>
+  <url>
+    <loc>https://ai-sekretar24.ru/kk/</loc>
+    <lastmod>2026-05-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://ai-sekretar24.ru/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://ai-sekretar24.ru/en/" />
+    <xhtml:link rel="alternate" hreflang="kk" href="https://ai-sekretar24.ru/kk/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://ai-sekretar24.ru/" />
   </url>
 </urlset>

--- a/site/styles.css
+++ b/site/styles.css
@@ -114,6 +114,29 @@ h1, h2, h3, h4 { line-height: 1.2; font-weight: 700; }
 .nav a:hover { color: var(--text); }
 .header__actions { display: flex; gap: 10px; margin-left: auto; align-items: center; }
 
+/* Переключатель языков */
+.lang-switcher {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 8px;
+  padding: 4px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+}
+.lang-switcher a {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  color: var(--muted);
+  padding: 4px 10px;
+  border-radius: 999px;
+  transition: color .15s, background .15s;
+}
+.lang-switcher a:hover { color: var(--text); }
+.lang-switcher a.is-active { color: #1a1205; background: var(--grad); }
+
 .burger {
   display: none;
   margin-left: auto;


### PR DESCRIPTION
## Summary

Мультиязычный лендинг: три отдельных HTML на язык + переключатель в шапке + автодетект по `navigator.language`.

- `site/index.html` — RU (отдаётся с `/`).
- `site/en/index.html` — английский (URL `/en/`).
- `site/kk/index.html` — казахский (URL `/kk/`).
- В каждом — `hreflang`-альтернативы и переводы JSON-LD/OG/meta.
- В `sitemap.xml` все 3 URL с `xhtml:link` альтернативами.
- `.lang-switcher` (RU·EN·KK) в шапке всех страниц.
- Inline-скрипт в RU-файле редиректит на `/en/` или `/kk/` при первом визите на `/` если `navigator.language` совпадает.
- Клик по переключателю пишет `localStorage.s24_lang` — авто-редирект больше не срабатывает.

## Notes

- Без NEWS-блока (маркетинговая страница, не для FCM-пуша мобильным юзерам).
- Деплой: rsync `site/` + новые nginx `location =` для `/en/` и `/kk/`.
- TODO: вынести переводы в `translations.json` + генерация HTML из шаблона (3 ручных файла плохо масштабируются).

## Test plan

- [ ] CI: lint-backend, lint-frontend, security
- [ ] `/` отдаёт RU-лендинг, в шапке RU выделен
- [ ] `/en/` отдаёт EN-лендинг, EN выделен
- [ ] `/kk/` отдаёт KK-лендинг, KK выделен
- [ ] Переключатель меняет URL и язык
- [ ] Браузер с `en-*` локалью при первом визите на `/` редиректит на `/en/`
- [ ] После клика по переключателю авто-редирект не срабатывает
- [ ] `/admin/` и API (`/v1/`, `/health`, `/widget/`) не затронуты

🤖 Generated with [Claude Code](https://claude.com/claude-code)