### PR TITLE
fix(landing): переключатель справа от auth + автодетект учитывает referrer

### DIFF
--- a/site/en/index.html
+++ b/site/en/index.html
@@ -31,7 +31,7 @@
   <meta name="twitter:description" content="Virtual AI assistant: Telegram, WhatsApp, web, phone. 14-day trial." />
   <meta name="twitter:image" content="https://ai-sekretar24.ru/og-image.png" />
 
-  <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="/styles.css?v=2" />
 
   <script type="application/ld+json">
   {
@@ -99,16 +99,16 @@
         <a href="#faq">FAQ</a>
       </nav>
 
+      <div class="header__actions">
+        <a href="/login" class="btn btn--ghost">Sign in</a>
+        <a href="#start" class="btn btn--primary">Try free</a>
+      </div>
+
       <nav class="lang-switcher" aria-label="Language">
         <a href="/" hreflang="ru" lang="ru">RU</a>
         <a href="/en/" hreflang="en" lang="en" class="is-active" aria-current="page">EN</a>
         <a href="/kk/" hreflang="kk" lang="kk">KK</a>
       </nav>
-
-      <div class="header__actions">
-        <a href="/login" class="btn btn--ghost">Sign in</a>
-        <a href="#start" class="btn btn--primary">Try free</a>
-      </div>
 
       <button class="burger" id="burger" aria-label="Menu" aria-expanded="false">
         <span></span><span></span><span></span>
@@ -415,6 +415,6 @@
     </div>
   </footer>
 
-  <script src="/main.js" defer></script>
+  <script src="/main.js?v=2" defer></script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -16,11 +16,20 @@
   <link rel="alternate" hreflang="kk" href="https://ai-sekretar24.ru/kk/" />
   <link rel="alternate" hreflang="x-default" href="https://ai-sekretar24.ru/" />
 
-  <!-- Auto-detect browser language and redirect (only on first visit, on the root URL) -->
+  <!-- Auto-detect browser language and redirect (only on first visit, on the root URL).
+       Skipped if user already chose a language, or arrived from another language page on this site. -->
   <script>
     (function () {
       try {
-        if (location.pathname !== '/' && location.pathname !== '/index.html') return;
+        var path = location.pathname;
+        if (path !== '/' && path !== '/index.html') return;
+        var origin = location.origin;
+        var ref = document.referrer || '';
+        // Came from /en/ or /kk/ on this site -> user explicitly picked RU
+        if (ref.indexOf(origin + '/en/') === 0 || ref.indexOf(origin + '/kk/') === 0) {
+          try { localStorage.setItem('s24_lang', 'ru'); } catch (e) {}
+          return;
+        }
         if (localStorage.getItem('s24_lang')) return;
         var lang = (navigator.language || navigator.userLanguage || '').toLowerCase();
         var target = null;
@@ -48,7 +57,7 @@
   <meta name="twitter:description" content="Виртуальный AI-ассистент: Telegram, WhatsApp, сайт, телефония. Триал 14 дней." />
   <meta name="twitter:image" content="https://ai-sekretar24.ru/og-image.png" />
 
-  <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="/styles.css?v=2" />
 
   <!-- SEO: структурированные данные -->
   <script type="application/ld+json">
@@ -118,16 +127,16 @@
         <a href="#faq">FAQ</a>
       </nav>
 
+      <div class="header__actions">
+        <a href="/login" class="btn btn--ghost">Войти</a>
+        <a href="#start" class="btn btn--primary">Попробовать бесплатно</a>
+      </div>
+
       <nav class="lang-switcher" aria-label="Язык / Language">
         <a href="/" hreflang="ru" lang="ru" class="is-active" aria-current="page">RU</a>
         <a href="/en/" hreflang="en" lang="en">EN</a>
         <a href="/kk/" hreflang="kk" lang="kk">KK</a>
       </nav>
-
-      <div class="header__actions">
-        <a href="/login" class="btn btn--ghost">Войти</a>
-        <a href="#start" class="btn btn--primary">Попробовать бесплатно</a>
-      </div>
 
       <button class="burger" id="burger" aria-label="Меню" aria-expanded="false">
         <span></span><span></span><span></span>
@@ -449,6 +458,6 @@
     </div>
   </footer>
 
-  <script src="/main.js" defer></script>
+  <script src="/main.js?v=2" defer></script>
 </body>
 </html>

--- a/site/kk/index.html
+++ b/site/kk/index.html
@@ -31,7 +31,7 @@
   <meta name="twitter:description" content="Виртуалды AI-көмекші: Telegram, WhatsApp, сайт, телефон. 14 күн триал." />
   <meta name="twitter:image" content="https://ai-sekretar24.ru/og-image.png" />
 
-  <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="/styles.css?v=2" />
 
   <script type="application/ld+json">
   {
@@ -99,16 +99,16 @@
         <a href="#faq">Жиі сұрақтар</a>
       </nav>
 
+      <div class="header__actions">
+        <a href="/login" class="btn btn--ghost">Кіру</a>
+        <a href="#start" class="btn btn--primary">Тегін көру</a>
+      </div>
+
       <nav class="lang-switcher" aria-label="Language">
         <a href="/" hreflang="ru" lang="ru">RU</a>
         <a href="/en/" hreflang="en" lang="en">EN</a>
         <a href="/kk/" hreflang="kk" lang="kk" class="is-active" aria-current="page">KK</a>
       </nav>
-
-      <div class="header__actions">
-        <a href="/login" class="btn btn--ghost">Кіру</a>
-        <a href="#start" class="btn btn--primary">Тегін көру</a>
-      </div>
 
       <button class="burger" id="burger" aria-label="Мәзір" aria-expanded="false">
         <span></span><span></span><span></span>
@@ -415,6 +415,6 @@
     </div>
   </footer>
 
-  <script src="/main.js" defer></script>
+  <script src="/main.js?v=2" defer></script>
 </body>
 </html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -114,12 +114,11 @@ h1, h2, h3, h4 { line-height: 1.2; font-weight: 700; }
 .nav a:hover { color: var(--text); }
 .header__actions { display: flex; gap: 10px; margin-left: auto; align-items: center; }
 
-/* Переключатель языков */
+/* Переключатель языков (справа от auth-кнопок) */
 .lang-switcher {
   display: flex;
   align-items: center;
   gap: 2px;
-  margin-left: 8px;
   padding: 4px;
   background: var(--surface);
   border: 1px solid var(--border);
@@ -129,13 +128,17 @@ h1, h2, h3, h4 { line-height: 1.2; font-weight: 700; }
   font-size: 12px;
   font-weight: 700;
   letter-spacing: .04em;
-  color: var(--muted);
-  padding: 4px 10px;
+  color: var(--dim);
+  padding: 5px 11px;
   border-radius: 999px;
   transition: color .15s, background .15s;
 }
 .lang-switcher a:hover { color: var(--text); }
-.lang-switcher a.is-active { color: #1a1205; background: var(--grad); }
+.lang-switcher a.is-active {
+  color: #1a1205;
+  background: var(--grad);
+  box-shadow: 0 2px 6px -1px rgba(245, 158, 11, .4);
+}
 
 .burger {
   display: none;


### PR DESCRIPTION
## Summary

- `.lang-switcher` теперь справа от «Войти / Sign in / Кіру» (раньше — между nav и actions).
- Усилен активный состояние (outline shadow + dim non-active).
- Inline-скрипт на `/` теперь учитывает `document.referrer`: переход с `/en/` или `/kk/` НЕ триггерит авто-редирект (плюс пишет `s24_lang=ru`). Чинит баг «клик RU из EN → обратно в EN» для пользователей со старым закешированным `main.js`.
- `?v=2` cache-bust на `styles.css` и `main.js`.

Без NEWS-блока.

## Test plan

- [ ] / в en-браузере с пустым localStorage → редирект на /en/.
- [ ] /en/ → клик RU → попадает на / (русская версия), `localStorage.s24_lang=ru`.
- [ ] / → клик EN → /en/, в шапке EN подсвечена градиентом.
- [ ] / → клик KK → /kk/, KK подсвечена.
- [ ] /admin/ и /login не затронуты.

🤖 Generated with [Claude Code](https://claude.com/claude-code)