### PR TITLE
feat(landing): lead form → owner Telegram + developer credit

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -84,6 +84,14 @@ HF_TOKEN=
 VECTOR_SEARCH_TOKEN=
 
 # -----------------------------------------------------------------------------
+# Landing lead form → Telegram (POST /widget/lead)
+# -----------------------------------------------------------------------------
+# Заявки с лендинга site/ уходят владельцу в Telegram.
+# chat_id: напиши боту, открой https://api.telegram.org/bot<token>/getUpdates
+LEAD_TELEGRAM_BOT_TOKEN=
+LEAD_TELEGRAM_CHAT_ID=
+
+# -----------------------------------------------------------------------------
 # Advanced (usually no need to change)
 # -----------------------------------------------------------------------------
 

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,12 @@ ORCHESTRATOR_PORT=8000
 VOICE_SAMPLES_DIR=./Марина
 VOICE_MODEL_PATH=./models/voice_marina
 
+# Landing lead form → Telegram notification (POST /widget/lead)
+# Заявки с лендинга (site/) уходят владельцу в Telegram. Узнать chat_id:
+# напиши боту, открой https://api.telegram.org/bot<token>/getUpdates
+LEAD_TELEGRAM_BOT_TOKEN=
+LEAD_TELEGRAM_CHAT_ID=
+
 # FCM push notifications for mobile app (optional)
 FCM_PROJECT_ID=ai-sekretar24-872f2
 FCM_SERVICE_ACCOUNT_FILE=/opt/ai-secretary/firebase-service-account.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,7 +374,11 @@ GOOGLE_REDIRECT_URI=                # OAuth callback URL (default: {BASE_URL}/ad
 PLATFORM_AGENT_PROMPT_FILE=         # Override path to platform-agent fallback prompt (default: /opt/ai-secretary/prompts/platform-agent.md)
 BRIDGE_ISOLATE_HOME=                # "1" to spawn Claude CLI with isolated HOME so host's CLAUDE.md/memory files don't leak into user chats
 BRIDGE_ISOLATED_HOME=               # Override isolated HOME path (default: /var/lib/ai-secretary-bridge)
+LEAD_TELEGRAM_BOT_TOKEN=            # Bot token for landing lead notifications (POST /widget/lead → owner's Telegram)
+LEAD_TELEGRAM_CHAT_ID=             # Numeric chat_id that receives landing lead notifications
 ```
+
+**Landing lead form** (`site/` → Telegram): the static landing's lead form (`#leadForm`, handled in `site/main.js`) POSTs JSON to `POST /widget/lead` (in `modules/channels/widget/router_public.py`). Mounted under the already nginx-proxied `/widget/` prefix so no new nginx location is needed. The endpoint reads `LEAD_TELEGRAM_BOT_TOKEN` + `LEAD_TELEGRAM_CHAT_ID` from env (no secrets in the static site) and sends an HTML message to the owner's Telegram via `api.telegram.org/bot<token>/sendMessage`. Anti-spam: a hidden `company` honeypot field (CSS `.lead-form__hp`). If the backend is unreachable, the frontend falls back to opening `t.me/ai_sekretar24bot` with a pre-filled message. Locale + page URL are included in the notification.
 
 ## Deployment
 

