### PR TITLE
fix(chat): harden file upload — deploy deps, non-blocking parse, auth'd image URLs

### DIFF
--- a/admin/src/api/chat.ts
+++ b/admin/src/api/chat.ts
@@ -136,6 +136,27 @@ export interface GroupedSessions {
 }
 
 // Chat API
+// <img>/<a download> requests can't carry an Authorization header, so the backend
+// also accepts the JWT as a ?token= query param on served files. Append it to
+// same-origin chat image URLs as they enter the app (token is valid for hours, so
+// it stays live for the render that immediately follows).
+function tokenizeImageUrl(url?: string | null): string | null | undefined {
+  if (!url || !url.startsWith('/admin/chat/images/')) return url
+  const token = localStorage.getItem('admin_token')
+  if (!token) return url
+  return `${url}${url.includes('?') ? '&' : '?'}token=${encodeURIComponent(token)}`
+}
+
+function tokenizeSessionImages(session: ChatSession): ChatSession {
+  for (const m of session.messages || []) {
+    for (const img of m.metadata?.images || []) {
+      img.url = tokenizeImageUrl(img.url) as string
+      img.thumb_url = tokenizeImageUrl(img.thumb_url)
+    }
+  }
+  return session
+}
+
 export const chatApi = {
   // Sessions
   listSessions: (source?: string, excludeSource?: string) => {
@@ -150,7 +171,9 @@ export const chatApi = {
     api.get<{ sessions: GroupedSessions; grouped: true }>('/admin/chat/sessions?group_by=source'),
 
   getSession: (sessionId: string) =>
-    api.get<{ session: ChatSession }>(`/admin/chat/sessions/${sessionId}`),
+    api
+      .get<{ session: ChatSession }>(`/admin/chat/sessions/${sessionId}`)
+      .then((r) => ({ session: tokenizeSessionImages(r.session) })),
 
   createSession: (title?: string, systemPrompt?: string, source?: string, sourceId?: string) =>
     api.post<{ session: ChatSession }>('/admin/chat/sessions', {
@@ -204,15 +227,19 @@ export const chatApi = {
     api.get<{ branches: BranchNode[] }>(`/admin/chat/sessions/${sessionId}/branches`),
 
   switchBranch: (sessionId: string, messageId: string) =>
-    api.post<{ status: string; session: ChatSession }>(
-      `/admin/chat/sessions/${sessionId}/branches/switch`,
-      { message_id: messageId }
-    ),
+    api
+      .post<{ status: string; session: ChatSession }>(
+        `/admin/chat/sessions/${sessionId}/branches/switch`,
+        { message_id: messageId }
+      )
+      .then((r) => ({ ...r, session: tokenizeSessionImages(r.session) })),
 
   newBranchFromScratch: (sessionId: string) =>
-    api.post<{ status: string; session: ChatSession }>(
-      `/admin/chat/sessions/${sessionId}/branches/new`
-    ),
+    api
+      .post<{ status: string; session: ChatSession }>(
+        `/admin/chat/sessions/${sessionId}/branches/new`
+      )
+      .then((r) => ({ ...r, session: tokenizeSessionImages(r.session) })),
 
   renameBranch: (sessionId: string, messageId: string, branchName: string) =>
     api.put<{ status: string; branch_name: string | null }>(
@@ -360,7 +387,13 @@ export const chatApi = {
 
   // Image upload
   uploadImage: (sessionId: string, file: File) =>
-    api.upload<{ image: ChatImage }>(`/admin/chat/sessions/${sessionId}/upload-image`, file),
+    api
+      .upload<{ image: ChatImage }>(`/admin/chat/sessions/${sessionId}/upload-image`, file)
+      .then((r) => {
+        r.image.url = tokenizeImageUrl(r.image.url) as string
+        r.image.thumb_url = tokenizeImageUrl(r.image.thumb_url)
+        return r
+      }),
 
   // Session prompts (named "roles")
   listPrompts: (sessionId: string) =>

--- a/auth_manager.py
+++ b/auth_manager.py
@@ -413,6 +413,26 @@ async def get_optional_user(
     return await _validate_session(token_payload)
 
 
+async def resolve_user_from_token(token: str) -> Optional[User]:
+    """Resolve a User from a raw JWT string, with permissions loaded.
+
+    For endpoints that must authenticate requests which can't carry an
+    Authorization header — e.g. ``<img src>`` / ``<a download>`` served files,
+    where the JWT arrives as a ``?token=`` query param. Validation (signature,
+    session revocation) is identical to the header path.
+    """
+    if not token:
+        return None
+    token_payload = decode_token(token)
+    if token_payload is None:
+        return None
+    user = await _validate_session(token_payload)
+    if user is None:
+        return None
+    user.permissions = await get_user_permissions(user)
+    return user
+
+
 def require_permission(module: str, min_level: str):
     """FastAPI Depends factory: checks user has >= min_level for module."""
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -41,7 +41,12 @@ log "Re-applying cloud-mode patches..."
 # These patches make TTS/STT/XTTS imports optional for servers without GPU/torch
 python3 "$REPO_DIR/apply_patches.py" 2>&1 | tee -a "$LOG_FILE"
 
-# Install/update Python deps (bridge)
+# Install/update Python deps (main app + bridge)
+# The main requirements.txt MUST be installed too — otherwise new deps added in a
+# PR (e.g. pdfplumber/openpyxl/python-docx for chat file extraction) silently miss
+# the prod venv and features fail at runtime with no error.
+log "Installing Python dependencies (main)..."
+"$REPO_DIR/venv/bin/pip" install -q -r "$REPO_DIR/requirements.txt" 2>&1 | tee -a "$LOG_FILE"
 log "Installing bridge dependencies..."
 "$REPO_DIR/venv/bin/pip" install -q -r "$REPO_DIR/services/bridge/requirements.txt" 2>&1 | tee -a "$LOG_FILE"
 

--- a/modules/chat/image_service.py
+++ b/modules/chat/image_service.py
@@ -1,5 +1,6 @@
 """Chat file service: upload images/documents, OCR/text extraction, storage, cleanup."""
 
+import asyncio
 import hashlib
 import io
 import logging
@@ -223,23 +224,18 @@ def extract_document_text(file_data: bytes, content_type: str, original_name: st
 # --- Upload ---
 
 
-async def upload_file(
+def _process_upload(
     session_id: str,
     file_data: bytes,
     content_type: str,
     original_name: str,
 ) -> dict:
-    """Save file, generate thumbnail (for images), extract text. Returns metadata dict."""
-    if len(file_data) > MAX_FILE_SIZE:
-        raise ValueError(f"File too large: {len(file_data)} > {MAX_FILE_SIZE}")
+    """Blocking upload work: write file, build thumbnail, OCR/extract text.
 
-    if content_type not in ALLOWED_MIME_TYPES:
-        # Try to detect by extension
-        ext = Path(original_name).suffix.lower()
-        text_exts = {".txt", ".csv", ".md", ".json", ".xml", ".html", ".log", ".yaml", ".yml"}
-        if ext not in text_exts:
-            raise ValueError(f"Unsupported type: {content_type}")
-
+    Runs in a worker thread (see ``upload_file``) — PIL, pdfplumber and disk I/O
+    are all synchronous and CPU-bound, so calling them on the event loop would
+    freeze every other request while a large PDF is parsed.
+    """
     file_id = _generate_file_id()
     ext = _get_extension(content_type, original_name)
     session_dir = _session_dir(session_id)
@@ -291,6 +287,30 @@ async def upload_file(
         "mime_type": content_type,
         "is_image": is_img,
     }
+
+
+async def upload_file(
+    session_id: str,
+    file_data: bytes,
+    content_type: str,
+    original_name: str,
+) -> dict:
+    """Save file, generate thumbnail (for images), extract text. Returns metadata dict."""
+    if len(file_data) > MAX_FILE_SIZE:
+        raise ValueError(f"File too large: {len(file_data)} > {MAX_FILE_SIZE}")
+
+    if content_type not in ALLOWED_MIME_TYPES:
+        # Try to detect by extension
+        ext = Path(original_name).suffix.lower()
+        text_exts = {".txt", ".csv", ".md", ".json", ".xml", ".html", ".log", ".yaml", ".yml"}
+        if ext not in text_exts:
+            raise ValueError(f"Unsupported type: {content_type}")
+
+    # Offload blocking I/O + CPU-bound parsing to a thread so a large/complex
+    # document (e.g. a 40MB PDF) can't freeze the orchestrator's event loop.
+    return await asyncio.to_thread(
+        _process_upload, session_id, file_data, content_type, original_name
+    )
 
 
 # Keep backward compatibility alias

--- a/modules/chat/router.py
+++ b/modules/chat/router.py
@@ -13,7 +13,16 @@ from pydantic import BaseModel
 from app.dependencies import get_container
 from app.rate_limiter import RATE_LIMIT_CHAT, limiter
 from app.utils.tokens import count_message_tokens, get_context_window
-from auth_manager import User, require_permission, user_has_level, workspace_context
+from auth_manager import (
+    User,
+    get_optional_user,
+    get_user_permissions,
+    level_gte,
+    require_permission,
+    resolve_user_from_token,
+    user_has_level,
+    workspace_context,
+)
 from cloud_llm_service import CloudLLMService
 from modules.channels.mobile.service import mobile_app_instance_service
 from modules.channels.telegram.service import bot_instance_service
@@ -1305,10 +1314,26 @@ async def admin_upload_chat_file(
 async def serve_chat_image(
     session_id: str,
     filename: str,
-    user: User = Depends(require_permission("chat", "view")),
+    token: Optional[str] = None,
+    user: Optional[User] = Depends(get_optional_user),
 ):
-    """Serve an uploaded chat image (auth-gated)."""
+    """Serve an uploaded chat file (image or document), auth-gated.
+
+    Accepts auth via the Authorization header OR a ``?token=`` query param —
+    ``<img src>`` / ``<a download>`` requests can't send an Authorization header,
+    so the frontend appends the JWT as a query param for these URLs.
+    """
     from modules.chat.image_service import get_image_path
+
+    # Header path (get_optional_user) doesn't load permissions; the token path does.
+    if user is not None:
+        user.permissions = await get_user_permissions(user)
+    elif token:
+        user = await resolve_user_from_token(token)
+    if user is None:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    if not level_gte(user.permissions.get("chat", ""), "view"):
+        raise HTTPException(status_code=403, detail="Permission denied: requires chat:view")
 
     path = get_image_path(session_id, filename)
     if not path:


### PR DESCRIPTION
## Context
On prod, uploading a 40MB PDF in the assistant chat first showed an *"empty file"*, then (after the missing libs were installed at runtime) a **"Save" spinner that never resolved**. Root-caused to three separate defects.

## Fixes

### 1. `deploy.sh` never installed the main `requirements.txt`
It only ran `pip install -r services/bridge/requirements.txt`. So `pdfplumber`, `openpyxl`, `python-docx` (present in `requirements.txt`) were **never installed in the prod venv** → `PDFPLUMBER_AVAILABLE=False` → `_extract_text_from_pdf` returned `None` → upload returned `200 OK` with empty `ocr_text` ("empty file"). Now installs the main requirements too.

### 2. Document parsing blocked the event loop
`upload_file()` is `async` but called the **synchronous** `extract_document_text()` (pdfplumber) and PIL image processing inline. A large/complex PDF froze the single event loop, so the upload *and every other concurrent request* (incl. the "Save" button's `PUT`) hung together. Now the blocking write/parse/thumbnail work runs in a worker thread via `asyncio.to_thread`.

### 3. Image thumbnails returned 401
`serve_chat_image` required the `Authorization` header, but `<img src>` / `<a download>` requests can't send it — every `_thumb.jpg` request 401'd. The endpoint now also accepts the JWT as a `?token=` query param (identical validation to the header path via the new `resolve_user_from_token`), and the frontend appends it to chat image URLs as they enter the app.

## Scope / notes
- Touches only backend + infra + the clean `admin/src/api/chat.ts`; the in-flight mobile private-sessions WIP is deliberately untouched.
- Mobile app renders the same image URLs — a follow-up should apply the same `?token=` append in `mobile/src/api/chat.ts` (left out here to avoid colliding with active WIP).
- `deploy.sh` on the server is a self-restoring local copy; it's being updated in place alongside this merge so the pipeline actually picks up the change.

## Verification
- `ruff check` + `ruff format --check`: clean
- `vue-tsc --noEmit`: clean
- On prod: `pdfplumber` extraction of the offending 40MB PDF yields 58k chars in ~4s; libs already installed at runtime as an immediate mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)