### PR TITLE
feat(procurement): unified product-offer search foundation + site adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ Always run lint locally before pushing. Protected branches require PR workflow �
 Foundation layer for the modular decomposition. All 28 routers live under `modules/*/router*.py`; inline endpoints and global service variables are gone from `orchestrator.py`; background tasks run through `TaskRegistry`; service initialization lives in per-domain `startup.py` modules; Protocol interfaces (`modules/*/protocols.py`) and facades (`modules/{core,knowledge,llm,chat}/{auth_service,facade}.py`) front the underlying services. History of the migration lives in `CHANGELOG.md` and issue #489.
 
 - **`EventBus`** (`modules/core/events.py`): In-process async pub/sub. Handlers run concurrently via `asyncio.gather`; exceptions are logged, never propagated to publisher. `BaseEvent` dataclass with auto-timestamp. Singleton in `ServiceContainer.event_bus`. Domain events: `InternetStatusChanged`, `UserRoleChanged`, `SessionRevoked`, `DatasetSynced` (in `modules/core/events.py`), `KnowledgeUpdated` (in `modules/knowledge/events.py`), `WidgetSessionCreated`, `WidgetMessageSent`, `WidgetContactSubmitted` (in `modules/channels/widget/events.py`). Subscriptions registered via `setup_event_subscriptions()` in `modules/core/startup.py`, which delegates to domain-specific setup functions (`setup_llm_event_subscriptions()` in `modules/llm/startup.py`, `setup_knowledge_event_subscriptions()` in `modules/knowledge/startup.py`, `setup_crm_event_subscriptions()` in `modules/crm/startup.py`). `DatasetSynced` decouples CRM/ecommerce/kanban from knowledge. Widget events decouple widget router from amoCRM: widget publishes events, CRM domain handles lead/contact/note creation reactively.
-- **`TaskRegistry`** (`modules/core/tasks.py`): Named background tasks — periodic (interval-based) or one-shot. `start_all()` / `cancel_all(timeout)` lifecycle. `TaskInfo` dataclass tracks status, run count, last error. 7 tasks registered in `startup_event()`: `session-cleanup` (1h), `periodic-vacuum` (7d), `kanban-sync` (15min), `woocommerce-sync` (daily 23:00 UTC), `rss-sync` (1h), `wiki-embeddings` (one-shot), `wiki-collection-indexes` (one-shot). Task functions in `modules/core/maintenance.py`, `modules/knowledge/tasks.py`, `modules/knowledge/rss_service.py`, `modules/kanban/tasks.py`, `modules/ecommerce/tasks.py`.
+- **`TaskRegistry`** (`modules/core/tasks.py`): Named background tasks — periodic (interval-based) or one-shot. `start_all()` / `cancel_all(timeout)` lifecycle. `TaskInfo` dataclass tracks status, run count, last error. 8 tasks registered in `startup_event()`: `session-cleanup` (1h), `periodic-vacuum` (7d), `kanban-sync` (15min), `woocommerce-sync` (daily 23:00 UTC), `procurement-site-sync` (daily 23:30 UTC), `rss-sync` (1h), `wiki-embeddings` (one-shot), `wiki-collection-indexes` (one-shot). Task functions in `modules/core/maintenance.py`, `modules/knowledge/tasks.py`, `modules/knowledge/rss_service.py`, `modules/kanban/tasks.py`, `modules/ecommerce/tasks.py`, `modules/procurement/tasks.py`.
 - **`HealthRegistry`** (`modules/core/health.py`): Modular health checks with per-check timeout (`asyncio.wait_for`). Status aggregation: all ok → ok, any degraded → degraded, any error → error.
 
 - **`InternetMonitor`** (`modules/core/internet_monitor.py`): Periodic connectivity checker (ping DNS/Cloudflare). Auto-switches LLM backend: online → cloud provider (claude_bridge priority), offline → local vLLM. Publishes `InternetStatusChanged` events via EventBus (`container.event_bus`). Configurable thresholds, 30s default interval. Status endpoint: `GET /admin/gsm/internet-status`. Health check includes `internet` section.
@@ -181,6 +181,7 @@ Service classes extracted from the former monolithic `db/integration.py` into pe
 | `modules/speech/` | `service.py`, `streaming.py` | `PresetService`, `StreamingTTSManager` |
 | `modules/crm/` | `service.py` | `AmoCRMService` |
 | `modules/ecommerce/` | `service.py` | `WooCommerceService` |
