### PR TITLE
feat(landing): repositioned tariffs — Старт/Бизнес/Команда for new audience

### DIFF
--- a/site/en/index.html
+++ b/site/en/index.html
@@ -74,9 +74,8 @@
     "offers": [
       { "@type": "Offer", "name": "Self-hosted (free)", "price": "0", "priceCurrency": "RUB", "description": "Open-source, MIT — download from GitHub" },
       { "@type": "Offer", "name": "Turnkey installation", "price": "5000", "priceCurrency": "RUB", "description": "We deploy and configure on your server" },
-      { "@type": "Offer", "name": "Start", "price": "2900", "priceCurrency": "RUB" },
-      { "@type": "Offer", "name": "Business", "price": "12900", "priceCurrency": "RUB" },
-      { "@type": "Offer", "name": "Team", "price": "29900", "priceCurrency": "RUB" }
+      { "@type": "Offer", "name": "Start", "price": "2900", "priceCurrency": "RUB", "description": "1 AI assistant with unlimited roles: lawyer, accountant. For freelancers and bloggers" },
+      { "@type": "Offer", "name": "Business", "price": "12900", "priceCurrency": "RUB", "description": "All cloud channels: Telegram, WhatsApp, web widgets, integrations with amoCRM/Google/WooCommerce" }
     ],
     "aggregateRating": { "@type": "AggregateRating", "ratingValue": "4.9", "reviewCount": "37" }
   }
@@ -105,9 +104,9 @@
       { "@type": "Question", "name": "Can I install Sekretar24 myself?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. The source is open on GitHub (https://github.com/ShaerWare/AI_Secretary_System) under MIT. Detailed wiki helps you deploy on any Linux server — all you need is Docker and root SSH access. If you'd rather not bother — we install turnkey for 5,000 ₽." } },
       { "@type": "Question", "name": "How much does the AI cost?", "acceptedAnswer": { "@type": "Answer", "text": "For most tasks OpenRouter's free models (DeepSeek, Llama, Qwen) are enough. Paid models (Claude, GPT-4) make sense only when you need maximum reasoning and expertise. On cloud plans the AI API is included. On self-hosted you plug in your own key or use the free OpenRouter models." } },
       { "@type": "Question", "name": "Is my data safe?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. You can run on cloud models or deploy the AI entirely on your own server — your customers' data never leaves your perimeter. The open-source code can be audited." } },
-      { "@type": "Question", "name": "Do I need my own server?", "acceptedAnswer": { "@type": "Answer", "text": "No. The Start, Business and Team plans all run in the cloud. A dedicated server is only needed for on-premise or self-hosted installation — any Linux server with Docker and root SSH access works." } },
+      { "@type": "Question", "name": "Do I need my own server?", "acceptedAnswer": { "@type": "Answer", "text": "Not for Start or Business — both run in our cloud. A dedicated server is only needed for the Team plan (on-premise with local AI) or for self-hosted installation from GitHub — any Linux server with Docker and root SSH access works." } },
       { "@type": "Question", "name": "Which channels does the assistant work on?", "acceptedAnswer": { "@type": "Answer", "text": "Telegram, WhatsApp, web chat widget, telephony and the Android app. One assistant — every channel at once." } },
-      { "@type": "Question", "name": "Can I connect telephony?", "acceptedAnswer": { "@type": "Answer", "text": "Yes, starting with the Business plan. The assistant takes and makes calls, recognizes speech and answers in voice." } },
+      { "@type": "Question", "name": "Can I connect telephony?", "acceptedAnswer": { "@type": "Answer", "text": "Yes, as part of the Team plan (on-premise). The assistant takes and makes calls via SIM7600 or SIP, recognizes speech and answers in voice — data stays on your server." } },
       { "@type": "Question", "name": "What's included in the 5,000 ₽ turnkey installation?", "acceptedAnswer": { "@type": "Answer", "text": "We deploy Sekretar24 on your server (Docker + root SSH required), configure the knowledge base (RAG), connect Telegram/WhatsApp/widget, and tune the assistant for your niche. Payment via YooMoney, Ozon Pay or Alfa-Bank card." } }
     ]
   }
@@ -405,8 +404,8 @@
     <section class="section pricing" id="pricing">
       <div class="container">
         <p class="eyebrow">Pricing</p>
-        <h2 class="section__title">Chat, WhatsApp and voice bot — in one subscription</h2>
-        <p class="section__lead">Competitors charge for chat and voice separately. We bundle them.</p>
+        <h2 class="section__title">One assistant, every channel — one subscription</h2>
+        <p class="section__lead">From freelancer to agency: cloud bots and widgets, local AI and on-premise — for any budget.</p>
 
         <div class="billing-toggle">
           <span class="billing-toggle__label is-active" id="lblMonthly">Monthly</span>
@@ -419,63 +418,55 @@
         <div class="grid grid-3 pricing__grid">
           <article class="plan">
             <h3 class="plan__name">Start</h3>
-            <p class="plan__for">For solo & micro businesses</p>
+            <p class="plan__for">For freelancers & bloggers</p>
             <div class="plan__price"><span class="plan__amount" data-monthly="2 900" data-yearly="2 320">2 900</span> <span class="plan__per">₽/mo</span></div>
             <p class="plan__note" data-monthly="billed monthly" data-yearly="billed yearly">billed monthly</p>
             <a href="#start" class="btn btn--outline btn--block">Try free</a>
             <ul class="plan__list">