--- a/modules/channels/widget/router_public.py
+++ b/modules/channels/widget/router_public.py
@@ -5,12 +5,15 @@ and contact form submissions. CRM integration (amoCRM lead/contact
 creation) is handled reactively via EventBus — see modules/crm/startup.py.
 """
 
+import html
 import json
 import logging
+import os
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
+import httpx
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
 
@@ -401,4 +404,90 @@ async def widget_submit_contacts(request: Request, session_id: str):
             exc_info=True,
         )
 
+    return {"ok": True}
+
+
+# ============== Landing lead form → Telegram ==============
+
+# Mounted under the already nginx-proxied /widget/ prefix so the static landing
+# site can POST here without a dedicated nginx location block.
+_LEAD_LOCALE_NAMES = {"ru": "🇷🇺 RU", "en": "🇬🇧 EN", "kk": "🇰🇿 KK"}
+
+
+@router.post("/widget/lead")
+async def submit_landing_lead(request: Request):
+    """Public: landing-page lead form → notify owner via Telegram.
+
+    Reads bot token + target chat id from env (LEAD_TELEGRAM_BOT_TOKEN,
+    LEAD_TELEGRAM_CHAT_ID) so no secrets live in the static site. Anti-spam:
+    a hidden honeypot field ("company") — bots fill it, humans don't.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON")
+
+    # Honeypot: silently accept (so the bot thinks it succeeded) but drop it.
+    if (body.get("company") or "").strip():
+        logger.info("Landing lead dropped (honeypot triggered)")
+        return {"ok": True}
+
+    name = (body.get("name") or "").strip()[:200]
+    contact = (body.get("contact") or "").strip()[:200]
+    role = (body.get("role") or "").strip()[:200]
+    locale = (body.get("locale") or "").strip().lower()[:8]
+    page = (body.get("page") or "").strip()[:300]
+
+    if not name or not contact:
+        raise HTTPException(status_code=400, detail="Name and contact are required")
+
+    token = os.getenv("LEAD_TELEGRAM_BOT_TOKEN", "").strip()
+    chat_id = os.getenv("LEAD_TELEGRAM_CHAT_ID", "").strip()
+    if not token or not chat_id:
+        logger.error("Landing lead delivery not configured (LEAD_TELEGRAM_* missing)")
+        raise HTTPException(status_code=503, detail="Lead delivery is not configured")
+
+    visitor_ip = (
+        request.headers.get("x-forwarded-for", "").split(",")[0].strip()
+        or request.headers.get("x-real-ip")
+        or (request.client.host if request.client else "")
+    )
+
+    lines = [
+        "🔔 <b>Новая заявка с лендинга</b>",
+        "",
+        f"👤 <b>Имя:</b> {html.escape(name)}",
+        f"📞 <b>Контакт:</b> {html.escape(contact)}",
+    ]
+    if role:
+        lines.append(f"🎯 <b>Какой ассистент:</b> {html.escape(role)}")
+    lines.append(f"🌐 <b>Язык:</b> {_LEAD_LOCALE_NAMES.get(locale, locale or '—')}")
+    if page:
+        lines.append(f"🔗 <b>Страница:</b> {html.escape(page)}")
+    if visitor_ip:
+        lines.append(f"🖥 <b>IP:</b> {html.escape(visitor_ip)}")
+    lines.append(f"🕒 {datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}")
+    text = "\n".join(lines)
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                f"https://api.telegram.org/bot{token}/sendMessage",
+                json={
+                    "chat_id": chat_id,
+                    "text": text,
+                    "parse_mode": "HTML",
+                    "disable_web_page_preview": True,
+                },
+            )
+        if resp.status_code != 200:
+            logger.error("Telegram lead notify failed: %s %s", resp.status_code, resp.text[:300])
+            raise HTTPException(status_code=502, detail="Failed to deliver lead")
+    except HTTPException:
+        raise
+    except Exception:
+        logger.error("Telegram lead notify error", exc_info=True)
+        raise HTTPException(status_code=502, detail="Failed to deliver lead")
+
+    logger.info("Landing lead delivered to Telegram (locale=%s, role=%s)", locale, role or "-")
     return {"ok": True}

--- a/site/en/index.html
+++ b/site/en/index.html
@@ -44,7 +44,7 @@
   <meta name="twitter:description" content="Virtual AI assistant: Telegram, WhatsApp, web, phone. 14-day trial." />
   <meta name="twitter:image" content="https://ai-sekretar24.ru/en/og-image.svg" />
 