+| `modules/procurement/` | `service.py` | `OfferService` (unified product-offer search) |
 | `modules/telephony/` | `service.py` | `GSMService` |
 | `modules/google/` | `service.py`, `models.py` | `GoogleOAuthService` |
 | `modules/search/` | `service.py` | `WebSearchService` (DuckDuckGo via `ddgs`/`duckduckgo_search`, optional import) |
@@ -194,6 +195,7 @@ All 28 routers live in domain modules. Files under `app/routers/` are 1–3 line
 | Domain | Router file | Facade |
 |--------|------------|--------|
 | `modules/ecommerce/` | `router.py` | `app/routers/woocommerce.py` |
+| `modules/procurement/` | `router.py` | `/admin/procurement/*` (direct include) |
 | `modules/crm/` | `router.py` | `app/routers/amocrm.py` (exports `router` + `webhook_router`) |
 | `modules/telephony/` | `router.py` | `app/routers/gsm.py` |
 | `modules/speech/` | `router_tts.py`, `router_stt.py`, `router_services.py` | `app/routers/tts.py`, `stt.py`, `services.py` |
@@ -316,6 +318,10 @@ These routers import domain services directly (`from modules.monitoring.service 
 ### Landing Site (`site/`)
 
 Static marketing site served at `https://ai-sekretar24.ru/` — no build step, no framework. Plain HTML/CSS/JS with i18n: `site/index.html` (ru, canonical), `site/en/index.html`, `site/kk/index.html`. Auto-detects browser language and redirects from root on first visit only (skipped if user already chose a language or arrived from an in-site language page). `site/main.js` handles the language switcher and shared interactions; `site/styles.css` is hand-written, no Tailwind. Deployed independently of admin/mobile — nginx serves `site/` from `/var/www/` directly. Auth CTAs link to `/login` (not `/admin/`).
+
+### Unified product search (`modules/procurement/`)
+
+Code-pipeline «единый поиск позиции» для торгового ассистента (StalkerElectric). Модель `ProductOffer` (table `product_offers`) — единое структурное представление оффера из любого источника: `source` (`site`/`ekf`/`supplier`), `article`, `name`, `price`, `in_stock`, `lead_time_days`, `url` + `UniqueConstraint(source, source_key)` для upsert. `OfferService.replace_source_offers()` делает полный ре-синк одного источника; `OfferService.search()` детерминированно ранжирует (article_exact → article_partial → name_all → name_any; тай-брейк: in_stock, `SOURCE_PRIORITY` site<ekf<supplier, price) и **возвращает `[]`, если ничего не найдено — не выдумывает позиций** (жёсткое требование клиента реализовано архитектурно, а не промптом). Адаптеры населяют общую таблицу: `site_adapter.sync_site_offers()` (WooCommerce→офферы, ~30k товаров) есть; EKF (партнёрский REST API `ekfgroup.com/api/v{N}`) и supplier (парсинг xlsx-прайсов) встают в тот же интерфейс. Провайдер по умолчанию `claude_bridge` не поддерживает tools → поиск = код-шаг, не агентный tool. Роутер `/admin/procurement/{status,search,sync}` (RBAC `sales`). Периодическая задача `procurement-site-sync` (daily 23:30 UTC, после `woocommerce-sync`). Перф: `search()` грузит офферы в память — приемлемо на фоне bridge-латентности; FTS-оптимизация при росте таблицы прайсами.
 
 ## Code Patterns
 

--- a/db/models.py
+++ b/db/models.py
@@ -81,6 +81,7 @@ from modules.llm.models import (
     LLMPreset,
 )
 from modules.monitoring.models import AuditLog, UsageLimits, UsageLog
+from modules.procurement.models import ProductOffer
 from modules.sales.models import PaymentLog
 from modules.speech.models import TTSPreset
 from modules.telephony.models import GSMCallLog, GSMSMSLog
@@ -154,6 +155,8 @@ __all__ = [
     "AmoCRMSyncLog",
     # ecommerce
     "WooCommerceConfig",
+    # procurement
+    "ProductOffer",
     # telephony
     "GSMCallLog",
     "GSMSMSLog",

--- a/modules/procurement/models.py
+++ b/modules/procurement/models.py
@@ -1,0 +1,82 @@
+"""Procurement models: unified product offers for the single-search pipeline.
+
+A `ProductOffer` is one structured, real row from one source (own site,
+EKF IMS, or a supplier price list). The unified search queries this table so
+the assistant only ever sees real articles/prices/stock — never generated ones.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from db.database import Base
+
+
+# Source discriminators — one adapter populates each.
+SOURCE_SITE = "site"  # own WooCommerce catalog (stalkerelectric.kz)
+SOURCE_EKF = "ekf"  # EKF IMS partner API
+SOURCE_SUPPLIER = "supplier"  # parsed supplier xlsx/csv price lists
+
+
+class ProductOffer(Base):
+    """One real offer (position + price + stock) from one source.
+
+    Uniqueness is (source, source_key) so re-syncing a source upserts rather
+    than duplicates. `source_key` is the source's own id (WooCommerce product
+    id, EKF article, or supplier-file row key).
+    """
+
+    __tablename__ = "product_offers"
+    __table_args__ = (UniqueConstraint("source", "source_key", name="uq_offer_source_key"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    source: Mapped[str] = mapped_column(String(20), index=True)
+    source_key: Mapped[str] = mapped_column(String(200))
+    supplier_name: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+
+    article: Mapped[Optional[str]] = mapped_column(String(200), index=True, nullable=True)
+    name: Mapped[str] = mapped_column(String(500), index=True)
+    brand: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    category: Mapped[Optional[str]] = mapped_column(String(300), nullable=True)
+
+    price: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    currency: Mapped[str] = mapped_column(String(10), default="KZT")
+    in_stock: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
+    stock_qty: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    lead_time_days: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+    url: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
+    extra: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON blob, raw source
+
+    workspace_id: Mapped[int] = mapped_column(Integer, ForeignKey("workspaces.id"), default=1)
+    updated: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "source": self.source,
+            "supplier_name": self.supplier_name,
+            "article": self.article,
+            "name": self.name,
+            "brand": self.brand,
+            "category": self.category,
+            "price": self.price,
+            "currency": self.currency,
+            "in_stock": self.in_stock,
+            "stock_qty": self.stock_qty,
+            "lead_time_days": self.lead_time_days,
+            "url": self.url,
+            "updated": self.updated.isoformat() if self.updated else None,
+        }

--- a/modules/procurement/router.py
+++ b/modules/procurement/router.py
@@ -1,0 +1,60 @@
+"""Procurement router — unified offer search + site-offer sync (admin).
+
+Read/inspect surface for the single-search pipeline. The sales assistant will
+consume `offer_service.search` server-side; these endpoints let admins verify
+coverage and trigger a manual site sync.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends
+
+from auth_manager import User, require_permission
+from modules.monitoring.service import audit_service
+from modules.procurement.models import SOURCE_EKF, SOURCE_SITE, SOURCE_SUPPLIER
+from modules.procurement.service import offer_service
+from modules.procurement.site_adapter import sync_site_offers
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin/procurement", tags=["procurement"])
+
+
+@router.get("/status")
+async def procurement_status(user: User = Depends(require_permission("sales", "view"))):
+    """Offer counts per source."""
+    return {
+        "sources": {
+            SOURCE_SITE: await offer_service.count(source=SOURCE_SITE),
+            SOURCE_EKF: await offer_service.count(source=SOURCE_EKF),
+            SOURCE_SUPPLIER: await offer_service.count(source=SOURCE_SUPPLIER),
+        },
+        "total": await offer_service.count(),
+    }
+
+
+@router.get("/search")
+async def procurement_search(
+    q: str,
+    limit: int = 10,
+    in_stock_only: bool = False,
+    user: User = Depends(require_permission("sales", "view")),
+):
+    """Unified deterministic offer search. Returns [] if nothing matches."""
+    results = await offer_service.search(q, limit=limit, in_stock_only=in_stock_only)
+    return {"query": q, "count": len(results), "results": results}
+
+
+@router.post("/sync")
+async def procurement_sync_site(user: User = Depends(require_permission("sales", "edit"))):
+    """Manually rebuild site offers from the WooCommerce catalog."""
+    result = await sync_site_offers()
+    await audit_service.log(
+        action="sync",
+        resource="procurement_offers",
+        resource_id=SOURCE_SITE,
+        user_id=user.username,
+        details=result,
+    )
+    return result

--- a/modules/procurement/service.py
+++ b/modules/procurement/service.py
@@ -1,0 +1,156 @@
+"""Procurement service: upsert offers per source + unified deterministic search.
+
+This is the code-pipeline core of the "single search" feature. Adapters
+(site / EKF / supplier) upsert real rows here; `search()` ranks them. The LLM
+never invents data — it only reformulates rows this search returns.
+"""
+
+import json
+import logging
+import re
+from typing import List, Optional
+
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select as sa_select
+
+from db.database import AsyncSessionLocal
+from db.retry import retry_on_busy
+from modules.procurement.models import ProductOffer
+
+
+logger = logging.getLogger(__name__)
+
+# Ranking preference between sources when the same position appears in several.
+# Own stock first, then EKF (direct API), then generic supplier price lists.
+SOURCE_PRIORITY = {"site": 0, "ekf": 1, "supplier": 2}
+
+_TOKEN_RE = re.compile(r"[^\w]+", re.UNICODE)
+
+
+def _norm(s: Optional[str]) -> str:
+    """Lowercase + strip punctuation/space, Unicode-aware (handles Cyrillic)."""
+    if not s:
+        return ""
+    return _TOKEN_RE.sub("", s.lower())
+
+
+def _tokens(s: str) -> List[str]:
+    return [t for t in _TOKEN_RE.split(s.lower()) if t]
+
+
+class OfferService:
+    """CRUD + search over `product_offers`."""
+
+    @retry_on_busy()
+    async def replace_source_offers(
+        self, source: str, offers: List[dict], workspace_id: int = 1
+    ) -> int:
+        """Full re-sync of one source: delete its offers, insert the fresh set.
+
+        `offers` is a list of dicts with keys matching ProductOffer fields
+        (must include source_key + name). Returns number of rows written.
+        """
+        async with AsyncSessionLocal() as session:
+            await session.execute(
+                sa_delete(ProductOffer).where(
+                    ProductOffer.source == source,
+                    ProductOffer.workspace_id == workspace_id,
+                )
+            )
+            rows = 0
+            for o in offers:
+                if not o.get("source_key") or not o.get("name"):
+                    continue
+                extra = o.get("extra")
+                session.add(
+                    ProductOffer(
+                        source=source,
+                        source_key=str(o["source_key"]),
+                        supplier_name=o.get("supplier_name"),
+                        article=o.get("article"),
+                        name=o["name"][:500],
+                        brand=o.get("brand"),
+                        category=o.get("category"),
+                        price=o.get("price"),
+                        currency=o.get("currency", "KZT"),
+                        in_stock=o.get("in_stock"),
+                        stock_qty=o.get("stock_qty"),
+                        lead_time_days=o.get("lead_time_days"),
+                        url=o.get("url"),
+                        extra=json.dumps(extra, ensure_ascii=False) if extra else None,
+                        workspace_id=workspace_id,
+                    )
+                )
+                rows += 1
+            await session.commit()
+            logger.info("procurement: replaced %d offers for source=%s", rows, source)
+            return rows
+
+    async def count(self, source: Optional[str] = None, workspace_id: int = 1) -> int:
+        async with AsyncSessionLocal() as session:
+            stmt = sa_select(ProductOffer).where(ProductOffer.workspace_id == workspace_id)
+            if source:
+                stmt = stmt.where(ProductOffer.source == source)
+            res = await session.execute(stmt)
+            return len(res.scalars().all())
+
+    async def search(
+        self,
+        query: str,
+        limit: int = 10,
+        in_stock_only: bool = False,
+        workspace_id: int = 1,
+    ) -> List[dict]:
+        """Rank real offers against a free-text position query.
+
+        Ranking (lower is better): exact article > article contains query >
+        name contains all tokens > name contains any token. Ties broken by
+        in-stock, source priority, then price. Returns [] if nothing matches
+        (the caller must then say "не найдено" — never invent a position).
+        """
+        q_norm = _norm(query)
+        q_tokens = _tokens(query)
+        if not q_norm and not q_tokens:
+            return []
+
+        async with AsyncSessionLocal() as session:
+            stmt = sa_select(ProductOffer).where(ProductOffer.workspace_id == workspace_id)
+            if in_stock_only:
+                stmt = stmt.where(ProductOffer.in_stock.is_(True))
+            res = await session.execute(stmt)
+            rows = res.scalars().all()
+
+        scored = []
+        for r in rows:
+            art_norm = _norm(r.article)
+            name_low = (r.name or "").lower()
+            rank = None
+            if q_norm and art_norm and art_norm == q_norm:
+                rank = 0
+            elif q_norm and art_norm and q_norm in art_norm:
+                rank = 1
+            elif q_tokens and all(t in name_low for t in q_tokens):
+                rank = 2
+            elif q_tokens and any(t in name_low for t in q_tokens):
+                rank = 3
+            if rank is None:
+                continue
+            scored.append((rank, r))
+
+        scored.sort(
+            key=lambda pair: (
+                pair[0],
+                0 if pair[1].in_stock else 1,
+                SOURCE_PRIORITY.get(pair[1].source, 9),
+                pair[1].price if pair[1].price is not None else float("inf"),
+            )
+        )
+        out = []
+        for rank, r in scored[:limit]:
+            d = r.to_dict()
+            d["match"] = ["article_exact", "article_partial", "name_all", "name_any"][rank]
+            out.append(d)
+        return out
+
+
+offer_service = OfferService()

--- a/modules/procurement/site_adapter.py
+++ b/modules/procurement/site_adapter.py
@@ -1,0 +1,85 @@
+"""Site adapter: WooCommerce catalog -> structured ProductOffer rows.
+
+The first of three unified-search sources. Reuses the existing WooCommerce
+client + stored credentials, so no new access is needed. EKF and supplier
+adapters plug into the same `offer_service.replace_source_offers` interface.
+"""
+
+import logging
+from typing import Optional
+
+from app.services.woocommerce_service import get_all_products
+from modules.ecommerce.service import woocommerce_service
+from modules.procurement.models import SOURCE_SITE
+from modules.procurement.service import offer_service
+
+
+logger = logging.getLogger(__name__)
+
+SITE_SUPPLIER_NAME = "Сайт StalkerElectric"
+
+# Product attribute names that carry the manufacturer/brand.
+_BRAND_ATTRS = {"бренд", "производитель", "brand", "manufacturer", "марка"}
+
+
+def _parse_price(product: dict) -> Optional[float]:
+    for key in ("price", "sale_price", "regular_price"):
+        raw = product.get(key)
+        if raw in (None, ""):
+            continue
+        try:
+            return float(str(raw).replace(",", ".").replace(" ", ""))
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _brand(product: dict) -> Optional[str]:
+    for attr in product.get("attributes", []) or []:
+        if str(attr.get("name", "")).strip().lower() in _BRAND_ATTRS:
+            opts = attr.get("options") or []
+            if opts:
+                return ", ".join(str(o) for o in opts)[:200]
+    return None
+
+
+def _category(product: dict) -> Optional[str]:
+    cats = [c.get("name", "") for c in product.get("categories", []) or [] if c.get("name")]
+    return ", ".join(cats)[:300] if cats else None
+
+
+def _to_offer(product: dict) -> dict:
+    return {
+        "source_key": product.get("id"),
+        "supplier_name": SITE_SUPPLIER_NAME,
+        "article": (product.get("sku") or None),
+        "name": product.get("name") or "Без названия",
+        "brand": _brand(product),
+        "category": _category(product),
+        "price": _parse_price(product),
+        "currency": "KZT",
+        "in_stock": product.get("stock_status") == "instock",
+        "stock_qty": product.get("stock_quantity"),
+        "url": product.get("permalink") or None,
+        "extra": None,
+    }
+
+
+async def sync_site_offers(workspace_id: int = 1) -> dict:
+    """Fetch all WooCommerce products and (re)build site offers.
+
+    Returns stats. Raises if WooCommerce credentials are missing.
+    """
+    secrets = await woocommerce_service.get_config_with_secrets()
+    if not secrets or not secrets.get("consumer_key"):
+        raise RuntimeError("WooCommerce credentials not configured")
+
+    products = await get_all_products(
+        secrets["store_url"], secrets["consumer_key"], secrets["consumer_secret"]
+    )
+    offers = [_to_offer(p) for p in products]
+    written = await offer_service.replace_source_offers(
+        SOURCE_SITE, offers, workspace_id=workspace_id
+    )
+    logger.info("procurement site adapter: %d products -> %d offers", len(products), written)
+    return {"products": len(products), "offers": written, "source": SOURCE_SITE}

--- a/modules/procurement/tasks.py
+++ b/modules/procurement/tasks.py
@@ -1,0 +1,45 @@
+"""Procurement domain background tasks: periodic site-offer sync.
+
+Rebuilds structured `product_offers` from the WooCommerce catalog daily,
+shortly after the WooCommerce dataset sync (23:00 UTC), so the unified search
+reflects fresh prices/stock.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+
+
+logger = logging.getLogger(__name__)
+
+
+async def procurement_site_sync() -> None:
+    """Daily site-offer sync at 23:30 UTC (after woocommerce-sync at 23:00).
+
+    Self-scheduling loop (TaskRegistry has no cron support).
+    """
+    await asyncio.sleep(180)  # warmup, and let woocommerce-sync go first
+    while True:
+        now = datetime.utcnow()
+        target = now.replace(hour=23, minute=30, second=0, microsecond=0)
+        if target <= now:
+            target += timedelta(days=1)
+        wait_seconds = (target - now).total_seconds()
+        logger.info("procurement site-offer sync scheduled in %.1fh", wait_seconds / 3600)
+        await asyncio.sleep(wait_seconds)
+        try:
+            from modules.ecommerce.service import woocommerce_service
+            from modules.procurement.site_adapter import sync_site_offers
+
+            config = await woocommerce_service.get_config()
+            if not config or not config.get("sync_enabled"):
+                continue
+            result = await sync_site_offers()
+            logger.info(
+                "procurement site-offer sync: %d products -> %d offers",
+                result["products"],
+                result["offers"],
+            )
+        except Exception as e:
+            logger.warning("procurement site-offer sync error: %s", e)
+            await asyncio.sleep(3600)  # on error retry in 1h

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -83,6 +83,7 @@ from modules.core.router_health import router as health_router  # noqa: E402
 from modules.knowledge.router_google_drive import router as google_drive_rag_router  # noqa: E402
 from modules.knowledge.router_rss import router as rss_router  # noqa: E402
 from modules.monitoring.router_logs import router as logs_router  # noqa: E402
+from modules.procurement.router import router as procurement_router  # noqa: E402
 
 
 # Always-available routers (all deployment modes)
@@ -121,6 +122,7 @@ app.include_router(rss_router)
 app.include_router(health_router)
 app.include_router(compat_router)
 app.include_router(logs_router)
+app.include_router(procurement_router)
 app.include_router(widget_public_router)
 
 # Hardware/GPU routers — skip in cloud mode
@@ -273,6 +275,9 @@ async def startup_event():
             "kanban-sync", sync_kanban_issues, interval=15 * 60, initial_delay=60
         )
         task_registry.register("woocommerce-sync", woocommerce_daily_sync)
+        from modules.procurement.tasks import procurement_site_sync
+
+        task_registry.register("procurement-site-sync", procurement_site_sync)
         task_registry.register("rss-sync", rss_sync_all, interval=60 * 60, initial_delay=120)
         task_registry.register(
             "bot-process-watcher", watch_bot_processes, interval=30, initial_delay=15


### PR DESCRIPTION
## Summary
Новый домен `modules/procurement/` — фундамент код-конвейера **«единого поиска позиции»** для торгового ассистента StalkerElectric (боль №1: подбор по каталогу, далее по прайсам поставщиков + EKF IMS).

- **`ProductOffer`** (table `product_offers`) — единый структурный оффер из любого источника (`source`/`article`/`name`/`price`/`in_stock`/`lead_time`/`url`), `UniqueConstraint(source, source_key)` для upsert.
- **`OfferService`** — `replace_source_offers` (полный ре-синк источника) + детерминированный `search` с ранжированием (`article_exact`→`article_partial`→`name_all`→`name_any`; тай-брейк `in_stock`/`SOURCE_PRIORITY` site<ekf<supplier/`price`). **Возвращает `[]`, если ничего не найдено — не выдумывает позиций** (жёсткое правило клиента реализовано архитектурно).
- **`site_adapter`** — WooCommerce → офферы. EKF (партнёрский REST API `ekfgroup.com/api/v{N}`) и supplier (xlsx-прайсы) встают в тот же интерфейс позже.
- **Роутер** `/admin/procurement/{status,search,sync}` (RBAC `sales`).
- **Задача** `procurement-site-sync` (daily 23:30 UTC, после `woocommerce-sync`).
- Провайдер `claude_bridge` без tools → поиск = код-шаг, не агентный tool.

## Контекст
Backend-инфраструктура. **Не подключено к чат-пути** (инертно) — интеграцию в ассистента-продавца делаю следующим PR. Фронтенд не затронут → пересборка admin не нужна, деплой = git pull + restart backend.

## Test plan
- [x] Прогон на проде: `sync_site_offers` синхронизировал **30 162 товара** живого каталога.
- [x] Поиск возвращает реальные артикулы+цены с ранжированием (STRUT-профиль, DIN-рейка, автомат, точный артикул).
- [x] Несуществующий запрос → **0 офферов** (правило «не выдумывать» соблюдено).
- [x] `ruff check` + `ruff format --check` чисты.
- [ ] После деплоя: `GET /admin/procurement/status` отдаёт счётчики, `GET /admin/procurement/search?q=...` работает.

🤖 Generated with [Claude Code](https://claude.com/claude-code)