-              <li>1 AI assistant</li>
+              <li>1 AI assistant with <strong>unlimited roles</strong></li>
+              <li>Ready-made: ⚖️ lawyer and 📊 accountant</li>
+              <li>Coming soon: SMM manager, tax advisor for freelancers, short-video scriptwriter, SEO/copywriter/ad specialist</li>
               <li>Channels: Telegram + web widget</li>
-              <li>1 500 AI replies per month</li>
-              <li>Knowledge base: 1 collection, 50 docs</li>
-              <li>Cloud AI — base models</li>
-              <li>1 user</li>
-              <li>Chat support (business hours)</li>
+              <li>Knowledge base (RAG) and conversation memory</li>
+              <li>Cloud AI: Claude + free OpenRouter models</li>
+              <li>1 user · chat support</li>
             </ul>
           </article>
 
           <article class="plan plan--featured">
             <div class="plan__badge">Best seller</div>
             <h3 class="plan__name">Business</h3>
-            <p class="plan__for">Full omnichannel + telephony</p>
+            <p class="plan__for">Full cloud: bots and widgets</p>
             <div class="plan__price"><span class="plan__amount" data-monthly="12 900" data-yearly="10 320">12 900</span> <span class="plan__per">₽/mo</span></div>
             <p class="plan__note" data-monthly="billed monthly" data-yearly="billed yearly">billed monthly</p>
             <a href="#start" class="btn btn--primary btn--block">Try free</a>
             <ul class="plan__list">
-              <li>Up to 3 AI assistants</li>
-              <li>All channels + <strong>voice & telephony</strong></li>
-              <li>10 000 AI replies + 300 voice minutes</li>
-              <li>Knowledge base: 5 collections + auto-update</li>
+              <li>Multiple AI assistants with any roles</li>
+              <li>Telegram bots, WhatsApp bots, web widgets</li>
+              <li><strong>Everything we have in the cloud</strong></li>
+              <li>Unlimited knowledge base: RAG + RSS auto-sync</li>
               <li>Integrations: amoCRM, Google, WooCommerce</li>
-              <li>Any AI model + fallback</li>
-              <li>Up to 5 users · priority support</li>
+              <li>Any AI model + fallback chain</li>
+              <li>Team of users · priority support</li>
             </ul>
           </article>
 
           <article class="plan">
             <h3 class="plan__name">Team</h3>
-            <p class="plan__for">For agencies & larger teams</p>
-            <div class="plan__price"><span class="plan__amount" data-monthly="29 900" data-yearly="23 920">29 900</span> <span class="plan__per">₽/mo</span></div>
-            <p class="plan__note" data-monthly="billed monthly" data-yearly="billed yearly">billed monthly</p>
-            <a href="#start" class="btn btn--outline btn--block">Try free</a>
+            <p class="plan__for">Local AI and on-premise</p>
+            <div class="plan__price"><span class="plan__amount">On request</span></div>
+            <p class="plan__note">Pricing = setup + ongoing support</p>
+            <a href="#start" class="btn btn--outline btn--block">Talk to sales</a>
             <ul class="plan__list">
-              <li>Up to 10 AI assistants</li>
-              <li>All channels, no instance limits</li>
-              <li>40 000 AI replies + 1 500 voice minutes</li>
-              <li>Unlimited knowledge base</li>
-              <li>Voice cloning + LoRA fine-tuning</li>
-              <li>White-label · up to 20 users</li>
-              <li>Dedicated manager + SLA</li>
+              <li>Local models on your hardware (Qwen, Llama, DeepSeek via vLLM)</li>
+              <li>Deployment on your server or by custom spec</li>
+              <li>Voice and telephony (SIM7600 or SIP) — no cloud</li>
+              <li>Voice cloning · LoRA fine-tuning for your industry</li>
+              <li>Closed perimeter: customer data never leaves your network</li>
+              <li>Integrations with 1C and your internal APIs</li>
+              <li>Onboarding, support and SLA tailored to your scenario</li>
             </ul>
           </article>
-        </div>
-
-        <div class="plan-enterprise">
-          <div>
-            <h3>Enterprise / On-premise</h3>
-            <p>Deploy on your server — data stays inside your perimeter. Local AI, custom roles and integrations (1C, your own APIs), industry-specific model training, 24/7 SLA and an onboarding team.</p>
-          </div>
-          <a href="#start" class="btn btn--outline btn--lg">Talk to sales</a>
         </div>
       </div>
     </section>
@@ -519,9 +510,9 @@
           <details class="faq-item"><summary>How much does the AI cost?</summary><p>For most business tasks OpenRouter's free models (DeepSeek, Llama, Qwen) are enough. Paying for top models (Claude, GPT-4) makes sense for complex reasoning and maximum expertise. On cloud plans the API is included; on self-hosted you plug in your own key or use the free models.</p></details>
           <details class="faq-item"><summary>What's included in the 5,000 ₽ turnkey installation?</summary><p>We deploy Sekretar24 on your server (Docker + root SSH required), configure the knowledge base (RAG), connect Telegram/WhatsApp/widget/telephony, and tune the assistant for your niche. Payment via YooMoney, Ozon Pay or Alfa-Bank.</p></details>
           <details class="faq-item"><summary>Is my data safe?</summary><p>Yes. Cloud models or your own server — your choice. Self-hosted means customer data stays inside your perimeter, and the open-source code can be audited.</p></details>