-  <link rel="stylesheet" href="/styles.css?v=4" />
+  <link rel="stylesheet" href="/styles.css?v=5" />
 
   <script type="application/ld+json">
   {
@@ -566,6 +566,8 @@
           <h3>Or leave a request — we'll help you decide</h3>
           <p class="section__lead">We'll reach out, answer your questions and activate your 14-day trial.</p>
           <form class="lead-form" id="leadForm" novalidate>
+            <!-- honeypot: hidden from humans, filled by bots → lead is dropped -->
+            <input type="text" name="company" class="lead-form__hp" tabindex="-1" autocomplete="off" aria-hidden="true" />
             <div class="lead-form__row">
               <input type="text" name="name" placeholder="Your name" required autocomplete="name" />
               <input type="text" name="contact" placeholder="Phone or @Telegram" required autocomplete="tel" />
@@ -615,6 +617,7 @@
         <a href="https://github.com/ShaerWare/AI_Secretary_System" target="_blank" rel="noopener">Project on GitHub</a>
         <a href="https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk" download>📱 Android APK · v2.2</a>
         <a href="/admin/">Sign in</a>
+        <a href="https://shaerware.github.io/en/" target="_blank" rel="noopener">Built by ShaerWare</a>
       </nav>
       <nav class="footer__col">
         <h4>Legal</h4>
@@ -624,10 +627,10 @@
     </div>
     <div class="container footer__bottom">
       <span>© 2026 Sekretar24. All rights reserved.</span>
-      <span>Powered by AI Secretary System</span>
+      <span>Built by <a href="https://shaerware.github.io/en/" target="_blank" rel="noopener">ShaerWare</a></span>
     </div>
   </footer>
 
-  <script src="/main.js?v=4" defer></script>
+  <script src="/main.js?v=5" defer></script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -70,7 +70,7 @@
   <meta name="twitter:description" content="Виртуальный AI-ассистент: Telegram, WhatsApp, сайт, телефония. Триал 14 дней." />
   <meta name="twitter:image" content="https://ai-sekretar24.ru/og-image.svg" />
 
-  <link rel="stylesheet" href="/styles.css?v=4" />
+  <link rel="stylesheet" href="/styles.css?v=5" />
 
   <!-- SEO: структурированные данные -->
   <script type="application/ld+json">
@@ -613,6 +613,8 @@
           <p class="section__lead">Свяжемся, ответим на вопросы и активируем бесплатный триал на 14 дней.</p>
           <!-- TODO (Фаза 2): заменить на POST /admin/auth/register для саморегистрации. -->
           <form class="lead-form" id="leadForm" novalidate>
+            <!-- honeypot: скрыто от людей, заполняется ботами → заявка отбрасывается -->
+            <input type="text" name="company" class="lead-form__hp" tabindex="-1" autocomplete="off" aria-hidden="true" />
             <div class="lead-form__row">
               <input type="text" name="name" placeholder="Ваше имя" required autocomplete="name" />
               <input type="text" name="contact" placeholder="Телефон или @Telegram" required autocomplete="tel" />
@@ -663,6 +665,7 @@
         <a href="https://github.com/ShaerWare/AI_Secretary_System" target="_blank" rel="noopener">GitHub проекта</a>
         <a href="https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk" download>📱 Android APK · v2.2</a>
         <a href="/admin/">Вход в кабинет</a>
+        <a href="https://shaerware.github.io/ru/" target="_blank" rel="noopener">Разработка — ShaerWare</a>
       </nav>
       <nav class="footer__col">
         <h4>Правовое</h4>
@@ -672,10 +675,10 @@
     </div>
     <div class="container footer__bottom">
       <span>© 2026 Секретарь24. Все права защищены.</span>
-      <span>Сделано на платформе AI Secretary System</span>
+      <span>Разработка — <a href="https://shaerware.github.io/ru/" target="_blank" rel="noopener">ShaerWare</a></span>
     </div>
   </footer>
 
-  <script src="/main.js?v=4" defer></script>
+  <script src="/main.js?v=5" defer></script>
 </body>
 </html>

--- a/site/kk/index.html
+++ b/site/kk/index.html
@@ -44,7 +44,7 @@
   <meta name="twitter:description" content="Виртуалды AI-көмекші: Telegram, WhatsApp, сайт, телефон. 14 күн триал." />
   <meta name="twitter:image" content="https://ai-sekretar24.ru/kk/og-image.svg" />
 
-  <link rel="stylesheet" href="/styles.css?v=4" />
+  <link rel="stylesheet" href="/styles.css?v=5" />
 
   <script type="application/ld+json">
   {
@@ -567,6 +567,8 @@
           <h3>Немесе өтінім қалдырыңыз — шешуге көмектесеміз</h3>
           <p class="section__lead">Хабарласамыз, сұрақтарға жауап береміз және 14 күндік тегін триалды іске қосамыз.</p>
           <form class="lead-form" id="leadForm" novalidate>
+            <!-- honeypot: адамдардан жасырылған, боттар толтырады → өтінім жойылады -->
+            <input type="text" name="company" class="lead-form__hp" tabindex="-1" autocomplete="off" aria-hidden="true" />
             <div class="lead-form__row">
               <input type="text" name="name" placeholder="Атыңыз" required autocomplete="name" />
               <input type="text" name="contact" placeholder="Телефон немесе @Telegram" required autocomplete="tel" />
@@ -616,6 +618,7 @@
         <a href="https://github.com/ShaerWare/AI_Secretary_System" target="_blank" rel="noopener">Жобаның GitHub</a>
         <a href="https://github.com/ShaerWare/AI_Secretary_System/releases/latest/download/ai-secretary-2.2.apk" download>📱 Android APK · v2.2</a>
         <a href="/admin/">Жеке кабинетке кіру</a>
+        <a href="https://shaerware.github.io/ru/" target="_blank" rel="noopener">Әзірлеу — ShaerWare</a>
       </nav>
       <nav class="footer__col">
         <h4>Құқықтық</h4>
@@ -625,10 +628,10 @@
     </div>
     <div class="container footer__bottom">
       <span>© 2026 Хатшы24. Барлық құқықтар қорғалған.</span>
-      <span>AI Secretary System платформасында жасалды</span>
+      <span>Әзірлеу — <a href="https://shaerware.github.io/ru/" target="_blank" rel="noopener">ShaerWare</a></span>
     </div>
   </footer>
 
-  <script src="/main.js?v=4" defer></script>
+  <script src="/main.js?v=5" defer></script>
 </body>
 </html>

--- a/site/main.js
+++ b/site/main.js
@@ -68,28 +68,64 @@
     applyBilling(billingSwitch.getAttribute('aria-checked') !== 'true');
   });
 
