### PR TITLE
fix(chat): не открывать дерево веток при создании новой ветки

### DIFF
--- a/admin/src/views/ChatView.vue
+++ b/admin/src/views/ChatView.vue
@@ -1177,19 +1177,12 @@ const switchBranchMutation = useMutation({
 const newBranchMutation = useMutation({
   mutationFn: (sessionId: string) => chatApi.newBranchFromScratch(sessionId),
   onSuccess: async () => {
-    showBranchTree.value = true
     await Promise.all([refetchSession(), refetchBranches()])
   },
 })
 
 function startNewBranch() {
   if (!currentSessionId.value) return
-  newBranchMutation.mutate(currentSessionId.value)
-}
-
-function startNewBranchAndShowTree() {
-  if (!currentSessionId.value) return
-  showBranchTree.value = true
   newBranchMutation.mutate(currentSessionId.value)
 }
 
@@ -3782,7 +3775,7 @@ class="w-4 h-4 rounded border flex items-center justify-center shrink-0"
           :disabled="newBranchMutation.isPending.value"
           class="absolute right-4 top-1/2 -translate-y-1/2 p-3 rounded-lg bg-amber-500 hover:bg-amber-600 text-white transition-colors disabled:opacity-50"
           :title="t('chatView.newBranch')"
-          @click="startNewBranchAndShowTree"
+          @click="startNewBranch"
         >
           <Plus class="w-5 h-5" />
         </button>
@@ -3893,7 +3886,7 @@ class="w-4 h-4 rounded border flex items-center justify-center shrink-0"
               :disabled="newBranchMutation.isPending.value"
               class="p-3 rounded-lg bg-amber-500 hover:bg-amber-600 text-white transition-colors disabled:opacity-50 shrink-0 sm:order-1"
               :title="t('chatView.newBranch')"
-              @click="startNewBranchAndShowTree"
+              @click="startNewBranch"
             >
               <Plus class="w-5 h-5" />
             </button>


### PR DESCRIPTION
## Summary

- Кнопка «новая ветка» вызывала `startNewBranchAndShowTree`, а `onSuccess` мутации дополнительно форсил `showBranchTree=true` — из-за чего при создании ветки всегда раскрывалось боковое дерево веток.
- Убрал авто-открытие: `onSuccess` больше не трогает `showBranchTree`; удалил `startNewBranchAndShowTree`, обе кнопки «+ ветка» теперь зовут `startNewBranch` (только создаёт ветку).
- Дерево веток открывается только по клику на кнопку меню веток.

## NEWS

🌿 **Ветки чата: меню больше не выскакивает само**

Раньше при создании новой ветки диалога сбоку каждый раз само раскрывалось дерево веток и загораживало чат. Теперь новая ветка создаётся тихо, а дерево открывается только когда ты сам нажимаешь кнопку меню веток. Стало чище и предсказуемее.

## Test plan

- [ ] `cd admin && npm run build` проходит (type-check)
- [ ] Открыть чат-сессию, нажать «+ ветка» → ветка создаётся, дерево НЕ открывается
- [ ] Нажать кнопку меню веток → дерево открывается/закрывается
- [ ] Создать ветку из уже открытого дерева (`@new-branch`) → дерево остаётся открытым

🤖 Generated with [Claude Code](https://claude.com/claude-code)