-          <details class="faq-item"><summary>Do I need my own server?</summary><p>Not for cloud plans — everything runs at our end. For self-hosted from GitHub you need any Linux server with Docker (from 2 GB RAM for cloud mode, from 12 GB + GPU for local AI).</p></details>
+          <details class="faq-item"><summary>Do I need my own server?</summary><p>Not on Start or Business — both run in our cloud. A dedicated server is only needed for the Team plan (on-premise with local AI) or for self-hosted install from GitHub: any Linux with Docker (from 2 GB RAM for cloud mode, from 12 GB + GPU for local AI).</p></details>
           <details class="faq-item"><summary>Which channels does the assistant work on?</summary><p>Telegram, WhatsApp, web chat widget, telephony and the Android app. One assistant — every channel at once.</p></details>
-          <details class="faq-item"><summary>Can I connect telephony?</summary><p>Yes, starting with the Business plan. The assistant takes and makes calls, recognizes speech and answers in voice.</p></details>
+          <details class="faq-item"><summary>Can I connect telephony?</summary><p>Yes, as part of the Team plan (on-premise). The assistant takes and makes calls via SIM7600 or SIP, recognizes speech and answers in voice — data never leaves your server.</p></details>
         </div>
       </div>
     </section>

--- a/site/index.html
+++ b/site/index.html
@@ -101,9 +101,8 @@
     "offers": [
       { "@type": "Offer", "name": "Self-hosted (бесплатно)", "price": "0", "priceCurrency": "RUB", "description": "Open-source, MIT — скачать с GitHub" },
       { "@type": "Offer", "name": "Установка под ключ", "price": "5000", "priceCurrency": "RUB", "description": "Развернём и настроим на вашем сервере" },
-      { "@type": "Offer", "name": "Старт", "price": "2900", "priceCurrency": "RUB" },
-      { "@type": "Offer", "name": "Бизнес", "price": "12900", "priceCurrency": "RUB" },
-      { "@type": "Offer", "name": "Команда", "price": "29900", "priceCurrency": "RUB" }
+      { "@type": "Offer", "name": "Старт", "price": "2900", "priceCurrency": "RUB", "description": "1 AI-ассистент с неограниченным числом ролей: юрист, бухгалтер. Для самозанятых и блогеров" },
+      { "@type": "Offer", "name": "Бизнес", "price": "12900", "priceCurrency": "RUB", "description": "Все облачные каналы: Telegram, WhatsApp, виджеты, интеграции с amoCRM/Google/WooCommerce" }
     ],
     "aggregateRating": { "@type": "AggregateRating", "ratingValue": "4.9", "reviewCount": "37" }
   }
@@ -131,9 +130,9 @@
       { "@type": "Question", "name": "Можно ли установить Секретарь24 самостоятельно?", "acceptedAnswer": { "@type": "Answer", "text": "Да, исходный код открыт на GitHub (https://github.com/ShaerWare/AI_Secretary_System) под лицензией MIT. Подробная документация поможет развернуть систему на своём сервере — нужны только Docker и root-доступ по SSH. Если не хотите возиться — мы установим под ключ за 5 000 ₽." } },
       { "@type": "Question", "name": "Сколько стоит ИИ?", "acceptedAnswer": { "@type": "Answer", "text": "Для большинства задач хватает бесплатных моделей через OpenRouter (DeepSeek, Llama, Qwen). Платные модели (Claude от Anthropic, GPT-4) нужны только когда требуются максимальная экспертиза и сложные рассуждения. На наших облачных тарифах API ИИ уже включён. На самохостинге подключаете свой API-ключ или используете бесплатные модели OpenRouter." } },
       { "@type": "Question", "name": "Безопасны ли мои данные?", "acceptedAnswer": { "@type": "Answer", "text": "Да. Вы можете работать на облачных моделях или развернуть ИИ полностью на своём сервере — тогда данные клиентов не покидают ваш периметр. Open-source код можно проверить на GitHub." } },
-      { "@type": "Question", "name": "Нужен ли свой сервер?", "acceptedAnswer": { "@type": "Answer", "text": "Нет. На тарифах Старт, Бизнес и Команда всё работает в нашем облаке. Свой сервер нужен только для on-premise развёртывания или самостоятельной установки с GitHub — там достаточно любого Linux-сервера с Docker и root SSH." } },
+      { "@type": "Question", "name": "Нужен ли свой сервер?", "acceptedAnswer": { "@type": "Answer", "text": "Если вы на тарифе Старт или Бизнес — нет, всё работает в нашем облаке. Свой сервер нужен только для тарифа Команда (on-premise с локальным ИИ) или самостоятельной установки с GitHub — там достаточно любого Linux-сервера с Docker и root SSH." } },
       { "@type": "Question", "name": "С какими каналами работает ассистент?", "acceptedAnswer": { "@type": "Answer", "text": "Telegram, WhatsApp, чат-виджет на сайте, телефония и Android-приложение. Один ассистент — все каналы одновременно." } },
-      { "@type": "Question", "name": "Можно ли подключить телефонию?", "acceptedAnswer": { "@type": "Answer", "text": "Да, начиная с тарифа Бизнес. Ассистент принимает и совершает звонки, распознаёт речь и отвечает голосом." } },
+      { "@type": "Question", "name": "Можно ли подключить телефонию?", "acceptedAnswer": { "@type": "Answer", "text": "Да, в составе тарифа Команда (on-premise). Ассистент принимает и совершает звонки через SIM7600 или SIP, распознаёт речь и отвечает голосом." } },
       { "@type": "Question", "name": "Что входит в установку под ключ за 5 000 ₽?", "acceptedAnswer": { "@type": "Answer", "text": "Развернём Секретарь24 на вашем сервере (нужен только Docker и root SSH), настроим базу знаний (RAG), подключим Telegram/WhatsApp/виджет, обучим ассистента под вашу нишу. Оплата картой через YooMoney, Ozon Pay или Альфа-Банк." } }
     ]
   }