-  /* --- Лид-форма --- */
+  /* --- Лид-форма: уходит на backend (/widget/lead) → уведомление в Telegram владельца --- */
   var form = document.getElementById('leadForm');
   var success = document.getElementById('leadSuccess');
 
-  form.addEventListener('submit', function (e) {
-    e.preventDefault();
-    var name = form.name.value.trim();
-    var contact = form.contact.value.trim();
-    if (!name || !contact) {
-      if (!name) form.name.focus();
-      else form.contact.focus();
-      return;
-    }
+  if (form) {
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var name = form.name.value.trim();
+      var contact = form.contact.value.trim();
+      if (!name || !contact) {
+        if (!name) form.name.focus();
+        else form.contact.focus();
+        return;
+      }
 
-    /* TODO (Фаза 2): отправить заявку на backend.
-       Пример: fetch('/admin/leads', { method: 'POST',
-         headers: { 'Content-Type': 'application/json' },
-         body: JSON.stringify({ name: name, contact: contact, role: form.role.value }) })
-       Лид уйдёт в amoCRM через существующее событие WidgetContactSubmitted. */
+      var honeypot = form.company ? form.company.value.trim() : '';
+      var roleEl = form.role;
+      var btn = form.querySelector('button[type="submit"]');
 
-    form.hidden = true;
-    success.hidden = false;
-    success.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  });
+      var payload = {
+        name: name,
+        contact: contact,
+        role: roleEl ? roleEl.value : '',
+        company: honeypot, /* honeypot — должно остаться пустым у людей */
+        locale: (document.documentElement.lang || '').toLowerCase(),
+        page: location.href
+      };
+
+      if (btn) { btn.disabled = true; btn.dataset.label = btn.textContent; btn.textContent = 'Отправляем…'; }
+
+      function showSuccess() {
+        form.hidden = true;
+        success.hidden = false;
+        success.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+      function restoreBtn() {
+        if (btn) { btn.disabled = false; if (btn.dataset.label) btn.textContent = btn.dataset.label; }
+      }
+
+      fetch('/widget/lead', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+        .then(function (r) {
+          if (r.ok) { showSuccess(); return; }
+          throw new Error('bad status ' + r.status);
+        })
+        .catch(function () {
+          /* Фолбэк: не теряем заявку — открываем Telegram владельца с заполненным текстом */
+          restoreBtn();
+          var msg =
+            'Заявка с сайта%0AИмя: ' + encodeURIComponent(name) +
+            '%0AКонтакт: ' + encodeURIComponent(contact) +
+            (payload.role ? '%0AАссистент: ' + encodeURIComponent(payload.role) : '');
+          window.open('https://t.me/ai_sekretar24bot?text=' + msg, '_blank', 'noopener');
+          showSuccess();
+        });
+    });
+  }
 })();

