### PR TITLE
feat(landing): Android app section + APK download CTA (3 locales)

### DIFF
--- a/site/en/index.html
+++ b/site/en/index.html
@@ -44,7 +44,7 @@
   <meta name="twitter:description" content="Virtual AI assistant: Telegram, WhatsApp, web, phone. 14-day trial." />
   <meta name="twitter:image" content="https://ai-sekretar24.ru/en/og-image.svg" />
 
-  <link rel="stylesheet" href="/styles.css?v=3" />
+  <link rel="stylesheet" href="/styles.css?v=4" />
 
   <script type="application/ld+json">
   {
@@ -133,6 +133,7 @@
       <nav class="nav" id="nav">
         <a href="#features">Features</a>
         <a href="#roles">Roles</a>
+        <a href="#mobile">📱 Android</a>
         <a href="#pricing">Pricing</a>
         <a href="#faq">FAQ</a>
       </nav>
@@ -337,6 +338,65 @@
             <div class="msg msg--out">Done — I've booked you for 4pm tomorrow. I'll send a reminder on Telegram an hour before. What's your name and best contact number?</div>
             <div class="msg msg--in">Alex, +1 555 123 4567</div>
             <div class="msg msg--out">Thanks, Alex! Your booking is confirmed ✅ I've passed your details to the manager.</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ MOBILE APP ============ -->
+    <section class="section mobile-app" id="mobile">
+      <div class="container">
+        <p class="eyebrow">📱 Android app</p>
+        <h2 class="section__title">Sekretar24 — in your pocket</h2>
+        <p class="section__lead">
+          Native Android app. Voice chat with your assistant, push notifications for new
+          messages and app updates, access to all your chats — from anywhere.
+        </p>
+
+        <div class="mobile-app__inner">
+          <div class="mobile-app__text">
+            <ul class="mobile-app__features">
+              <li>✓ All your AI chats in one app</li>
+              <li>✓ Voice input and TTS answers</li>
+              <li>✓ Push notifications for new messages and app updates</li>
+              <li>✓ Attach photos, PDFs, documents into the context</li>
+              <li>✓ Shared team chats (admin / user roles)</li>
+              <li>✓ Warm-brown dark theme</li>
+              <li>✓ Open-source: <a href="https://github.com/ShaerWare/AI_Secretary_System/tree/main/mobile" target="_blank" rel="noopener">source code on GitHub</a></li>
+            </ul>
+
+            <div class="mobile-app__cta">
+              <a href="https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk" class="btn btn--primary btn--lg" download>
+                📲 Download APK · v2.2
+              </a>
+              <p class="mobile-app__meta">
+                Android 8.0+ · auto-updates via push · free
+              </p>
+            </div>
+
+            <p class="mobile-app__note">
+              💡 On iPhone our mobile browser version (PWA) works fully — all assistant
+              features are available without installation. Native iOS app is on the roadmap.
+            </p>
+          </div>
+
+          <div class="mobile-app__mockup" aria-hidden="true">
+            <div class="phone-frame">
+              <div class="phone-frame__notch"></div>
+              <div class="phone-frame__screen">
+                <div class="phone-frame__head">
+                  <span class="phone-frame__dot"></span>
+                  <span>Sekretar24</span>
+                </div>
+                <div class="phone-frame__body">
+                  <div class="phone-frame__msg phone-frame__msg--in">Book a meeting tomorrow at 4pm</div>
+                  <div class="phone-frame__msg phone-frame__msg--out">Booked. Send a reminder one hour before?</div>
+                  <div class="phone-frame__msg phone-frame__msg--in">Yes, and on WhatsApp too</div>
+                  <div class="phone-frame__msg phone-frame__msg--out">✓ Done. Reminder on Telegram and WhatsApp one hour before.</div>
+                </div>
+              </div>
+              <div class="phone-frame__home"></div>
+            </div>
           </div>
         </div>
       </div>
@@ -562,6 +622,7 @@
         <h4>Contacts</h4>
         <a href="https://t.me/ai_sekretar24bot" target="_blank" rel="noopener">Telegram support</a>
         <a href="https://github.com/ShaerWare/AI_Secretary_System" target="_blank" rel="noopener">Project on GitHub</a>
+        <a href="https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk" download>📱 Android APK · v2.2</a>
         <a href="/admin/">Sign in</a>
       </nav>
       <nav class="footer__col">
@@ -576,6 +637,6 @@
     </div>
   </footer>
 
-  <script src="/main.js?v=3" defer></script>
+  <script src="/main.js?v=4" defer></script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -70,7 +70,7 @@
   <meta name="twitter:description" content="Виртуальный AI-ассистент: Telegram, WhatsApp, сайт, телефония. Триал 14 дней." />
   <meta name="twitter:image" content="https://ai-sekretar24.ru/og-image.svg" />
 
-  <link rel="stylesheet" href="/styles.css?v=3" />
+  <link rel="stylesheet" href="/styles.css?v=4" />
 
   <!-- SEO: структурированные данные -->
   <script type="application/ld+json">
@@ -160,6 +160,7 @@
       <nav class="nav" id="nav">
         <a href="#features">Возможности</a>
         <a href="#roles">Роли</a>
+        <a href="#mobile">📱 Android</a>
         <a href="#pricing">Тарифы</a>
         <a href="#faq">FAQ</a>
       </nav>
@@ -371,6 +372,65 @@
             <div class="msg msg--out">Отлично — записал вас на завтра, 16:00. Отправлю напоминание в Telegram за час. Как вас зовут и по какому номеру связаться?</div>
             <div class="msg msg--in">Алексей, +7 900 123-45-67</div>
             <div class="msg msg--out">Спасибо, Алексей! Запись подтверждена ✅ Передал данные менеджеру.</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ МОБИЛЬНОЕ ПРИЛОЖЕНИЕ ============ -->
+    <section class="section mobile-app" id="mobile">
+      <div class="container">
+        <p class="eyebrow">📱 Android-приложение</p>
+        <h2 class="section__title">Секретарь24 — у вас в кармане</h2>
+        <p class="section__lead">
+          Нативное Android-приложение. Голосовое общение с ассистентом, push-уведомления
+          о новых сообщениях, доступ ко всем своим чатам — откуда угодно.
+        </p>
+
+        <div class="mobile-app__inner">
+          <div class="mobile-app__text">
+            <ul class="mobile-app__features">
+              <li>✓ Все ваши AI-чаты в одном приложении</li>
+              <li>✓ Голосовой ввод и озвучка ответов TTS</li>
+              <li>✓ Push-уведомления о новых сообщениях и обновлениях приложения</li>
+              <li>✓ Прикрепление фото, PDF, документов в контекст</li>
+              <li>✓ Общие чаты с командой (роли admin / user)</li>
+              <li>✓ Тёмная тема в тёплых тонах (warm brown)</li>
+              <li>✓ Open-source: <a href="https://github.com/ShaerWare/AI_Secretary_System/tree/main/mobile" target="_blank" rel="noopener">исходники на GitHub</a></li>
+            </ul>
+
+            <div class="mobile-app__cta">
+              <a href="https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk" class="btn btn--primary btn--lg" download>
+                📲 Скачать APK · v2.2
+              </a>
+              <p class="mobile-app__meta">
+                Android 8.0+ · обновляется автоматически через push · бесплатно
+              </p>
+            </div>
+
+            <p class="mobile-app__note">
+              💡 На iPhone полноценно работает мобильный браузер (PWA) — все функции
+              ассистента доступны без установки. Нативное iOS-приложение в планах.
+            </p>
+          </div>
+
+          <div class="mobile-app__mockup" aria-hidden="true">
+            <div class="phone-frame">
+              <div class="phone-frame__notch"></div>
+              <div class="phone-frame__screen">
+                <div class="phone-frame__head">
+                  <span class="phone-frame__dot"></span>
+                  <span>Секретарь24</span>
+                </div>
+                <div class="phone-frame__body">
+                  <div class="phone-frame__msg phone-frame__msg--in">Запиши встречу на завтра в 16:00</div>
+                  <div class="phone-frame__msg phone-frame__msg--out">Записал. Прислать напоминание за час?</div>
+                  <div class="phone-frame__msg phone-frame__msg--in">Да, и в WhatsApp тоже</div>
+                  <div class="phone-frame__msg phone-frame__msg--out">✓ Готово. Напоминание в Telegram и WhatsApp за час до встречи.</div>
+                </div>
+              </div>
+              <div class="phone-frame__home"></div>
+            </div>
           </div>
         </div>
       </div>
@@ -610,6 +670,7 @@
         <h4>Контакты</h4>
         <a href="https://t.me/ai_sekretar24bot" target="_blank" rel="noopener">Поддержка в Telegram</a>
         <a href="https://github.com/ShaerWare/AI_Secretary_System" target="_blank" rel="noopener">GitHub проекта</a>
+        <a href="https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk" download>📱 Android APK · v2.2</a>
         <a href="/admin/">Вход в кабинет</a>
       </nav>
       <nav class="footer__col">
@@ -624,6 +685,6 @@
     </div>
   </footer>
 
-  <script src="/main.js?v=3" defer></script>
+  <script src="/main.js?v=4" defer></script>
 </body>
 </html>

--- a/site/kk/index.html
+++ b/site/kk/index.html
@@ -44,7 +44,7 @@
   <meta name="twitter:description" content="Виртуалды AI-көмекші: Telegram, WhatsApp, сайт, телефон. 14 күн триал." />
   <meta name="twitter:image" content="https://ai-sekretar24.ru/kk/og-image.svg" />
 
-  <link rel="stylesheet" href="/styles.css?v=3" />
+  <link rel="stylesheet" href="/styles.css?v=4" />
 
   <script type="application/ld+json">
   {
@@ -134,6 +134,7 @@
       <nav class="nav" id="nav">
         <a href="#features">Мүмкіндіктер</a>
         <a href="#roles">Рөлдер</a>
+        <a href="#mobile">📱 Android</a>
         <a href="#pricing">Тарифтер</a>
         <a href="#faq">Жиі сұрақтар</a>
       </nav>
@@ -338,6 +339,65 @@
             <div class="msg msg--out">Тамаша — сізді ертең 16:00-ге жаздым. Бір сағат бұрын Telegram-ға ескертпе жіберемін. Атыңыз кім және байланыс үшін қандай нөмір?</div>
             <div class="msg msg--in">Алексей, +7 900 123-45-67</div>
             <div class="msg msg--out">Рахмет, Алексей! Жазылу расталды ✅ Деректерді менеджерге жібердім.</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ МОБИЛЬДІ ҚОСЫМША ============ -->
+    <section class="section mobile-app" id="mobile">
+      <div class="container">
+        <p class="eyebrow">📱 Android қосымшасы</p>
+        <h2 class="section__title">Хатшы24 — қалтаңызда</h2>
+        <p class="section__lead">
+          Нативті Android қосымшасы. Көмекшімен дауыспен сөйлесу, жаңа хабарлар туралы push-хабарламалар,
+          барлық чаттарға қол жеткізу — кез келген жерден.
+        </p>
+
+        <div class="mobile-app__inner">
+          <div class="mobile-app__text">
+            <ul class="mobile-app__features">
+              <li>✓ Барлық AI-чаттар бір қосымшада</li>
+              <li>✓ Дауысты енгізу және жауапты дыбыстау (TTS)</li>
+              <li>✓ Жаңа хабарлар мен қосымша жаңартулары туралы push-хабарламалар</li>
+              <li>✓ Фотолар, PDF, құжаттарды контекстке тіркеу</li>
+              <li>✓ Команда чаттары (admin / user рөлдері)</li>
+              <li>✓ Жылы қоңыр түсті қара тақырып</li>
+              <li>✓ Open-source: <a href="https://github.com/ShaerWare/AI_Secretary_System/tree/main/mobile" target="_blank" rel="noopener">бастапқы код GitHub-та</a></li>
+            </ul>
+
+            <div class="mobile-app__cta">
+              <a href="https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk" class="btn btn--primary btn--lg" download>
+                📲 APK жүктеу · v2.2
+              </a>
+              <p class="mobile-app__meta">
+                Android 8.0+ · push арқылы автожаңарту · тегін
+              </p>
+            </div>
+
+            <p class="mobile-app__note">
+              💡 iPhone иелері мобильді браузер арқылы (PWA) толық жұмыс істей алады — барлық
+              ассистент функциялары орнатусыз қолжетімді. Нативті iOS қосымшасы жоспарда.
+            </p>
+          </div>
+
+          <div class="mobile-app__mockup" aria-hidden="true">
+            <div class="phone-frame">
+              <div class="phone-frame__notch"></div>
+              <div class="phone-frame__screen">
+                <div class="phone-frame__head">
+                  <span class="phone-frame__dot"></span>
+                  <span>Хатшы24</span>
+                </div>
+                <div class="phone-frame__body">
+                  <div class="phone-frame__msg phone-frame__msg--in">Ертең 16:00-ге кездесу жазып қой</div>
+                  <div class="phone-frame__msg phone-frame__msg--out">Жаздым. Бір сағат бұрын ескертпе жіберейін бе?</div>
+                  <div class="phone-frame__msg phone-frame__msg--in">Иә, WhatsApp-қа да</div>
+                  <div class="phone-frame__msg phone-frame__msg--out">✓ Дайын. Кездесуден бір сағат бұрын Telegram мен WhatsApp-та ескертпе.</div>
+                </div>
+              </div>
+              <div class="phone-frame__home"></div>
+            </div>
           </div>
         </div>
       </div>
@@ -563,6 +623,7 @@
         <h4>Байланыс</h4>
         <a href="https://t.me/ai_sekretar24bot" target="_blank" rel="noopener">Telegram-да қолдау</a>
         <a href="https://github.com/ShaerWare/AI_Secretary_System" target="_blank" rel="noopener">Жобаның GitHub</a>
+        <a href="https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk" download>📱 Android APK · v2.2</a>
         <a href="/admin/">Жеке кабинетке кіру</a>
       </nav>
       <nav class="footer__col">
@@ -577,6 +638,6 @@
     </div>
   </footer>
 
-  <script src="/main.js?v=3" defer></script>
+  <script src="/main.js?v=4" defer></script>
 </body>
 </html>

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -47,9 +47,34 @@
 - **WhatsApp** (Cloud API) — множественные инстансы
 - **Чат-виджет на сайте** — кастомизация, мобильная адаптация, capture лидов
 - **Телефония** (GSM SIM7600E-H) — приём и совершение звонков, распознавание речи (Vosk/Whisper), синтез голоса (XTTS v2/OpenVoice/Piper), клонирование голоса
-- **Android-приложение** — нативный чат с ассистентом
+- **Android-приложение** — нативный чат с ассистентом, текущая версия [v2.2](https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk) (Android 8.0+, ~25 МБ, бесплатно, исходники в [mobile/](https://github.com/ShaerWare/AI_Secretary_System/tree/main/mobile))
 
 Один ассистент работает во всех каналах одновременно.
+
+## Мобильное приложение для Android
+
+Нативное Android-приложение позволяет общаться с ассистентом и управлять чатами из любой точки.
+
+**Скачать**: [ai-secretary-2.2.apk](https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk) (текущая стабильная версия)
+
+**Что умеет**:
+- Все ваши AI-чаты в одном приложении
+- Голосовой ввод и озвучка ответов (TTS)
+- Push-уведомления о новых сообщениях через Firebase Cloud Messaging
+- Автоматические уведомления об обновлениях приложения (через GitHub webhook)
+- Прикрепление фото, PDF, DOCX, XLSX, TXT и других документов в контекст чата
+- Общие чаты с командой (роли admin / user)
+- Тёмная тема в тёплых тонах (warm brown / amber / gold)
+- Open-source — исходники под MIT, [mobile/](https://github.com/ShaerWare/AI_Secretary_System/tree/main/mobile)
+
+**Технические детали**:
+- Стек: Vue 3 + TypeScript + Capacitor (Android)
+- Размер: ~25 МБ
+- Системные требования: Android 8.0+
+- Сборка APK через `gradlew assembleRelease` в `mobile/android/`
+- Релизы: [https://github.com/ShaerWare/AI_Secretary_System/releases](https://github.com/ShaerWare/AI_Secretary_System/releases) (теги `mobile-vX.Y`)
+
+**iOS**: нативного приложения нет. На iPhone работает мобильный браузер (PWA) с полным функционалом ассистента — установка не требуется, просто открыть https://ai-sekretar24.ru/admin/ или ваш собственный домен.
 
 ## Возможности
 

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -20,7 +20,7 @@
 - WhatsApp Cloud API
 - Чат-виджет для сайта
 - Телефония (SIM7600E-H, голос: распознавание + синтез + клонирование)
-- Android-приложение
+- [Android-приложение](https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk) (нативное, текущая версия v2.2, бесплатно)
 
 ## Возможности
 
@@ -42,8 +42,17 @@
 - [English](https://ai-sekretar24.ru/en/)
 - [Қазақша](https://ai-sekretar24.ru/kk/)
 
+## Мобильное приложение
+
+- [Скачать Android APK (v2.2)](https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk) — последняя стабильная сборка
+- [Все релизы на GitHub](https://github.com/ShaerWare/AI_Secretary_System/releases) — история версий
+- Системные требования: Android 8.0+
+- Open-source ([mobile/](https://github.com/ShaerWare/AI_Secretary_System/tree/main/mobile)), Vue 3 + Capacitor
+- iOS-приложения нет — на iPhone работает мобильный браузер (PWA) с полным функционалом
+
 ## Контакты
 
 - [Поддержка в Telegram](https://t.me/ai_sekretar24bot)
 - [GitHub проекта](https://github.com/ShaerWare/AI_Secretary_System)
+- [Скачать Android APK](https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk)
 - [Вход в кабинет](https://ai-sekretar24.ru/admin/)

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -3,7 +3,7 @@
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://ai-sekretar24.ru/</loc>
-    <lastmod>2026-05-27</lastmod>
+    <lastmod>2026-05-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <xhtml:link rel="alternate" hreflang="ru" href="https://ai-sekretar24.ru/" />
@@ -13,7 +13,7 @@
   </url>
   <url>
     <loc>https://ai-sekretar24.ru/en/</loc>
-    <lastmod>2026-05-27</lastmod>
+    <lastmod>2026-05-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <xhtml:link rel="alternate" hreflang="ru" href="https://ai-sekretar24.ru/" />
@@ -23,7 +23,7 @@
   </url>
   <url>
     <loc>https://ai-sekretar24.ru/kk/</loc>
-    <lastmod>2026-05-27</lastmod>
+    <lastmod>2026-05-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <xhtml:link rel="alternate" hreflang="ru" href="https://ai-sekretar24.ru/" />

--- a/site/styles.css
+++ b/site/styles.css
@@ -718,6 +718,133 @@ h1, h2, h3, h4 { line-height: 1.2; font-weight: 700; }
   text-align: center;
 }
 
+/* ---------- Мобильное приложение ---------- */
+.mobile-app { background: var(--bg-soft); }
+.mobile-app__inner {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 48px;
+  align-items: center;
+  margin-top: 48px;
+}
+.mobile-app__features {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 28px;
+}
+.mobile-app__features li {
+  padding: 10px 0;
+  border-top: 1px dashed var(--border);
+  color: var(--text);
+  font-size: 15px;
+}
+.mobile-app__features li:first-child { border-top: none; }
+.mobile-app__features a {
+  color: var(--accent-2);
+  border-bottom: 1px solid currentColor;
+}
+.mobile-app__cta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 18px;
+  align-items: flex-start;
+}
+.mobile-app__meta {
+  color: var(--dim);
+  font-size: 13px;
+}
+.mobile-app__note {
+  padding: 14px 18px;
+  background: rgba(245,158,11,0.06);
+  border: 1px solid rgba(245,158,11,0.18);
+  border-radius: 10px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+/* ---------- Телефон-мокап ---------- */
+.mobile-app__mockup {
+  display: flex;
+  justify-content: center;
+}
+.phone-frame {
+  width: 280px;
+  background: #0a0a0d;
+  border: 2px solid #2a2a2e;
+  border-radius: 36px;
+  padding: 12px 8px 10px;
+  box-shadow: 0 30px 60px rgba(0,0,0,0.45), 0 0 0 1px rgba(245,158,11,0.15);
+  position: relative;
+}
+.phone-frame__notch {
+  position: absolute;
+  top: 8px; left: 50%;
+  transform: translateX(-50%);
+  width: 100px; height: 18px;
+  background: #0a0a0d;
+  border-radius: 0 0 12px 12px;
+  z-index: 2;
+}
+.phone-frame__screen {
+  background: linear-gradient(180deg, #18181b, #14140f);
+  border-radius: 26px;
+  padding: 36px 14px 16px;
+  min-height: 460px;
+  display: flex;
+  flex-direction: column;
+}
+.phone-frame__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 4px 14px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+.phone-frame__dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: #22c55e;
+  box-shadow: 0 0 8px rgba(34,197,94,0.6);
+}
+.phone-frame__body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 14px;
+  flex-grow: 1;
+}
+.phone-frame__msg {
+  font-size: 12.5px;
+  line-height: 1.4;
+  padding: 8px 12px;
+  border-radius: 14px;
+  max-width: 82%;
+}
+.phone-frame__msg--in {
+  align-self: flex-end;
+  background: var(--grad);
+  color: #1a1205;
+  border-bottom-right-radius: 4px;
+}
+.phone-frame__msg--out {
+  align-self: flex-start;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-bottom-left-radius: 4px;
+}
+.phone-frame__home {
+  width: 100px;
+  height: 4px;
+  background: #3f3f46;
+  border-radius: 2px;
+  margin: 8px auto 0;
+}
+
 /* ---------- Адаптив ---------- */
 @media (max-width: 960px) {
   .grid-4 { grid-template-columns: repeat(2, 1fr); }
@@ -725,6 +852,10 @@ h1, h2, h3, h4 { line-height: 1.2; font-weight: 700; }
   .footer__inner { grid-template-columns: 1fr 1fr; }
   .grid-2 { grid-template-columns: 1fr; }
   .after-trial__paths { grid-template-columns: 1fr; }
+  .mobile-app__inner { grid-template-columns: 1fr; gap: 36px; }
+  .mobile-app__mockup { order: -1; }
+  .phone-frame { width: 240px; }
+  .phone-frame__screen { min-height: 380px; }
   .vs-row { grid-template-columns: 1fr 1fr; gap: 8px; }
   .vs-row > span:first-child { grid-column: 1 / -1; padding-bottom: 4px; }
   .vs-row--head > span:first-child { display: none; }


### PR DESCRIPTION
## Summary

- **Новый раздел «Мобильное приложение»** на лендинге (RU/EN/KZ), между демо-чатом и тарифами: 7-пунктовый чек-лист фич, большая CTA-кнопка «📲 Скачать APK · v2.2», стилизованный мокап телефона с примером диалога
- **Кнопки скачивания APK** добавлены в header nav и в footer «Контакты» во всех трёх локалях
- **AEO**: `llms.txt` получил отдельный раздел про мобильное приложение; `llms-full.txt` — расширенное описание (стек, размер, требования, теги релизов, PWA на iOS)
- **Стили**: новые классы `.mobile-app`, `.phone-frame` (рамка телефона с notch, градиентным экраном, home-bar и сообщениями) + мобильная адаптация
- **Cache-bust**: `styles.css?v=3` → `?v=4` во всех трёх локалях
- **sitemap.xml** lastmod обновлён

Mobile-каталог НЕ затронут — переиспользуется уже опубликованная APK v2.2 (`releases/latest/download/ai-secretary-2.2.apk`). Полный мобильный цикл не нужен.

## NEWS

📱 **На лендинге появилась кнопка скачивания Android-приложения**

Теперь прямо с главной ai-sekretar24.ru можно одним кликом скачать APK Секретарь24 v2.2 — кнопка есть в шапке, в новом разделе «Мобильное приложение» (с описанием фич и мокапом телефона) и в подвале. Раздел переведён на 3 языка: русский, английский, казахский. iOS-пользователям подсказали, что мобильный браузер (PWA) уже работает с полным функционалом, нативное iOS-приложение в планах.

## Test plan

- [ ] `ai-sekretar24.ru/` (RU): секция `#mobile` отрисована, кнопка ведёт на `releases/latest/download/ai-secretary-2.2.apk`, мокап телефона выглядит корректно
- [ ] `ai-sekretar24.ru/en/`: то же самое, тексты по-английски
- [ ] `ai-sekretar24.ru/kk/`: тексты на казахском, в мокапе телефона заголовок «Хатшы24»
- [ ] Mobile-адаптив ≤960px: мокап телефона поднимается над текстом и масштабируется (240px вместо 280px)
- [ ] Header nav: пункт «📱 Android» работает якорь #mobile
- [ ] Footer: ссылка «📱 Android APK · v2.2» скачивает файл
- [ ] `curl ai-sekretar24.ru/llms.txt` содержит секцию «Мобильное приложение» с APK-ссылкой
- [ ] Cache-bust: после деплоя у возвращающихся посетителей подгрузится `styles.css?v=4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)