@@ -440,8 +439,8 @@
     <section class="section pricing" id="pricing">
       <div class="container">
         <p class="eyebrow">Тарифы</p>
-        <h2 class="section__title">Чат, WhatsApp и голосовой робот — в одной подписке</h2>
-        <p class="section__lead">У конкурентов чат и звонки — это две разные подписки. У нас всё включено.</p>
+        <h2 class="section__title">Один ассистент, все каналы — одна подписка</h2>
+        <p class="section__lead">От самозанятого до агентства: облачные боты и виджеты, локальный ИИ и on-premise — на любой бюджет.</p>
 
         <div class="billing-toggle">
           <span class="billing-toggle__label is-active" id="lblMonthly">Помесячно</span>
@@ -455,18 +454,18 @@
           <!-- Старт -->
           <article class="plan">
             <h3 class="plan__name">Старт</h3>
-            <p class="plan__for">Для соло и микробизнеса</p>
+            <p class="plan__for">Самозанятым и блогерам</p>
             <div class="plan__price"><span class="plan__amount" data-monthly="2 900" data-yearly="2 320">2 900</span> <span class="plan__per">₽/мес</span></div>
             <p class="plan__note" data-monthly="при помесячной оплате" data-yearly="при оплате за год">при помесячной оплате</p>
             <a href="#start" class="btn btn--outline btn--block">Попробовать бесплатно</a>
             <ul class="plan__list">
-              <li>1 AI-ассистент</li>
+              <li>1 AI-ассистент с <strong>неограниченным числом ролей</strong></li>
+              <li>Готовые роли: ⚖️ юрист и 📊 бухгалтер</li>
+              <li>Скоро: SMM-менеджер, налоговый консультант (НПД), сценарист коротких видео, SEO/копирайтер/рекламист</li>
               <li>Каналы: Telegram + виджет на сайт</li>
-              <li>1 500 AI-ответов в месяц</li>
-              <li>База знаний: 1 коллекция, 50 документов</li>
-              <li>Облачный ИИ — базовые модели</li>
-              <li>1 пользователь</li>
-              <li>Поддержка в чате (рабочие часы)</li>
+              <li>База знаний (RAG) и память диалогов</li>
+              <li>Облачный ИИ: Claude + бесплатные модели OpenRouter</li>
+              <li>1 пользователь · поддержка в чате</li>
             </ul>
           </article>
 
@@ -474,46 +473,38 @@
           <article class="plan plan--featured">
             <div class="plan__badge">Хит продаж</div>
             <h3 class="plan__name">Бизнес</h3>
-            <p class="plan__for">Полный омниканал + телефония</p>
+            <p class="plan__for">Всё облако: боты и виджеты</p>
             <div class="plan__price"><span class="plan__amount" data-monthly="12 900" data-yearly="10 320">12 900</span> <span class="plan__per">₽/мес</span></div>
             <p class="plan__note" data-monthly="при помесячной оплате" data-yearly="при оплате за год">при помесячной оплате</p>
             <a href="#start" class="btn btn--primary btn--block">Попробовать бесплатно</a>
             <ul class="plan__list">
-              <li>До 3 AI-ассистентов</li>
-              <li>Все каналы + <strong>голос и телефония</strong></li>
-              <li>10 000 AI-ответов + 300 минут голоса</li>
-              <li>База знаний: 5 коллекций + авто-обновление</li>
+              <li>Несколько AI-ассистентов с любыми ролями</li>
+              <li>Telegram-боты, WhatsApp-боты, виджеты на сайт</li>
+              <li><strong>Всё, что у нас есть в облаке</strong></li>
+              <li>База знаний без лимита: RAG + авто-синк с RSS</li>
               <li>Интеграции: amoCRM, Google, WooCommerce</li>
-              <li>Любая модель ИИ + резервная</li>
-              <li>До 5 пользователей · приоритетная поддержка</li>
+              <li>Любая модель ИИ + резервная цепочка fallback</li>
+              <li>Команда пользователей · приоритетная поддержка</li>
             </ul>
           </article>
 
           <!-- Команда -->
           <article class="plan">
             <h3 class="plan__name">Команда</h3>
-            <p class="plan__for">Для агентств и больших команд</p>
-            <div class="plan__price"><span class="plan__amount" data-monthly="29 900" data-yearly="23 920">29 900</span> <span class="plan__per">₽/мес</span></div>
-            <p class="plan__note" data-monthly="при помесячной оплате" data-yearly="при оплате за год">при помесячной оплате</p>
-            <a href="#start" class="btn btn--outline btn--block">Попробовать бесплатно</a>
+            <p class="plan__for">Локальный ИИ и on-premise</p>
+            <div class="plan__price"><span class="plan__amount">По запросу</span></div>
+            <p class="plan__note">Цена = настройка + сопровождение</p>
+            <a href="#start" class="btn btn--outline btn--block">Обсудить внедрение</a>
             <ul class="plan__list">
