### PR TITLE
fix(bridge): raise Claude bridge client read/write timeouts

### DIFF
--- a/cloud_llm_service.py
+++ b/cloud_llm_service.py
@@ -230,9 +230,11 @@ class OpenAICompatibleProvider(BaseLLMProvider):
         # Claude bridge needs longer timeouts: CLI warmup (7-30s) + complex
         # prompt processing can exceed 60s before first token arrives.
         # Bridge itself allows 600s per-chunk; match that on client side.
+        # write bumped to 30s so large prompts (big context files, agentic RAG)
+        # finish uploading before the client gives up.
         if self.provider_type == "claude_bridge":
             self.client = httpx.Client(
-                timeout=httpx.Timeout(connect=10.0, read=300.0, write=10.0, pool=10.0)
+                timeout=httpx.Timeout(connect=10.0, read=600.0, write=30.0, pool=10.0)
             )
             # Bridge/Claude can handle much longer responses than default 512
             self.runtime_params.setdefault("max_tokens", 4096)


### PR DESCRIPTION
## Summary
- Клиентские httpx-таймауты для Claude bridge были жёстче, чем лимиты самого бриджа, из-за чего длинные генерации и загрузка больших промптов могли обрываться на стороне клиента.
- `read` 300s → 600s (бридж допускает 600s на чанк — теперь совпадает).
- `write` 10s → 30s (большие context-файлы / промпты agentic RAG дольше заливаются).

## Контекст
Изменение уже работало как незакоммиченный хотфикс на проде. `deploy.sh` делает `git reset --hard origin/main`, поэтому без коммита в репо хотфикс терялся бы при следующем полном деплое. Этот PR закрепляет его в git.

## Test plan
- [x] Прод уже работает с этими значениями (health 200, длинные ответы бриджа не обрываются)
- [ ] После merge — прод остаётся на `read=600/write=30`, git-дерево чистое по `cloud_llm_service.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)