--- a/site/styles.css
+++ b/site/styles.css
@@ -462,6 +462,8 @@ h1, h2, h3, h4 { line-height: 1.2; font-weight: 700; }
   pointer-events: none;
 }
 .lead-form { margin-top: 28px; display: flex; flex-direction: column; gap: 12px; text-align: left; }
+/* honeypot — невидимо для людей, но доступно ботам-автозаполнителям */
+.lead-form__hp { position: absolute !important; left: -9999px !important; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
 .lead-form__row { display: flex; gap: 12px; }
 .lead-form input, .lead-form select {
   width: 100%;


### PR DESCRIPTION
## Summary

- **New public endpoint `POST /widget/lead`** (`modules/channels/widget/router_public.py`) — sends landing lead notifications to the owner's Telegram via Bot API. Token + chat_id come from env (`LEAD_TELEGRAM_BOT_TOKEN` / `LEAD_TELEGRAM_CHAT_ID`), so no secrets live in the static site. Mounted under the already nginx-proxied `/widget/` prefix → **no new nginx location needed**.
- **`site/main.js`** — lead form now POSTs to `/widget/lead` (name, contact, role, locale, page), shows a "sending" state and success screen. **Fallback:** if the backend is unreachable it opens `t.me/ai_sekretar24bot` with a pre-filled message so no lead is lost.
- **Anti-spam** — hidden `company` honeypot field added to all 3 locale forms + `.lead-form__hp` CSS.
- **Footer developer credit** — links to `shaerware.github.io` in the Contacts column and footer bottom line (ru/en → locale path, kk → `/ru/`), all 3 locales.
- Cache-bust `main.js?v=5`, `styles.css?v=5`.
- Docs: `LEAD_TELEGRAM_*` documented in `.env.example`, `.env.docker.example`, `CLAUDE.md`.

## NEWS

📩 **Заявки с сайта теперь сразу прилетают в Telegram**

Каждая заявка с лендинга — на подключение секретаря или с вопросом — мгновенно приходит уведомлением в Telegram с именем, контактом и тем, какой ассистент нужен клиенту. Больше ни одна заявка не потеряется: даже если что-то пойдёт не так, форма откроет чат с ботом с уже заполненным текстом. А в контактах появился значок разработчика.

## Test plan

- [ ] `LEAD_TELEGRAM_BOT_TOKEN` + `LEAD_TELEGRAM_CHAT_ID` set in prod `.env`
- [ ] Submit lead form on ru/en/kk → notification arrives in owner's Telegram with correct locale + page
- [ ] Honeypot field hidden for humans; bot-filled `company` → silently dropped
- [ ] Backend-down fallback opens `t.me/ai_sekretar24bot` with pre-filled text
- [ ] Footer shows developer credit linking to shaerware.github.io in all 3 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)