-              <li>До 10 AI-ассистентов</li>
-              <li>Все каналы без лимита инстансов</li>
-              <li>40 000 AI-ответов + 1 500 минут голоса</li>
-              <li>База знаний без лимита</li>
-              <li>Клонирование голоса + дообучение LoRA</li>
-              <li>White-label · до 20 пользователей</li>
-              <li>Выделенный менеджер + SLA</li>
+              <li>Локальные модели на вашем железе (Qwen, Llama, DeepSeek через vLLM)</li>
+              <li>Развёртывание на сервере заказчика или по спецзаказу</li>
+              <li>Голос и телефония (SIM7600 или SIP) — без облака</li>
+              <li>Клонирование голоса · LoRA-дообучение под отрасль</li>
+              <li>Закрытый контур: данные клиентов не покидают периметр</li>
+              <li>Интеграции с 1С и внутренними API</li>
+              <li>Внедрение, поддержка и SLA под ваш сценарий</li>
             </ul>
           </article>
-        </div>
-
-        <div class="plan-enterprise">
-          <div>
-            <h3>Enterprise / On-premise</h3>
-            <p>Развёртывание на вашем сервере — данные не покидают периметр. Локальный ИИ, кастомные роли и интеграции (1С, собственные API), обучение моделей под отрасль, SLA 24/7 и команда внедрения.</p>
-          </div>
-          <a href="#start" class="btn btn--outline btn--lg">Обсудить внедрение</a>
         </div>
       </div>
     </section>
@@ -558,9 +549,9 @@
           <details class="faq-item"><summary>Сколько стоит ИИ?</summary><p>Для большинства бизнес-задач хватает бесплатных моделей OpenRouter (DeepSeek, Llama, Qwen). Платить за топ-модели (Claude, GPT-4) имеет смысл там, где нужны сложные рассуждения и максимальная экспертиза. На облачных тарифах API уже включён, на самохостинге — подключаете свой ключ или бесплатные модели.</p></details>
           <details class="faq-item"><summary>Что входит в установку под ключ за 5 000 ₽?</summary><p>Развернём Секретарь24 на вашем сервере (нужны Docker и root SSH), настроим базу знаний (RAG), подключим Telegram/WhatsApp/виджет/телефонию, обучим ассистента под вашу нишу. Оплата картой — YooMoney, Ozon Pay или Альфа-Банк.</p></details>
           <details class="faq-item"><summary>Безопасны ли мои данные?</summary><p>Да. Облачные модели или собственный сервер — выбор за вами. На самохостинге данные клиентов не покидают периметр, а open-source код можно проверить.</p></details>
-          <details class="faq-item"><summary>Нужен ли свой сервер?</summary><p>На облачных тарифах — нет, всё работает у нас. Для самостоятельной установки с GitHub нужен любой Linux-сервер с Docker (от 2 ГБ ОЗУ для cloud-режима, от 12 ГБ + GPU для локального ИИ).</p></details>
+          <details class="faq-item"><summary>Нужен ли свой сервер?</summary><p>На тарифах Старт и Бизнес — нет, всё работает у нас в облаке. Свой сервер нужен только на тарифе Команда (on-premise с локальным ИИ) или при самостоятельной установке с GitHub: любой Linux с Docker (от 2 ГБ ОЗУ для cloud-режима, от 12 ГБ + GPU для локального ИИ).</p></details>
           <details class="faq-item"><summary>С какими каналами работает ассистент?</summary><p>Telegram, WhatsApp, чат-виджет на сайте, телефония и Android-приложение. Один ассистент — все каналы одновременно.</p></details>
-          <details class="faq-item"><summary>Можно ли подключить телефонию?</summary><p>Да, начиная с тарифа Бизнес. Ассистент принимает и совершает звонки, распознаёт речь и отвечает голосом.</p></details>
+          <details class="faq-item"><summary>Можно ли подключить телефонию?</summary><p>Да, в составе тарифа Команда (on-premise). Ассистент принимает и совершает звонки через SIM7600 или SIP, распознаёт речь и отвечает голосом — данные не уходят в облако.</p></details>
         </div>
       </div>
     </section>

--- a/site/kk/index.html
+++ b/site/kk/index.html
@@ -75,9 +75,8 @@
     "offers": [
       { "@type": "Offer", "name": "Self-hosted (тегін)", "price": "0", "priceCurrency": "RUB", "description": "Open-source, MIT — GitHub-тан жүктеу" },
       { "@type": "Offer", "name": "Кілт астында орнату", "price": "5000", "priceCurrency": "RUB", "description": "Сіздің серверде орналастырып, баптап береміз" },
-      { "@type": "Offer", "name": "Старт", "price": "2900", "priceCurrency": "RUB" },
-      { "@type": "Offer", "name": "Бизнес", "price": "12900", "priceCurrency": "RUB" },
-      { "@type": "Offer", "name": "Команда", "price": "29900", "priceCurrency": "RUB" }
+      { "@type": "Offer", "name": "Старт", "price": "2900", "priceCurrency": "RUB", "description": "1 AI-көмекші шексіз рөлдермен: заңгер, бухгалтер. Жалғыз кәсіпкерлер мен блогерлерге" },
+      { "@type": "Offer", "name": "Бизнес", "price": "12900", "priceCurrency": "RUB", "description": "Барлық бұлттық арналар: Telegram, WhatsApp, виджеттер, amoCRM/Google/WooCommerce интеграциялары" }
     ],
     "aggregateRating": { "@type": "AggregateRating", "ratingValue": "4.9", "reviewCount": "37" }
   }
@@ -106,9 +105,9 @@
       { "@type": "Question", "name": "Хатшы24-ті өзі орнатуға бола ма?", "acceptedAnswer": { "@type": "Answer", "text": "Иә. Бастапқы код GitHub-та (https://github.com/ShaerWare/AI_Secretary_System) MIT лицензиясымен ашық. Толық құжаттама бар. Қажет нәрсе — Docker және root SSH қолжетімділігі бар кез келген Linux сервер. Әуре болғыңыз келмесе — 5 000 ₽-ге кілт астында орнатамыз." } },
       { "@type": "Question", "name": "AI қанша тұрады?", "acceptedAnswer": { "@type": "Answer", "text": "Көп тапсырмаларға OpenRouter-дің тегін модельдері (DeepSeek, Llama, Qwen) жеткілікті. Топ-модельдер (Claude, GPT-4) күрделі рассуждение мен жоғары деңгейлі сараптама керек болғанда ғана төленеді. Бұлттық тарифтерде AI API кіреді, self-hosted режимде өз кілтіңізді қосасыз немесе тегін модельдерді қолданасыз." } },
       { "@type": "Question", "name": "Менің деректерім қауіпсіз бе?", "acceptedAnswer": { "@type": "Answer", "text": "Иә. Бұлттық модельдер немесе өз сервер — таңдау сізде. Self-hosted режимде клиент деректері сіздің периметрден шықпайды, open-source кодты тексеруге болады." } },
-      { "@type": "Question", "name": "Өз серверіңіз керек пе?", "acceptedAnswer": { "@type": "Answer", "text": "Бұлттық тарифтерде керек емес — бәрі бізде жұмыс істейді. GitHub-тан өзі орнату үшін Docker және root SSH бар кез келген Linux сервер жеткілікті (cloud-режим үшін 2 ГБ жедел жады, жергілікті AI үшін 12 ГБ + GPU)." } },
+      { "@type": "Question", "name": "Өз серверіңіз керек пе?", "acceptedAnswer": { "@type": "Answer", "text": "Старт пен Бизнес тарифтерінде керек емес — бәрі біздің бұлтта жұмыс істейді. Өз сервер тек Команда тарифінде (жергілікті AI-мен on-premise) немесе GitHub-тан өзі орнату үшін қажет: Docker бар кез келген Linux сервер жеткілікті (cloud-режим үшін 2 ГБ жедел жады, жергілікті AI үшін 12 ГБ + GPU)." } },
       { "@type": "Question", "name": "Көмекші қандай арналарда жұмыс істейді?", "acceptedAnswer": { "@type": "Answer", "text": "Telegram, WhatsApp, сайт чат-виджеті, телефония және Android-қосымша. Бір көмекші — барлық арналар бір уақытта." } },
-      { "@type": "Question", "name": "Телефонияны қосуға бола ма?", "acceptedAnswer": { "@type": "Answer", "text": "Иә, Бизнес тарифінен бастап. Көмекші қоңырауларды қабылдайды және шығарады, сөзді таниды және дауыспен жауап береді." } },
+      { "@type": "Question", "name": "Телефонияны қосуға бола ма?", "acceptedAnswer": { "@type": "Answer", "text": "Иә, Команда тарифінің құрамында (on-premise). Көмекші SIM7600 немесе SIP арқылы қоңырауларды қабылдайды әрі шығарады, сөзді таниды және дауыспен жауап береді — деректер серверден шықпайды." } },
       { "@type": "Question", "name": "5 000 ₽-ге кілт астында орнатуға не кіреді?", "acceptedAnswer": { "@type": "Answer", "text": "Хатшы24-ті сіздің серверде орналастырамыз (Docker және root SSH қажет), білім қорын (RAG) баптаймыз, Telegram/WhatsApp/виджет/телефонияны қосамыз, ассистентті сіздің салаға бейімдейміз. Төлем картамен — YooMoney, Ozon Pay немесе Альфа-Банк арқылы." } }
     ]
   }
@@ -406,8 +405,8 @@
     <section class="section pricing" id="pricing">
       <div class="container">
         <p class="eyebrow">Тарифтер</p>
-        <h2 class="section__title">Чат, WhatsApp және дауыстық бот — бір жазылымда</h2>
-        <p class="section__lead">Бәсекелестерде чат пен қоңыраулар — екі бөлек жазылым. Бізде бәрі бір тарифте.</p>
+        <h2 class="section__title">Бір көмекші, барлық арналар — бір жазылым</h2>
+        <p class="section__lead">Жалғыз кәсіпкерден агенттікке дейін: бұлттық боттар мен виджеттер, жергілікті AI және on-premise — кез келген бюджетке.</p>
 
         <div class="billing-toggle">
           <span class="billing-toggle__label is-active" id="lblMonthly">Айлық</span>
@@ -420,63 +419,55 @@
         <div class="grid grid-3 pricing__grid">
           <article class="plan">
             <h3 class="plan__name">Старт</h3>
-            <p class="plan__for">Жалғыз кәсіпкер мен микробизнеске</p>
+            <p class="plan__for">Жалғыз кәсіпкерлер мен блогерлерге</p>
             <div class="plan__price"><span class="plan__amount" data-monthly="2 900" data-yearly="2 320">2 900</span> <span class="plan__per">₽/ай</span></div>
             <p class="plan__note" data-monthly="айлық төлеммен" data-yearly="жылдық төлеммен">айлық төлеммен</p>
             <a href="#start" class="btn btn--outline btn--block">Тегін көру</a>
             <ul class="plan__list">
-              <li>1 AI-көмекшi</li>
+              <li>1 AI-көмекші <strong>шексіз рөлдермен</strong></li>
+              <li>Дайын рөлдер: ⚖️ заңгер және 📊 бухгалтер</li>
+              <li>Жақында: SMM-менеджер, жалғыз кәсіпкерге арналған салық кеңесшісі, қысқа видео сценаристі, SEO/копирайтер/жарнама маманы</li>
               <li>Арналар: Telegram + сайт виджеті</li>
-              <li>Айына 1 500 AI-жауап</li>
-              <li>Білім қоры: 1 коллекция, 50 құжат</li>
-              <li>Бұлттық AI — базалық модельдер</li>
-              <li>1 пайдаланушы</li>
-              <li>Чатта қолдау (жұмыс уақытында)</li>
+              <li>Білім қоры (RAG) және диалог жады</li>
+              <li>Бұлттық AI: Claude + OpenRouter тегін модельдері</li>
+              <li>1 пайдаланушы · чатта қолдау</li>
             </ul>
           </article>
 
           <article class="plan plan--featured">
             <div class="plan__badge">Хит</div>
             <h3 class="plan__name">Бизнес</h3>
-            <p class="plan__for">Толық омниарна + телефония</p>
+            <p class="plan__for">Бүкіл бұлт: боттар мен виджеттер</p>
             <div class="plan__price"><span class="plan__amount" data-monthly="12 900" data-yearly="10 320">12 900</span> <span class="plan__per">₽/ай</span></div>
             <p class="plan__note" data-monthly="айлық төлеммен" data-yearly="жылдық төлеммен">айлық төлеммен</p>
             <a href="#start" class="btn btn--primary btn--block">Тегін көру</a>
             <ul class="plan__list">
-              <li>3-ке дейін AI-көмекшi</li>
-              <li>Барлық арналар + <strong>дауыс және телефония</strong></li>
-              <li>10 000 AI-жауап + 300 минут дауыс</li>
-              <li>Білім қоры: 5 коллекция + автожаңарту</li>
+              <li>Кез келген рөлдермен бірнеше AI-көмекші</li>
+              <li>Telegram-боттар, WhatsApp-боттар, сайт виджеттері</li>
+              <li><strong>Бізде бұлтта бар нәрсенің барлығы</strong></li>
+              <li>Шектеусіз білім қоры: RAG + RSS авто-синк</li>
               <li>Интеграциялар: amoCRM, Google, WooCommerce</li>
-              <li>Кез келген AI-модель + резерв</li>
-              <li>5-ке дейін пайдаланушы · басымдылықпен қолдау</li>
+              <li>Кез келген AI-модель + резервтік тізбек</li>
+              <li>Пайдаланушылар тобы · басымдылықпен қолдау</li>
             </ul>
           </article>
 
           <article class="plan">
             <h3 class="plan__name">Команда</h3>
-            <p class="plan__for">Агенттіктер мен үлкен командаларға</p>
-            <div class="plan__price"><span class="plan__amount" data-monthly="29 900" data-yearly="23 920">29 900</span> <span class="plan__per">₽/ай</span></div>
-            <p class="plan__note" data-monthly="айлық төлеммен" data-yearly="жылдық төлеммен">айлық төлеммен</p>
-            <a href="#start" class="btn btn--outline btn--block">Тегін көру</a>
+            <p class="plan__for">Жергілікті AI және on-premise</p>
+            <div class="plan__price"><span class="plan__amount">Сұраныс бойынша</span></div>
+            <p class="plan__note">Бағасы = баптау + сүйемелдеу</p>
+            <a href="#start" class="btn btn--outline btn--block">Енгізуді талқылау</a>
             <ul class="plan__list">
-              <li>10-ға дейін AI-көмекшi</li>
-              <li>Инстанс лимитісіз барлық арналар</li>
-              <li>40 000 AI-жауап + 1 500 минут дауыс</li>
-              <li>Шектеусіз білім қоры</li>
-              <li>Дауыс клондау + LoRA-баптау</li>
-              <li>White-label · 20-ға дейін пайдаланушы</li>
-              <li>Бөлінген менеджер + SLA</li>
+              <li>Өз жабдығыңыздағы жергілікті модельдер (Qwen, Llama, DeepSeek — vLLM арқылы)</li>
+              <li>Тапсырыс берушінің серверінде немесе арнайы тапсырыспен орналастыру</li>
+              <li>Дауыс және телефония (SIM7600 немесе SIP) — бұлтсыз</li>
+              <li>Дауыс клондау · сала бойынша LoRA-баптау</li>
+              <li>Жабық периметр: клиент деректері периметрден шықпайды</li>
+              <li>1С және ішкі API-мен интеграциялар</li>
+              <li>Сценарийіңізге бейімделген енгізу, қолдау және SLA</li>
             </ul>
           </article>
-        </div>
-
-        <div class="plan-enterprise">
-          <div>
-            <h3>Enterprise / On-premise</h3>
-            <p>Серверіңізде орналастыру — деректер периметрден шықпайды. Жергілікті AI, кастомды рөлдер мен интеграциялар (1С, өз API), сала бойынша модельдерді оқыту, 24/7 SLA және енгізу командасы.</p>
-          </div>
-          <a href="#start" class="btn btn--outline btn--lg">Енгізуді талқылау</a>
         </div>
       </div>
     </section>
@@ -520,9 +511,9 @@
           <details class="faq-item"><summary>AI қанша тұрады?</summary><p>Көп бизнес-тапсырмаға OpenRouter-дің тегін модельдері (DeepSeek, Llama, Qwen) жеткілікті. Топ-модельдер (Claude, GPT-4) күрделі рассуждение керек болғанда ғана төленеді. Бұлттық тарифтерде API кіреді, self-hosted режимде өз кілтіңізді қосасыз.</p></details>
           <details class="faq-item"><summary>5 000 ₽-ге кілт астында орнатуға не кіреді?</summary><p>Сіздің серверде орналастырамыз (Docker және root SSH қажет), білім қорын (RAG) баптаймыз, Telegram/WhatsApp/виджет/телефонияны қосамыз, ассистентті сіздің салаға бейімдейміз. Төлем — YooMoney, Ozon Pay немесе Альфа-Банк картасымен.</p></details>
           <details class="faq-item"><summary>Менің деректерім қауіпсіз бе?</summary><p>Иә. Бұлттық модельдер немесе өз сервер — таңдау сізде. Self-hosted режимде клиент деректері периметрден шықпайды, open-source кодты тексеруге болады.</p></details>
-          <details class="faq-item"><summary>Өз серверім керек пе?</summary><p>Бұлттық тарифтерде керек емес — бәрі бізде істейді. GitHub-тан өзі орнату үшін Docker бар кез келген Linux сервер жеткілікті (cloud режим — 2 ГБ жедел жадыдан, жергілікті AI — 12 ГБ + GPU).</p></details>
+          <details class="faq-item"><summary>Өз серверім керек пе?</summary><p>Старт пен Бизнес тарифтерінде керек емес — бәрі бұлтта істейді. Өз сервер тек Команда тарифінде (жергілікті AI-мен on-premise) немесе GitHub-тан өзі орнату үшін қажет: Docker бар кез келген Linux сервер жеткілікті (cloud режим — 2 ГБ жедел жадыдан, жергілікті AI — 12 ГБ + GPU).</p></details>
           <details class="faq-item"><summary>Көмекшi қандай арналарда жұмыс істейді?</summary><p>Telegram, WhatsApp, сайт чат-виджеті, телефония және Android-қосымша. Бір көмекші — барлық арналар бір уақытта.</p></details>
-          <details class="faq-item"><summary>Телефонияны қосуға бола ма?</summary><p>Иә, Бизнес тарифінен бастап. Көмекші қоңырауларды қабылдайды және шығарады, сөзді таниды және дауыспен жауап береді.</p></details>
+          <details class="faq-item"><summary>Телефонияны қосуға бола ма?</summary><p>Иә, Команда тарифінің құрамында (on-premise). Көмекші SIM7600 немесе SIP арқылы қоңырауларды қабылдайды әрі шығарады, сөзді таниды және дауыспен жауап береді — деректер серверден шықпайды.</p></details>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

Перепозиционировали тарифную сетку лендинга под целевую аудиторию (самозанятые, блогеры, малый бизнес, on-premise-клиенты).

- **Старт (2 900 ₽/мес)** — самозанятым и блогерам: 1 AI-ассистент с *неограниченным числом ролей*, готовые ⚖️ юрист и 📊 бухгалтер, скоро SMM-менеджер / налоговый консультант (НПД) / сценарист коротких видео / SEO-копирайтер.
- **Бизнес (12 900 ₽/мес)** — всё облако: Telegram-боты, WhatsApp-боты, виджеты на сайт, интеграции (amoCRM, Google, WooCommerce). Голос/телефония убраны.
- **Команда (По запросу)** — локальный ИИ на железе заказчика или по спецзаказу; голос и телефония (SIM7600 / SIP), клонирование голоса, LoRA. Цена = настройка + сопровождение.
- Удалён дублирующий блок «Enterprise / On-premise» (теперь покрывается тарифом «Команда»).
- Обновлены FAQ-вопросы про телефонию и про «нужен ли свой сервер» — в видимом блоке и в JSON-LD `FAQPage`.
- В JSON-LD `SoftwareApplication.offers` убрана позиция «Команда» (price «по запросу») и расширены `description` у Старт/Бизнес.
- Изменения синхронны во всех трёх локалях: `site/index.html` (RU), `site/en/index.html`, `site/kk/index.html`.

## NEWS

🎯 **Новая тарифная сетка — теперь и для самозанятых с блогерами**

На лендинге обновили тарифы под живых пользователей. Тариф «Старт» за 2 900 ₽/мес — это 1 ИИ-ассистент с неограниченным числом ролей: готовые юрист и бухгалтер, скоро подъедут SMM-менеджер, налоговый консультант для НПД и сценарист коротких видео. «Бизнес» — все каналы в облаке (TG-боты, WhatsApp-боты, виджеты), «Команда» — локальные модели на вашем сервере с телефонией и LoRA.

## Test plan

- [ ] Открыть https://ai-sekretar24.ru/ — раздел «Тарифы» показывает новые карточки Старт / Бизнес / Команда
- [ ] У Команда в `.plan__amount` написано «По запросу», переключатель «помесячно/за год» не ломает её
- [ ] Билинг-тоггл переключает 2 900 ↔ 2 320 для Старт и 12 900 ↔ 10 320 для Бизнес
- [ ] Кнопка Команды ведёт на `#start` и говорит «Обсудить внедрение»
- [ ] Открыть `/en/` и `/kk/` — обе локали синхронны с RU
- [ ] FAQ «Можно ли подключить телефонию?» отвечает «в составе тарифа Команда (on-premise)»
- [ ] Google Rich Results Test на главной странице — `FAQPage` + `SoftwareApplication` валидные
- [ ] Mobile view: карточки тарифов не ломают сетку

🤖 Generated with [Claude Code](https://claude.com/claude-code)